### PR TITLE
Link between tabs

### DIFF
--- a/pq.js
+++ b/pq.js
@@ -2,8 +2,32 @@ var log = true;
 var points;
 var point_centres = [];
 var last_mouse_location = [0,0];
-var format;
 var selected_rank = -1;
+
+//Table-clicking function
+
+function format(d) {
+    console.log(d);
+    d[3] = d[3].replace(/&lt;(.+?)&gt;/g, '<' + '$1' + '>');
+    return '<div style=\"background-color:#eee; padding: .5em;word-wrap:break-word;width: 600px; \"> Question Text: ' +
+                d[2] + '</br>' + '</br>' +
+                'Answer Text: ' + d[3] +  '</div>' +
+                '<input type = \"button\" value = \"See all questions asked by this Member\" onclick = \"mp_finder(\'' + d[6] + '\')\">' + 
+                '<input type = \"button\" value = \"See all questions in the same topic\" onclick = \"topic_finder(' + d[9] + ')\">';
+}
+var table1;
+function rowActivate() {
+    var row = this.closest('tr');
+    var showHideIcon = $(row.firstChild);
+    var shinyRow = table1.row(row);
+    if (shinyRow.child.isShown()) {
+        shinyRow.child.hide();
+        showHideIcon.html('&oplus;');
+    } else {
+        shinyRow.child(format(shinyRow.data())).show();
+        showHideIcon.html('&ominus;');
+    }
+}
 
 //Plotly point-clicking functions
 function get_point_locations(e) {
@@ -100,4 +124,23 @@ function deselect_rows(){
 
 //Cluster selecting functions
 
+function mp_finder(mp){
+    var mp_tab = $("a")[2];
+    mp_tab.click();
+    var is_lords = mp.match(/^(Baron)|(Lord)|(The )|(Viscount)/);
+    var radio_button = is_lords ? 0 : 1;
+    $(".radio-inline")[radio_button].click()
+    setTimeout(function(){
+        $("#person_choice").append("<option value='" + mp + "'>" + mp + "</option>");
+        $("#person_choice").val(mp).change();
+        document.getElementsByClassName("item")[1].innerHTML = mp
+        return; }, 500)
+}
 
+function topic_finder(topic){
+    var topic_tab = $("a")[1];
+    topic_tab.click();
+    $("#topic_choice").append("<option value='" + topic + "'>" + topic + "</option>");
+    $("#topic_choice").val(""+topic).change();
+    document.getElementsByClassName("item")[0].innerHTML = topic;
+}

--- a/pq.js
+++ b/pq.js
@@ -3,6 +3,9 @@ var points;
 var point_centres = [];
 var last_mouse_location = [0,0];
 var format;
+var selected_rank = -1;
+
+//Plotly point-clicking functions
 function get_point_locations(e) {
     last_mouse_location = [e.clientX, e.clientY];
     if(!!similarity_plot){
@@ -40,6 +43,13 @@ function find_nearest_point(e){
         }
         current_index++;
     });
+    if (min_index === selected_rank){
+        selected_rank = -1;
+        return ;
+    }else{
+        selected_rank = min_index;
+    }
+    
     return rank_to_selection(min_index + 1);
 }
 
@@ -70,7 +80,7 @@ function goto_page(i, row){
     for (var j = 0; j < Math.abs(page_shift); j++){
         button.click();
     }
-    setTimeout(function() {return toggle_row(row)}, 500);
+    setTimeout(function() {return toggle_row(row)}, 1000);
 }
 
 function toggle_row(i){
@@ -86,3 +96,8 @@ function deselect_rows(){
         selected[s].click();
     }
 }
+
+
+//Cluster selecting functions
+
+

--- a/server.R
+++ b/server.R
@@ -91,26 +91,9 @@ function(input, output, session) {
         server = FALSE
       ),
       callback = JS("
+                table1 = table;
                 table.column(1).nodes().to$().css({cursor: 'pointer'});
-                format = function(d) {
-                d[3] = d[3].replace(/&lt;(.+?)&gt;/g, '<' + '$1' + '>')
-                return '<div style=\"background-color:#eee; padding: .5em;word-wrap:break-word;width: 600px; \"> Question Text: ' +
-                d[2] + '</br>' + '</br>' +
-                'Answer Text: ' + d[3] +  '</div>' +
-                '<input type = \"button\" value = \"click me\">';
-                };
-                table.on('click', 'tr', function() {
-                var row = this.closest('tr');
-                var showHideIcon = $(row.firstChild);
-                var shinyRow = table.row(row);
-                if (shinyRow.child.isShown()) {
-                shinyRow.child.hide();
-                showHideIcon.html('&oplus;');
-                } else {
-                shinyRow.child(format(shinyRow.data())).show();
-                showHideIcon.html('&ominus;');
-                }
-                });"
+                table.on('click', 'tr', rowActivate);"
       ),
       caption = "Questions ranked by similarity to search text. Select a row to see the corresponding question text:"
     )

--- a/server.R
+++ b/server.R
@@ -96,7 +96,8 @@ function(input, output, session) {
                 d[3] = d[3].replace(/&lt;(.+?)&gt;/g, '<' + '$1' + '>')
                 return '<div style=\"background-color:#eee; padding: .5em;word-wrap:break-word;width: 600px; \"> Question Text: ' +
                 d[2] + '</br>' + '</br>' +
-                'Answer Text: ' + d[3] +  '</div>';
+                'Answer Text: ' + d[3] +  '</div>' +
+                '<input type = \"button\" value = \"click me\">';
                 };
                 table.on('click', 'tr', function() {
                 var row = this.closest('tr');

--- a/ui.R
+++ b/ui.R
@@ -13,7 +13,7 @@ navbarPage("PQ Text Analysis",
            tags$head(includeScript("d3.min.js")),
            tags$body(id = "test"),
            tags$body(onmousemove = "get_point_locations(event)"),
-           tags$body(includeScript("pq.js")),
+           tags$head(includeScript("pq.js")),
     fluidRow(
       column(3,
         textInput(inputId = "question",


### PR DESCRIPTION
Added buttons to rows (after they're clicked on) to allow moving to mp/topic tab focused on relevent mp/topic.  Also removed most of the callback thing from ui.R and moved into pq.js (in particular, the row-expansion function and format function is now in the global scope (which will help with formatting tables on the mp/topic tabs)