### PR TITLE
Configure Shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,15 @@
+language: java
+build:
+  pre_ci_boot:
+    image_name: r-base
+    image_tag: 3.3.3
+    pull: true
+  ci:
+    - apt-get install -y build-essential
+    - apt-get install -y libcurl4-gnutls-dev
+    - apt-get install -y libssl-dev
+    - apt-get install -y libxml2-dev
+    - apt-get install -y r-cran-rgl
+    - apt-get install -y libgl1-mesa-dev
+    - apt-get install -y libglu1-mesa-dev
+    - R -e "0" --args --bootstrap-packrat


### PR DESCRIPTION
- We will use Shippable for CI in some cases, if not all, because it can be used with private repos (for free)
- This PR contains the basic config for Shippable
- Later we can make Shippable do thing like run tests and static code analysis on our pull requests