### PR TITLE
So that we can see the build status in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run Status](https://api.shippable.com/projects/58d10e96665a9306000199bb/badge?branch=master)](https://app.shippable.com/github/moj-analytical-services/PQTool)
+
 # PQ Tool
 
    Welcome to the PQ Tool.  Sometime soon we will add some helpful information about how to get this set up.


### PR DESCRIPTION
Ignore the red cross - it indicates that Shippable (a replacement for Travis) is failing.  That's to be expected because I haven't sorted out the config yet.

We need to switch from TravisCI to Shippable because the repo is now private and the free version of Travis only works with public repos.