### PR TITLE
Hide all error messages from the user

### DIFF
--- a/www/pq.css
+++ b/www/pq.css
@@ -2,3 +2,11 @@
   height: 38px;
   font-size: 14px;
 }
+
+.shiny-output-error {
+  visibility: hidden;
+}
+
+.shiny-output-error:before {
+  visibility: hidden;
+}


### PR DESCRIPTION
This is a bit of a cheat and we should watch out for the side effects.  I.e. Be aware that all error messages are now hidden and if you're debugging you might want to switch them back on.