### PR TITLE
Fix plotly clicking

### DIFF
--- a/server.R
+++ b/server.R
@@ -100,7 +100,7 @@ function(input, output, session) {
         searching = FALSE,
         paging = TRUE,
         lengthChange = FALSE,
-        pageLength = 8,
+        pageLength = 10,
         server = FALSE
       ),
       callback = JS("

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -10,7 +10,7 @@ sysDetails  <- remDr$getStatus()
 browser     <- remDr$sessionInfo$browserName
 appURL      <- "http://127.0.0.1:8888"
 
-test_that("entering search terms returns the 30 most similar questions", {  
+test_that("entering search terms returns 10 questions per page", {  
   remDr$setImplicitWaitTimeout(10000)
   remDr$navigate(appURL)
   searchBox  <- remDr$findElement("css selector", "#question")
@@ -20,9 +20,9 @@ test_that("entering search terms returns the 30 most similar questions", {
   oddResultsRows  <- length(remDr$findElements("css selector", "#similarity_table .odd"))
   evenResultsRows <- length(remDr$findElements("css selector", "#similarity_table .even"))
   totalRowCount   <- oddResultsRows + evenResultsRows
-  expect_equal(oddResultsRows, 4)
-  expect_equal(evenResultsRows, 4)
-  expect_equal(totalRowCount, 8)
+  expect_equal(oddResultsRows, 5)
+  expect_equal(evenResultsRows, 5)
+  expect_equal(totalRowCount, 10)
 })
 
 remDr$close()


### PR DESCRIPTION
Changed clicking on plotly chart so there's only two clicks at most required to get to point user is after. This speeds it up, and allows the table to expand the correct row before plotly adds the 'Qs selected' layer.