### PR TITLE
The legend was removed in error - back in now

### DIFF
--- a/server.R
+++ b/server.R
@@ -142,7 +142,6 @@ function(input, output, session) {
                   hoverinfo = "text"
       )%>%
       layout(yaxis = y_axis,
-             showlegend = FALSE,
              title = "Top 100 questions most similar to your search",
              titlefont=list(
                family='Arial',


### PR DESCRIPTION
On one branch we had `showlegend=FALSE` and on another it was omitted. There were some merge conflicts in this area and I resolved one of them incorrectly, meaning the legend was lost.  Here, I am rectifying that.