### PR TITLE
Added a top dozen words per member csv file

### DIFF
--- a/Data/topDozenWordsPerMember.csv
+++ b/Data/topDozenWordsPerMember.csv
@@ -1,0 +1,7429 @@
+"","member","word","freq"
+"1","Abbott, Diane","bme",8.95803551786742
+"2","Abbott, Diane","bisexual",6.32432648569487
+"3","Abbott, Diane","lesbian",6.32432648569487
+"4","Abbott, Diane","sex",6.18474456802233
+"5","Abbott, Diane","gay",6.13648498098449
+"6","Abbott, Diane","ethnicity",5.96545638622259
+"7","Abbott, Diane","school",5.76233518465985
+"8","Abbott, Diane","offender",5.33962928957968
+"9","Abbott, Diane","declaring",5.26975475524741
+"10","Abbott, Diane","excluded",5.24932347193194
+"11","Abbott, Diane","youth",5.16158337546691
+"12","Abbott, Diane","age",5.13253978920285
+"13","Abrahams, Debbie","justice",5.10019722536499
+"14","Abrahams, Debbie","heard",5.09872440435961
+"15","Abrahams, Debbie","access",5.06584654409245
+"16","Abrahams, Debbie","promote",5.05259262962482
+"17","Abrahams, Debbie","social",4.09521286230241
+"18","Abrahams, Debbie","length",3.75827686391164
+"19","Abrahams, Debbie","deprived",3.61293666190285
+"20","Abrahams, Debbie","tribunal",3.50290599855943
+"21","Abrahams, Debbie","appeal",3.15719635331699
+"22","Abrahams, Debbie","longest",2.96651282783612
+"23","Abrahams, Debbie","security",2.96169819309976
+"24","Abrahams, Debbie","2010",2.88563651002617
+"25","Ahmed-Sheikh, Tasmina","entitlement",5.28252655371236
+"26","Ahmed-Sheikh, Tasmina","live",5.26086341126186
+"27","Ahmed-Sheikh, Tasmina","disabl",5.21883279914635
+"28","Ahmed-Sheikh, Tasmina","assessments",4.71989760708762
+"29","Ahmed-Sheikh, Tasmina","allowance",4.48034483059886
+"30","Ahmed-Sheikh, Tasmina","tribunal",4.31876771956456
+"31","Ahmed-Sheikh, Tasmina","favour",4.19486774545624
+"32","Ahmed-Sheikh, Tasmina","appeal",3.72194338483707
+"33","Ahmed-Sheikh, Tasmina","children",3.53618947520229
+"34","Ahmed-Sheikh, Tasmina","relation",3.28281854442702
+"35","Ahmed-Sheikh, Tasmina","three",3.21033289599527
+"36","Ahmed-Sheikh, Tasmina","found",3.16671793020089
+"37","Ainsworth, Bob","midlands",5.31765841979541
+"38","Ainsworth, Bob","west",4.37903709950946
+"39","Ainsworth, Bob","coventry",4.26659071445412
+"40","Ainsworth, Bob","hedge",3.70624520066165
+"41","Ainsworth, Bob","award",3.58351443421651
+"42","Ainsworth, Bob","jobseekers",3.51422140585431
+"43","Ainsworth, Bob","credits",3.30012969318613
+"44","Ainsworth, Bob","shore",3.24870593743824
+"45","Ainsworth, Bob","tax",3.22500136669914
+"46","Ainsworth, Bob","live",3.0056366197541
+"47","Ainsworth, Bob","disabl",2.98162368935667
+"48","Ainsworth, Bob","income",2.93630079378868
+"49","Aldous, Peter","stable",3.56084520918548
+"50","Aldous, Peter","helping",2.1999186210656
+"51","Aldous, Peter","housing",2.08480792992019
+"52","Aldous, Peter","accommodation",1.95017475177803
+"53","Aldous, Peter","benefits",1.95017475177803
+"54","Aldous, Peter","find",1.8967446205098
+"55","Aldous, Peter","potential",1.60106467893954
+"56","Aldous, Peter","supported",1.37629246127001
+"57","Aldous, Peter","rehabilitate",1.35474808209269
+"58","Aldous, Peter","providing",1.32371458082692
+"59","Aldous, Peter","work",1.22967839973421
+"60","Aldous, Peter","offenders",0.962489022917663
+"61","Alexander, Heidi","land",3.01048502121699
+"62","Alexander, Heidi","command",2.91527851217387
+"63","Alexander, Heidi","hostel",2.91527851217387
+"64","Alexander, Heidi","gold",2.86944785508927
+"65","Alexander, Heidi","premises",2.6137671675961
+"66","Alexander, Heidi","nature",2.50714161391784
+"67","Alexander, Heidi","purpose",2.5056272969404
+"68","Alexander, Heidi","months",2.43886141786033
+"69","Alexander, Heidi","approved",2.43739433747609
+"70","Alexander, Heidi","housing",2.26642516593374
+"71","Alexander, Heidi","caused",2.17814814705622
+"72","Alexander, Heidi","building",2.13751507700215
+"73","Ali, Rushanara","maintain",2.86362749075499
+"74","Ali, Rushanara","help",2.64397313003335
+"75","Ali, Rushanara","capacity",2.40803338053112
+"76","Ali, Rushanara","youth",1.9351289947237
+"77","Ali, Rushanara","reduce",1.92066479621924
+"78","Ali, Rushanara","crime",1.79862216328661
+"79","Ali, Rushanara","plans",1.17379912398123
+"80","Ali, Rushanara","service",1.16483802593091
+"81","Ali, Rushanara","offending",1.15676784140029
+"82","Ali, Rushanara","2010",0
+"83","Ali, Rushanara","accommod",0
+"84","Ali, Rushanara","cost",0
+"85","Allen, Graham","intervention",3.79153362664858
+"86","Allen, Graham","promote",3.30769831157596
+"87","Allen, Graham","early",3.2765305446558
+"88","Allen, Graham","olds",2.92973383856673
+"89","Allen, Graham","obscuring",2.87084518782474
+"90","Allen, Graham","anonymity",2.64723839007477
+"91","Allen, Graham","reoffending",2.50566128129862
+"92","Allen, Graham","faces",2.2431015435558
+"93","Allen, Graham","others",2.2431015435558
+"94","Allen, Graham","reduce",2.17782917259114
+"95","Allen, Graham","medical",1.99723789258122
+"96","Allen, Graham","prohibiting",1.93842161139465
+"97","Allin-Khan, Dr Rosena","promession",4.27960332856952
+"98","Allin-Khan, Dr Rosena","permitted",2.94626999523619
+"99","Allin-Khan, Dr Rosena","bereaved",2.86362749075499
+"100","Allin-Khan, Dr Rosena","offer",2.73165126531128
+"101","Allin-Khan, Dr Rosena","serious",2.30406568859574
+"102","Allin-Khan, Dr Rosena","bring",2.14629028544491
+"103","Allin-Khan, Dr Rosena","local",2.02354188697721
+"104","Allin-Khan, Dr Rosena","law",1.98004226355524
+"105","Allin-Khan, Dr Rosena","authorities",1.95767523368216
+"106","Allin-Khan, Dr Rosena","crime",1.90772689267857
+"107","Allin-Khan, Dr Rosena","section",1.86285668500313
+"108","Allin-Khan, Dr Rosena","families",1.71510767606974
+"109","Amess, David","essex",48.6773215973517
+"110","Amess, David","probation",27.9419714274665
+"111","Amess, David","cycling",20.3107150181687
+"112","Amess, David","trust",19.7220812270836
+"113","Amess, David","budgeted",14.8962206678303
+"114","Amess, David","type",14.1644335724845
+"115","Amess, David","2013",13.9071790398801
+"116","Amess, David","cyclists",13.6096679642816
+"117","Amess, David","prosecuted",13.0419967983623
+"118","Amess, David","board",12.9255914840786
+"119","Amess, David","will",11.6646682188243
+"120","Amess, David","a2c",9.80129045748309
+"121","Amess, Sir David","community",15.7090081794045
+"122","Amess, Sir David","rehabilitation",15.5393517942764
+"123","Amess, Sir David","essex",15.3305460924355
+"124","Amess, Sir David","companies",15.2005460685115
+"125","Amess, Sir David","executive",8.00668528938193
+"126","Amess, Sir David","chief",7.5854701528124
+"127","Amess, Sir David","will",6.9037838399393
+"128","Amess, Sir David","employed",6.38608992877636
+"129","Amess, Sir David","guidance",5.81451464488145
+"130","Amess, Sir David","ministers",5.4432960302343
+"131","Amess, Sir David","new",4.69831515174744
+"132","Amess, Sir David","post",4.31595537000227
+"133","Anderson, David","prison",17.1529789546674
+"134","Anderson, David","establishment",13.2725314462618
+"135","Anderson, David","work",11.9654410273654
+"136","Anderson, David","sex",11.7330228689289
+"137","Anderson, David","offender",11.4440985157401
+"138","Anderson, David","cell",11.2646029252126
+"139","Anderson, David","resettlement",10.8495086214784
+"140","Anderson, David","data",10.603215141676
+"141","Anderson, David","officer",9.4283681223881
+"142","Anderson, David","shifts",9.35499630402403
+"143","Anderson, David","restricted",9.29849732692825
+"144","Anderson, David","justice",9.28647563177524
+"145","Ansell, Caroline","potential",7.61866435035959
+"146","Ansell, Caroline","closures",7.17765139344072
+"147","Ansell, Caroline","estate",5.98828840028835
+"148","Ansell, Caroline","test",5.12270719125771
+"149","Ansell, Caroline","will",4.74150626253458
+"150","Ansell, Caroline","proposals",4.73478899571562
+"151","Ansell, Caroline","part",4.68214653321473
+"152","Ansell, Caroline","10800",4.27960332856952
+"153","Ansell, Caroline","tribunal",4.07882374698061
+"154","Ansell, Caroline","court",3.75402872813402
+"155","Ansell, Caroline","family",3.57184331346494
+"156","Ansell, Caroline","considering",3.44089948914725
+"157","Antoniazzi, Tonia","availability",3.50721308287814
+"158","Antoniazzi, Tonia","quickly",3.39316268687164
+"159","Antoniazzi, Tonia","possible",2.56793651051151
+"160","Antoniazzi, Tonia","increase",2.35232435883189
+"161","Antoniazzi, Tonia","aid",1.97085239671184
+"162","Antoniazzi, Tonia","hears",1.93345513476648
+"163","Antoniazzi, Tonia","agency",1.79955395722818
+"164","Antoniazzi, Tonia","child",1.75039003539168
+"165","Antoniazzi, Tonia","legal",1.71701669743954
+"166","Antoniazzi, Tonia","england",1.6631783852026
+"167","Antoniazzi, Tonia","wales",1.65644713726121
+"168","Antoniazzi, Tonia","appeals",1.54099117452405
+"169","Argar, Edward","guidelines",2.1912990193745
+"170","Argar, Edward","caused",2.08541808070087
+"171","Argar, Edward","merits",2.068757051589
+"172","Argar, Edward","drive",1.876088147768
+"173","Argar, Edward","deaths",1.78418510471754
+"174","Argar, Edward","involving",1.78008191699418
+"175","Argar, Edward","potential",1.6664409525473
+"176","Argar, Edward","applicable",1.61669773828525
+"177","Argar, Edward","reviewing",1.28235418531452
+"178","Argar, Edward","offences",1.0470021073612
+"179","Argar, Edward","sentencing",1.00877932175029
+"180","Argar, Edward","made",0.823991858216293
+"181","Arkless, Richard ","british",6.8532275788746
+"182","Arkless, Richard ","rights",6.78820511628926
+"183","Arkless, Richard ","bill",6.49741720694303
+"184","Arkless, Richard ","consultation",5.65854333834003
+"185","Arkless, Richard ","proposed",4.74540217522019
+"186","Arkless, Richard ","dependencies",3.57272251098088
+"187","Arkless, Richard ","plans",3.48142213252609
+"188","Arkless, Richard ","sub",3.22296166142208
+"189","Arkless, Richard ","better",3.12645945569042
+"190","Arkless, Richard ","undertaken",3.06875418154652
+"191","Arkless, Richard ","receipt",3.04612342252249
+"192","Arkless, Richard ","scotland",3.03560468063012
+"193","Ashworth, Jonathan","may",7.09449194469745
+"194","Ashworth, Jonathan","spent",6.96557845935657
+"195","Ashworth, Jonathan","last",6.31977988580802
+"196","Ashworth, Jonathan","since",6.21875605621374
+"197","Ashworth, Jonathan","sent",5.05805523789309
+"198","Ashworth, Jonathan","overtime",5.03287359696938
+"199","Ashworth, Jonathan","six",5.02094534702147
+"200","Ashworth, Jonathan","catering",4.83317393779203
+"201","Ashworth, Jonathan","month",4.55677603663228
+"202","Ashworth, Jonathan","2010",4.35665790383253
+"203","Ashworth, Jonathan","circular",4.27960332856952
+"204","Ashworth, Jonathan","cards",4.09532438060057
+"205","Austin, Ian","companies",23.0804958214855
+"206","Austin, Ian","probation",20.7656226606868
+"207","Austin, Ian","rehabilitation",18.7863915726072
+"208","Austin, Ian","community",16.437292045658
+"209","Austin, Ian","service",13.4900701081678
+"210","Austin, Ian","national",11.1205823031695
+"211","Austin, Ian","staff",10.941028597366
+"212","Austin, Ian","estimate",7.98805091715484
+"213","Austin, Ian","agency",7.64003007640959
+"214","Austin, Ian","compensation",7.30746694548266
+"215","Austin, Ian","established",7.0972555952175
+"216","Austin, Ian","made",6.71678411441571
+"217","Bailey, Adrian","apprenticeships",2.51643679848469
+"218","Bailey, Adrian","innovation",2.51643679848469
+"219","Bailey, Adrian","chain",2.29283000073471
+"220","Bailey, Adrian","supply",1.97641799682483
+"221","Bailey, Adrian","sit",1.97641799682483
+"222","Bailey, Adrian","skills",1.93842161139465
+"223","Bailey, Adrian","projects",1.75281119907485
+"224","Bailey, Adrian","business",1.72390263765233
+"225","Bailey, Adrian","ministers",1.56096081622403
+"226","Bailey, Adrian","boards",1.39505981175432
+"227","Bailey, Adrian","programme",1.34296453237956
+"228","Bailey, Adrian","reform",1.25659003254675
+"229","Bailey, Rebecca Long","paragraph",3.9867404976815
+"230","Bailey, Rebecca Long","1287",3.56953551699164
+"231","Bailey, Rebecca Long","budget",3.38222757872084
+"232","Bailey, Rebecca Long","expertise",3.26802417241388
+"233","Bailey, Rebecca Long","small",3.05543550134056
+"234","Bailey, Rebecca Long","minor",2.92973383856673
+"235","Bailey, Rebecca Long","limit",2.86908389330461
+"236","Bailey, Rebecca Long","whiplash",2.75317680220667
+"237","Bailey, Rebecca Long","funded",2.70361116575242
+"238","Bailey, Rebecca Long","nuisance",2.65255729035792
+"239","Bailey, Rebecca Long","1293",2.62071111412795
+"240","Bailey, Rebecca Long","located",2.52647763818148
+"241","Baker, Norman","comrcio",2.42630702515697
+"242","Baker, Norman","diligence",2.42630702515697
+"243","Baker, Norman","internacional",2.42630702515697
+"244","Baker, Norman","killarney",2.42630702515697
+"245","Baker, Norman","lda",2.42630702515697
+"246","Baker, Norman","lewes",2.42630702515697
+"247","Baker, Norman","quora",2.42630702515697
+"248","Baker, Norman","whitbread",2.42630702515697
+"249","Baker, Norman","plc",2.23732478865236
+"250","Baker, Norman","offshore",2.23732478865236
+"251","Baker, Norman","fact",1.98750386078226
+"252","Baker, Norman","relationship",1.62352418315692
+"253","Baker, Steve","obstacle",4.18565141103677
+"254","Baker, Steve","preparation",3.06491367885045
+"255","Baker, Steve","restricted",2.83954816915131
+"256","Baker, Steve","books",2.58633074391407
+"257","Baker, Steve","delays",2.55636074762475
+"258","Baker, Steve","asylum)",2.34405261889994
+"259","Baker, Steve","tier",2.08422004028389
+"260","Baker, Steve","immigr",2.06655769663929
+"261","Baker, Steve","hearings",2.0278248528831
+"262","Baker, Steve","access",1.96670634776687
+"263","Baker, Steve","reduce",1.82210261332679
+"264","Baker, Steve","first",1.81873565907934
+"265","Barclay, Stephen","rail",5.14615843204391
+"266","Barclay, Stephen","network",5.03454504634076
+"267","Barclay, Stephen","532",4.81361879692826
+"268","Barclay, Stephen","tackling",4.63609441598887
+"269","Barclay, Stephen","task",4.63609441598887
+"270","Barclay, Stephen","publish",4.42277527742086
+"271","Barclay, Stephen","prime",4.29076373385608
+"272","Barclay, Stephen","lay",4.27441734640014
+"273","Barclay, Stephen","radicalisation",3.95815691096444
+"274","Barclay, Stephen","drive",3.84434424635101
+"275","Barclay, Stephen","2000",3.8289898459067
+"276","Barclay, Stephen","extremism",3.8204583033659
+"277","Bardell, Hannah","july",1.82891199689891
+"278","Bardell, Hannah","change",1.75322657673322
+"279","Bardell, Hannah","claims",1.56921484208927
+"280","Bardell, Hannah","estimate",1.47643106836407
+"281","Bardell, Hannah","employment",1.35478967833672
+"282","Bardell, Hannah","number",1.31976838121835
+"283","Bardell, Hannah","tribunal",1.30757221743891
+"284","Bardell, Hannah","2013",1.30647947385104
+"285","Bardell, Hannah","made",0.902637855891325
+"286","Bardell, Hannah","since",0.875112156661343
+"287","Bardell, Hannah","2010",0
+"288","Bardell, Hannah","accommod",0
+"289","Baroness Afshar","tax",4.45258041785696
+"290","Baroness Afshar","council",3.62764680599292
+"291","Baroness Afshar","rough",3.31496648398472
+"292","Baroness Afshar","groups",3.1963948213698
+"293","Baroness Afshar","non",3.13853544740376
+"294","Baroness Afshar","begging",3.05676759423755
+"295","Baroness Afshar","sleeping",3.05676759423755
+"296","Baroness Afshar","payment",3.02227758310171
+"297","Baroness Afshar","sum",2.59011055998321
+"298","Baroness Afshar","specific",2.47726871917821
+"299","Baroness Afshar","committals",2.42174508089634
+"300","Baroness Afshar","breakdown",2.42174508089634
+"301","Baroness Altmann","county",5.66474277598811
+"302","Baroness Altmann","action",4.84077794640428
+"303","Baroness Altmann","lodge",4.65434754087279
+"304","Baroness Altmann","defence",4.21452149066555
+"305","Baroness Altmann","discovered",3.43131630145811
+"306","Baroness Altmann","penalise",3.43131630145811
+"307","Baroness Altmann","individual",3.26873967432028
+"308","Baroness Altmann","knowing",2.79043427402451
+"309","Baroness Altmann","sue",2.79043427402451
+"310","Baroness Altmann","monies",2.65255729035792
+"311","Baroness Altmann","notification",2.54349367327473
+"312","Baroness Altmann","repeatedly",2.44233218676566
+"313","Baroness Armstrong of Hill Top","chairs",3.22296166142208
+"314","Baroness Armstrong of Hill Top","departmental",2.66027633019366
+"315","Baroness Armstrong of Hill Top","list",2.31063979670001
+"316","Baroness Armstrong of Hill Top","appointed",2.26480528878337
+"317","Baroness Armstrong of Hill Top","bodies",2.20978554002654
+"318","Baroness Armstrong of Hill Top","non",1.82125685145388
+"319","Baroness Armstrong of Hill Top","persons",1.49817135926425
+"320","Baroness Armstrong of Hill Top","public",1.41794916166247
+"321","Baroness Armstrong of Hill Top","will",0.900179395178779
+"322","Baroness Armstrong of Hill Top","2010",0
+"323","Baroness Armstrong of Hill Top","accommod",0
+"324","Baroness Armstrong of Hill Top","cost",0
+"325","Baroness Corston","holloway",14.2726588046084
+"326","Baroness Corston","site",11.9871051662021
+"327","Baroness Corston","carillion",11.8212082058624
+"328","Baroness Corston","women",11.0903929910522
+"329","Baroness Corston","prison",10.4658110684586
+"330","Baroness Corston","rehabilitation",10.2073326033919
+"331","Baroness Corston","programme",9.40410400297167
+"332","Baroness Corston","contract",9.03326296018738
+"333","Baroness Corston","irish",8.94394828894506
+"334","Baroness Corston","republic",8.46125006244967
+"335","Baroness Corston","community",7.61834192012394
+"336","Baroness Corston","market",7.51069654642771
+"337","Baroness Coussins","interpretation",25.7692208540722
+"338","Baroness Coussins","ithebigword/",10.1794880606149
+"339","Baroness Coussins","translating",7.11832355650257
+"340","Baroness Coussins","court",6.89641397890954
+"341","Baroness Coussins","provision",5.7562720324828
+"342","Baroness Coussins","contract",5.72558632250244
+"343","Baroness Coussins","services",4.3235231532781
+"344","Baroness Coussins","current",4.29260091041316
+"345","Baroness Coussins","cancellation",4.2611350099131
+"346","Baroness Coussins","quality",4.13908975680492
+"347","Baroness Coussins","independent",3.73487471281509
+"348","Baroness Coussins","language",3.64652299729548
+"349","Baroness Deech","nuptial",3.94626999523619
+"350","Baroness Deech","binding",3.7512824949958
+"351","Baroness Deech","divorce",3.41356915363935
+"352","Baroness Deech","pre",2.69464082784836
+"353","Baroness Deech","plan",2.504762225924
+"354","Baroness Deech","post",2.22968762206796
+"355","Baroness Deech","agreements",2.22296166142208
+"356","Baroness Deech","forward",2.14313968319029
+"357","Baroness Deech","provisions",2.12037740348141
+"358","Baroness Deech","financial",2.11675421758744
+"359","Baroness Deech","law",2.11675421758744
+"360","Baroness Deech","bring",2.02354188697721
+"361","Baroness Doocey","section",7.66325666151651
+"362","Baroness Doocey","past",7.33166499315877
+"363","Baroness Doocey","coroners",6.05295149116692
+"364","Baroness Doocey","act",5.97400454931691
+"365","Baroness Doocey","2009",5.67368937545166
+"366","Baroness Doocey","modern",5.64901042592591
+"367","Baroness Doocey","slavery",5.42433430504679
+"368","Baroness Doocey","guidance",3.98262668743765
+"369","Baroness Doocey","commission",3.59987621683962
+"370","Baroness Doocey","victim",3.40602457592214
+"371","Baroness Doocey","embedded",3.28349511107287
+"372","Baroness Doocey","prosecutions",3.16800633486634
+"373","Baroness Drake","lower",3.54507180166424
+"374","Baroness Drake","level",2.21979506406568
+"375","Baroness Drake","access",2.10249752392489
+"376","Baroness Drake","fees",1.98011699800062
+"377","Baroness Drake","employment",1.61928338317899
+"378","Baroness Drake","tribunals",1.5628477230538
+"379","Baroness Drake","plans",1.33096310194277
+"380","Baroness Drake","2010",0
+"381","Baroness Drake","accommod",0
+"382","Baroness Drake","cost",0
+"383","Baroness Drake","flight",0
+"384","Baroness Drake","hotel",0
+"385","Baroness Gale","53a",2.90573092600763
+"386","Baroness Gale","2003",1.81551389074173
+"387","Baroness Gale","imposed",1.80244229488281
+"388","Baroness Gale","penalty",1.67345361488249
+"389","Baroness Gale","sexual",1.47419352431623
+"390","Baroness Gale","prosecutions",1.40186997057128
+"391","Baroness Gale","section",1.36043817036734
+"392","Baroness Gale","act",1.06054960414579
+"393","Baroness Gale","wales",1.0476291554822
+"394","Baroness Gale","convictions",1.03760606851785
+"395","Baroness Gale","case",1.02068954575811
+"396","Baroness Gale","offences",0.936467153858068
+"397","Baroness Golding","thames",2.3217816590325
+"398","Baroness Golding","drawn",2.01094493905212
+"399","Baroness Golding","leeds",1.89622435420992
+"400","Baroness Golding","formal",1.81482880391393
+"401","Baroness Golding","liverpool",1.81482880391393
+"402","Baroness Golding","1999",1.71628037922373
+"403","Baroness Golding","conclusions",1.63075430629066
+"404","Baroness Golding","kingston",1.59606572319884
+"405","Baroness Golding","pilot",1.57509792661922
+"406","Baroness Golding","basis",1.51196263285752
+"407","Baroness Golding","upon",1.40544365924334
+"408","Baroness Golding","light",1.34120098334158
+"409","Baroness Gould of Potternewton","genital",2.44233218676566
+"410","Baroness Gould of Potternewton","mutilation",2.44233218676566
+"411","Baroness Gould of Potternewton","abroad",2.41375789658761
+"412","Baroness Gould of Potternewton","sufficient",2.17507094485323
+"413","Baroness Gould of Potternewton","kingdom",2.14649665467518
+"414","Baroness Gould of Potternewton","practice",1.99945029909348
+"415","Baroness Gould of Potternewton","consider",1.92293228700379
+"416","Baroness Gould of Potternewton","carried",1.82177080049471
+"417","Baroness Gould of Potternewton","united",1.72751534579565
+"418","Baroness Gould of Potternewton","female",1.59844378368851
+"419","Baroness Gould of Potternewton","legislation",1.54571275570314
+"420","Baroness Gould of Potternewton","current",1.47444870562504
+"421","Baroness Hamwee","timetabling",3.56084520918548
+"422","Baroness Hamwee","guardianship",2.60137151034255
+"423","Baroness Hamwee","affairs",2.40431610091321
+"424","Baroness Hamwee","decide",2.28920540976781
+"425","Baroness Hamwee","missing",2.242076693946
+"426","Baroness Hamwee","property",2.1999186210656
+"427","Baroness Hamwee","legislation",1.60406193348702
+"428","Baroness Hamwee","consultation",1.54023818899418
+"429","Baroness Hamwee","response",1.53010773369497
+"430","Baroness Hamwee","proposed",1.3312502387859
+"431","Baroness Hamwee","recent",1.32821892420368
+"432","Baroness Hamwee","persons",1.24655392044434
+"433","Baroness Hayter of Kentish Town","brussels",6.78677450004374
+"434","Baroness Hayter of Kentish Town","bank",6.77623236109263
+"435","Baroness Hayter of Kentish Town","ombudsman",5.91675374394508
+"436","Baroness Hayter of Kentish Town","complaints",5.53146221829931
+"437","Baroness Hayter of Kentish Town","continued",5.45070686692146
+"438","Baroness Hayter of Kentish Town","manage",5.26623791181041
+"439","Baroness Hayter of Kentish Town","participation",5.25186879316833
+"440","Baroness Hayter of Kentish Town","enforced",4.6430614566333
+"441","Baroness Hayter of Kentish Town","will",4.44505590520349
+"442","Baroness Hayter of Kentish Town","legal",4.06313205976505
+"443","Baroness Hayter of Kentish Town","framework",3.91372142194145
+"444","Baroness Hayter of Kentish Town","reform)",3.87038639935663
+"445","Baroness Healy of Primrose Hill","immediate",2.07163466432223
+"446","Baroness Healy of Primrose Hill","remanded",1.90046516719597
+"447","Baroness Healy of Primrose Hill","subsequently",1.86570502560093
+"448","Baroness Healy of Primrose Hill","crown",1.51776019605754
+"449","Baroness Healy of Primrose Hill","women",1.5071229292146
+"450","Baroness Healy of Primrose Hill","magistrates",1.23465111519188
+"451","Baroness Healy of Primrose Hill","custodial",1.22569868889372
+"452","Baroness Healy of Primrose Hill","receive",1.16716586258098
+"453","Baroness Healy of Primrose Hill","england",1.08880583491505
+"454","Baroness Healy of Primrose Hill","wales",1.08439919874177
+"455","Baroness Healy of Primrose Hill","convicted",1.07402431807318
+"456","Baroness Healy of Primrose Hill","proportion",1.05326707454125
+"457","Baroness Hodgson of Abinger","identification",3.87104686156941
+"458","Baroness Hodgson of Abinger","gathered",3.56953551699164
+"459","Baroness Hodgson of Abinger","gypsies",2.6137671675961
+"460","Baroness Hodgson of Abinger","enable",2.28873718074439
+"461","Baroness Hodgson of Abinger","can",2.24520198503728
+"462","Baroness Hodgson of Abinger","travellers",2.1693601931869
+"463","Baroness Hodgson of Abinger","youth",1.75039003539168
+"464","Baroness Hodgson of Abinger","justice",1.68858571601744
+"465","Baroness Hodgson of Abinger","system",1.68858571601744
+"466","Baroness Hodgson of Abinger","data",1.66340247677821
+"467","Baroness Hodgson of Abinger","plans",1.06174125640735
+"468","Baroness Hodgson of Abinger","2010",0
+"469","Baroness Howe of Idlicote","visiting",11.6291425450565
+"470","Baroness Howe of Idlicote","ilocked",11.5962899139051
+"471","Baroness Howe of Idlicote","barnardos",10.9704467857323
+"472","Baroness Howe of Idlicote","experiences",8.96497871731169
+"473","Baroness Howe of Idlicote","fathers",8.78385249311297
+"474","Baroness Howe of Idlicote","parent",8.00409238503407
+"475","Baroness Howe of Idlicote","incentive",7.63738854151286
+"476","Baroness Howe of Idlicote","privileges",7.63738854151286
+"477","Baroness Howe of Idlicote","children",7.13866280486522
+"478","Baroness Howe of Idlicote","earned",6.38294300762292
+"479","Baroness Howe of Idlicote","recent",5.9449423992648
+"480","Baroness Howe of Idlicote","scheme",5.02112971430791
+"481","Baroness Hussein-Ece","pursue",2.18115276956689
+"482","Baroness Hussein-Ece","sex",1.63958427058547
+"483","Baroness Hussein-Ece","child",1.36834283463984
+"484","Baroness Hussein-Ece","violence",1.36575691737036
+"485","Baroness Hussein-Ece","domestic",1.35811510179291
+"486","Baroness Hussein-Ece","given",1.3385386762003
+"487","Baroness Hussein-Ece","access",1.31113756517791
+"488","Baroness Hussein-Ece","prosecuted",1.27972634261832
+"489","Baroness Hussein-Ece","family",1.21276426821402
+"490","Baroness Hussein-Ece","aid",1.1378721617746
+"491","Baroness Hussein-Ece","legal",0.991320052469801
+"492","Baroness Hussein-Ece","convicted",0.947200415885793
+"493","Baroness Jones of Moulsecoomb","laid",2.31084205339541
+"494","Baroness Jones of Moulsecoomb","crash",2.31084205339541
+"495","Baroness Jones of Moulsecoomb","treated",2.18612762920049
+"496","Baroness Jones of Moulsecoomb","definition",1.99969018682991
+"497","Baroness Jones of Moulsecoomb","traffic",1.86579348027512
+"498","Baroness Jones of Moulsecoomb","qualify",1.75972619648927
+"499","Baroness Jones of Moulsecoomb","extend",1.73510637101258
+"500","Baroness Jones of Moulsecoomb","code",1.69109089604429
+"501","Baroness Jones of Moulsecoomb","road",1.69109089604429
+"502","Baroness Jones of Moulsecoomb","practice",1.59500956080962
+"503","Baroness Jones of Moulsecoomb","regard",1.55961612024068
+"504","Baroness Jones of Moulsecoomb","include",1.37075674711891
+"505","Baroness Kennedy of Cradley","holloway",4.13844640596946
+"506","Baroness Kennedy of Cradley","presently",3.71869196881441
+"507","Baroness Kennedy of Cradley","hmp",2.71486632875954
+"508","Baroness Kennedy of Cradley","held",2.60119201706186
+"509","Baroness Kennedy of Cradley","prisoners",0.80096153145735
+"510","Baroness Kennedy of Cradley","2010",0
+"511","Baroness Kennedy of Cradley","accommod",0
+"512","Baroness Kennedy of Cradley","cost",0
+"513","Baroness Kennedy of Cradley","flight",0
+"514","Baroness Kennedy of Cradley","hotel",0
+"515","Baroness Kennedy of Cradley","intern",0
+"516","Baroness Kennedy of Cradley","made",0
+"517","Baroness Kennedy of The Shaws","unaccompanied",10.4680019980261
+"518","Baroness Kennedy of The Shaws","migrant",10.157087428535
+"519","Baroness Kennedy of The Shaws","appeared",7.75668987316958
+"520","Baroness Kennedy of The Shaws","deradicalisation",4.77975330953336
+"521","Baroness Kennedy of The Shaws","children",4.68969342202395
+"522","Baroness Kennedy of The Shaws","undergone",4.50707747220806
+"523","Baroness Kennedy of The Shaws","2014",4.31616340890492
+"524","Baroness Kennedy of The Shaws","proceedings",4.01467635822262
+"525","Baroness Kennedy of The Shaws","rights/",3.31496648398472
+"526","Baroness Kennedy of The Shaws","programme",2.79961408659613
+"527","Baroness Kennedy of The Shaws","ithe",2.71544722781206
+"528","Baroness Kennedy of The Shaws","healthy",2.64723839007477
+"529","Baroness King of Bow","explanatory",3.02613653442003
+"530","Baroness King of Bow","academy",2.79043427402451
+"531","Baroness King of Bow","admission",2.79043427402451
+"532","Baroness King of Bow","pupils",2.79043427402451
+"533","Baroness King of Bow","sen",2.65255729035792
+"534","Baroness King of Bow","went",2.36443663355857
+"535","Baroness King of Bow","schools",2.36443663355857
+"536","Baroness King of Bow","memorandum",2.36443663355857
+"537","Baroness King of Bow","instances",2.2107406822235
+"538","Baroness King of Bow","goods",1.94545050917137
+"539","Baroness King of Bow","compliance",1.88109943291
+"540","Baroness King of Bow","copy",1.79825660071626
+"541","Baroness Kinnock of Holyhead","eritrean",7.16133050014528
+"542","Baroness Kinnock of Holyhead","asylum",4.48387011115087
+"543","Baroness Kinnock of Holyhead","appeals",3.09159190209555
+"544","Baroness Kinnock of Holyhead","nationals",2.87090113226887
+"545","Baroness Kinnock of Holyhead","lodged",2.67135566824861
+"546","Baroness Kinnock of Holyhead","2013",2.49912660509386
+"547","Baroness Kinnock of Holyhead","outside",2.40040534414891
+"548","Baroness Kinnock of Holyhead","initial",2.27609191395159
+"549","Baroness Kinnock of Holyhead","2015",2.26759803121602
+"550","Baroness Kinnock of Holyhead","2014",2.16072734294158
+"551","Baroness Kinnock of Holyhead","pay",2.04955373233904
+"552","Baroness Kinnock of Holyhead","refusals",1.98741677935678
+"553","Baroness Lister of Burtersett","pursuing",4.49461464081374
+"554","Baroness Lister of Burtersett","upper",4.3865981390758
+"555","Baroness Lister of Burtersett","chamber)",4.00891238041823
+"556","Baroness Lister of Burtersett","appeals",3.89987631081498
+"557","Baroness Lister of Burtersett","representation",3.87630668055525
+"558","Baroness Lister of Burtersett","asylum",3.60028997398384
+"559","Baroness Lister of Burtersett","hl2645",3.56084520918548
+"560","Baroness Lister of Burtersett","litigants",3.46379457557142
+"561","Baroness Lister of Burtersett","200203",3.20970249642714
+"562","Baroness Lister of Burtersett","forcible",3.20970249642714
+"563","Baroness Lister of Burtersett","meters",3.20970249642714
+"564","Baroness Lister of Burtersett","prepayment",3.20970249642714
+"565","Baroness Ludford","rental",10.5238964630621
+"566","Baroness Ludford","buildings",10.1584719391983
+"567","Baroness Ludford","raised",9.63341171160929
+"568","Baroness Ludford","disposed",8.87121317314744
+"569","Baroness Ludford","sale",7.9861520608672
+"570","Baroness Ludford","money",7.92037684016899
+"571","Baroness Ludford","estate",7.69711761306624
+"572","Baroness Ludford","may",6.68005264896399
+"573","Baroness Ludford","third",6.16040447077757
+"574","Baroness Ludford","amp",5.50644355504998
+"575","Baroness Ludford","parties",5.38617379744614
+"576","Baroness Ludford","2010",4.51656535328283
+"577","Baroness Masham of Ilton","training",6.33445230451572
+"578","Baroness Masham of Ilton","officer",5.789841971308
+"579","Baroness Masham of Ilton","role",4.81491552488357
+"580","Baroness Masham of Ilton","suggestion",3.41757006606683
+"581","Baroness Masham of Ilton","fulfil",3.26802417241388
+"582","Baroness Masham of Ilton","vocational",3.12889493147202
+"583","Baroness Masham of Ilton","howard",3.03596229535056
+"584","Baroness Masham of Ilton","league",3.03596229535056
+"585","Baroness Masham of Ilton","penal",3.03596229535056
+"586","Baroness Masham of Ilton","degree",3.03596229535056
+"587","Baroness Masham of Ilton","receive",2.69774994947982
+"588","Baroness Masham of Ilton","england",2.51663108072749
+"589","Baroness Meacher","havemade",3.70624520066165
+"590","Baroness Meacher","law",3.38770137813807
+"591","Baroness Meacher","terminal",2.71667557231756
+"592","Baroness Meacher","die",2.71667557231756
+"593","Baroness Meacher","illness",2.69327453376365
+"594","Baroness Meacher","burials",2.63802026696727
+"595","Baroness Meacher","possible",2.45861202616093
+"596","Baroness Meacher","assisted",2.34405261889994
+"597","Baroness Meacher","cremations",2.33362741099141
+"598","Baroness Meacher","scotland",2.31848137149163
+"599","Baroness Meacher","basis",2.22554873537017
+"600","Baroness Meacher","level",1.8572137972014
+"601","Baroness Miller of Chilthorne Domer","800th",6.87253819910146
+"602","Baroness Miller of Chilthorne Domer","anniversary",6.87253819910146
+"603","Baroness Miller of Chilthorne Domer","forest",6.61908167486311
+"604","Baroness Miller of Chilthorne Domer","charter",6.42248552119844
+"605","Baroness Miller of Chilthorne Domer","mark",5.81180208975249
+"606","Baroness Miller of Chilthorne Domer","granting",3.83766972609515
+"607","Baroness Miller of Chilthorne Domer","2017",3.79201028872588
+"608","Baroness Miller of Chilthorne Domer","celebrate",3.7512824949958
+"609","Baroness Miller of Chilthorne Domer","carta",3.12125570410566
+"610","Baroness Miller of Chilthorne Domer","magna",3.12125570410566
+"611","Baroness Miller of Chilthorne Domer","similar",2.53452789029924
+"612","Baroness Miller of Chilthorne Domer","way",2.242076693946
+"613","Baroness Morgan of Huyton","improve",6.12332166597687
+"614","Baroness Morgan of Huyton","literacy",5.96681688256058
+"615","Baroness Morgan of Huyton","light",3.92839474949601
+"616","Baroness Morgan of Huyton","parcels",3.32573006579733
+"617","Baroness Morgan of Huyton","skills",3.2765305446558
+"618","Baroness Morgan of Huyton","targets",3.03560468063012
+"619","Baroness Morgan of Huyton","governors",2.9627916852678
+"620","Baroness Morgan of Huyton","showing",2.90573092600763
+"621","Baroness Morgan of Huyton","stop",2.82452091497381
+"622","Baroness Morgan of Huyton","monitored",2.5517693655575
+"623","Baroness Morgan of Huyton","sent",2.207531956637
+"624","Baroness Morgan of Huyton","regulations",2.14858295080525
+"625","Baroness Pinnock","foster",4.27960332856952
+"626","Baroness Pinnock","abused",3.41041236748549
+"627","Baroness Pinnock","compensation",3.39625779564767
+"628","Baroness Pinnock","injuries",3.19777601771974
+"629","Baroness Pinnock","children",2.76313237447978
+"630","Baroness Pinnock","criminal",2.55501638086591
+"631","Baroness Pinnock","indefinitely",2.554732013629
+"632","Baroness Pinnock","parents",2.49375266036349
+"633","Baroness Pinnock","former",2.49375266036349
+"634","Baroness Pinnock","keeping",2.24315057358371
+"635","Baroness Pinnock","best",2.2107406822235
+"636","Baroness Pinnock","allege",1.79825660071626
+"637","Baroness Rebuck","least",2.84390560599304
+"638","Baroness Rebuck","literacy",2.60137151034255
+"639","Baroness Rebuck","studies",2.47885283397922
+"640","Baroness Rebuck","entry",2.45144481673503
+"641","Baroness Rebuck","cent",2.42718698913304
+"642","Baroness Rebuck","skills",2.40431610091321
+"643","Baroness Rebuck","recognised",2.31902975323348
+"644","Baroness Rebuck","qualifications",2.2107406822235
+"645","Baroness Rebuck","towards",2.18115276956689
+"646","Baroness Rebuck","materials",2.15393452839683
+"647","Baroness Rebuck","higher",2.10527358991712
+"648","Baroness Rebuck","specific",2.10527358991712
+"649","Baroness Redfern","sanctions",3.2765305446558
+"650","Baroness Redfern","targets",3.03560468063012
+"651","Baroness Redfern","met",2.89856607164657
+"652","Baroness Redfern","imposed",2.63850535059248
+"653","Baroness Redfern","percentage",2.43739433747609
+"654","Baroness Redfern","education",2.33604665605167
+"655","Baroness Redfern","less",2.24520198503728
+"656","Baroness Redfern","upon",2.1607462696946
+"657","Baroness Redfern","accommodation",2.12006347057952
+"658","Baroness Redfern","allocated",2.0757891261447
+"659","Baroness Redfern","providers",1.80391890019714
+"660","Baroness Redfern","given",1.71226442781356
+"661","Baroness Seccombe","bears",3.02613653442003
+"662","Baroness Seccombe","kingdom",1.89303211276754
+"663","Baroness Seccombe","aware",1.83716143816139
+"664","Baroness Seccombe","concerns",1.74715366623222
+"665","Baroness Seccombe","incurred",1.73933616143247
+"666","Baroness Seccombe","united",1.52352533034101
+"667","Baroness Seccombe","purse",1.51542860301384
+"668","Baroness Seccombe","european",1.50363390103695
+"669","Baroness Seccombe","private",1.40101240259319
+"670","Baroness Seccombe","human",1.38977017268291
+"671","Baroness Seccombe","rights",1.22616684956584
+"672","Baroness Seccombe","average",1.11990326187258
+"673","Baroness Sharples","inquests",3.36961912549556
+"674","Baroness Sharples","delays",3.30024753414967
+"675","Baroness Sharples","london",2.8398432599448
+"676","Baroness Sharples","six",2.69071650195041
+"677","Baroness Sharples","holding",2.68301733631525
+"678","Baroness Sharples","months",1.65111698519019
+"679","Baroness Sharples","2010",0
+"680","Baroness Sharples","accommod",0
+"681","Baroness Sharples","cost",0
+"682","Baroness Sharples","flight",0
+"683","Baroness Sharples","hotel",0
+"684","Baroness Sharples","intern",0
+"685","Baroness Smith of Basildon","genital",8.42855628598462
+"686","Baroness Smith of Basildon","mutilation",8.42855628598462
+"687","Baroness Smith of Basildon","phone",7.9529768000131
+"688","Baroness Smith of Basildon","whilst",7.41210545238532
+"689","Baroness Smith of Basildon","mobile",6.82199036925716
+"690","Baroness Smith of Basildon","cautioned",6.54182152131737
+"691","Baroness Smith of Basildon","drug",6.36813608215758
+"692","Baroness Smith of Basildon","prosecuted",6.36216759178798
+"693","Baroness Smith of Basildon","use",6.12981516855198
+"694","Baroness Smith of Basildon","drive",5.65594044170532
+"695","Baroness Smith of Basildon","female",5.5162739425067
+"696","Baroness Smith of Basildon","since",5.17234715180876
+"697","Baroness Stern","inspector",40.0249449165297
+"698","Baroness Stern","chief",33.4791279786355
+"699","Baroness Stern","report",22.6177594692682
+"700","Baroness Stern","action",20.1805469182677
+"701","Baroness Stern","hmp",18.610202383962
+"702","Baroness Stern","conclusion",15.9813946963396
+"703","Baroness Stern","taken",13.1213815322169
+"704","Baroness Stern","respect",12.4813085145107
+"705","Baroness Stern","response",10.623704394371
+"706","Baroness Stern","light",10.6208547025687
+"707","Baroness Stern","prison",10.6178592494587
+"708","Baroness Stern","finding",10.4542349636178
+"709","Baroness Taylor of Bolton","category",3.06228223402122
+"710","Baroness Taylor of Bolton","held",2.90822108634005
+"711","Baroness Taylor of Bolton","currently",2.7584409454106
+"712","Baroness Taylor of Bolton","prisoners",0.895502215850485
+"713","Baroness Taylor of Bolton","2010",0
+"714","Baroness Taylor of Bolton","accommod",0
+"715","Baroness Taylor of Bolton","cost",0
+"716","Baroness Taylor of Bolton","flight",0
+"717","Baroness Taylor of Bolton","hotel",0
+"718","Baroness Taylor of Bolton","intern",0
+"719","Baroness Taylor of Bolton","made",0
+"720","Baroness Taylor of Bolton","oversea",0
+"721","Baroness Thomas of Winchester","itransforming",3.11386880460654
+"722","Baroness Thomas of Winchester","referenced",3.11386880460654
+"723","Baroness Thomas of Winchester","independence",2.9236936851068
+"724","Baroness Thomas of Winchester","payment",2.63455514107831
+"725","Baroness Thomas of Winchester","appeals",2.55919878949011
+"726","Baroness Thomas of Winchester","panel",2.28217092499607
+"727","Baroness Thomas of Winchester","personal",2.25055832593113
+"728","Baroness Thomas of Winchester","website",2.24438768376232
+"729","Baroness Thomas of Winchester","experience",2.16354619114918
+"730","Baroness Thomas of Winchester","relevance",2.01674387820367
+"731","Baroness Thomas of Winchester","cross",2.00185205872598
+"732","Baroness Thomas of Winchester","remove",1.99059130381056
+"733","Baroness Thornton","conducted",4.18377452036378
+"734","Baroness Thornton","celebrant",3.55877904927178
+"735","Baroness Thornton","humanist",3.24255128325494
+"736","Baroness Thornton","workplace",2.91527851217387
+"737","Baroness Thornton","recognition",2.76741895712986
+"738","Baroness Thornton","marriages",2.57357864873072
+"739","Baroness Thornton","enable",2.40044780630072
+"740","Baroness Thornton","harassment",2.3915636803915
+"741","Baroness Thornton","intend",2.36578149835588
+"742","Baroness Thornton","concerning",2.23496647934425
+"743","Baroness Thornton","brought",2.10479913521751
+"744","Baroness Thornton","monitoring",2.03560775523684
+"745","Baroness Tonge","girls",3.03596229535056
+"746","Baroness Tonge","genital",2.63802026696727
+"747","Baroness Tonge","mutilation",2.63802026696727
+"748","Baroness Tonge","contain",2.36567939003947
+"749","Baroness Tonge","origin",2.25005404930656
+"750","Baroness Tonge","country",1.83686198087729
+"751","Baroness Tonge","female",1.72651661384453
+"752","Baroness Tonge","current",1.59258662237649
+"753","Baroness Tonge","protection",1.50174156047615
+"754","Baroness Tonge","orders",1.41854888454459
+"755","Baroness Tonge","information",1.41006651016715
+"756","Baroness Tonge","nationality",1.37006744376347
+"757","Baroness Uddin","spectrum",3.28349511107287
+"758","Baroness Uddin","autism",3.00614501296026
+"759","Baroness Uddin","disorder",2.40431610091321
+"760","Baroness Uddin","engage",2.16178200526272
+"761","Baroness Uddin","justice",1.55327294455486
+"762","Baroness Uddin","system",1.55327294455486
+"763","Baroness Uddin","currently",1.53010773369497
+"764","Baroness Uddin","training",1.36786832672775
+"765","Baroness Uddin","provide",1.32371458082692
+"766","Baroness Uddin","criminal",1.24532463649395
+"767","Baroness Uddin","staff",1.14299679793399
+"768","Baroness Uddin","plans",0.976659906602086
+"769","Baroness Wheatcroft","women",8.29974566777819
+"770","Baroness Wheatcroft","current",8.11980829145094
+"771","Baroness Wheatcroft","proportion",5.80035554464873
+"772","Baroness Wheatcroft","jailed",5.70092064974283
+"773","Baroness Wheatcroft","woman",3.55877904927178
+"774","Baroness Wheatcroft","crime",3.53598993463321
+"775","Baroness Wheatcroft","children",3.51792272444587
+"776","Baroness Wheatcroft","prison",3.20238562631074
+"777","Baroness Wheatcroft","addiction",3.12125570410566
+"778","Baroness Wheatcroft","combined",3.05756989844826
+"779","Baroness Wheatcroft","keeping",3.00950229978049
+"780","Baroness Wheatcroft","violent",2.94601228533978
+"781","Baroness Whitaker","romany",5.15906497720846
+"782","Baroness Whitaker","gypsies",4.25252858956317
+"783","Baroness Whitaker","traveller",3.52949044465659
+"784","Baroness Whitaker","recommendations",3.37725284572813
+"785","Baroness Whitaker","inspectorate",3.3118788404717
+"786","Baroness Whitaker","humanist",3.09165134229387
+"787","Baroness Whitaker","ipeople",2.73724348610663
+"788","Baroness Whitaker","response",2.70631090486734
+"789","Baroness Whitaker","ithat",2.52404276975102
+"790","Baroness Whitaker","marriages",2.45381096204596
+"791","Baroness Whitaker","now",2.45381096204596
+"792","Baroness Whitaker","report",2.10919738562955
+"793","Baroness Young of Hornsey","ago",3.41757006606683
+"794","Baroness Young of Hornsey","ten",3.24870593743824
+"795","Baroness Young of Hornsey","race",2.74728716075575
+"796","Baroness Young of Hornsey","senior",2.40040534414891
+"797","Baroness Young of Hornsey","posts",1.93096612321457
+"798","Baroness Young of Hornsey","level",1.69539648472839
+"799","Baroness Young of Hornsey","currently",1.59258662237649
+"800","Baroness Young of Hornsey","relations",1.30131664957371
+"801","Baroness Young of Hornsey","numbers",1.20477818845895
+"802","Baroness Young of Hornsey","five",1.07383365913102
+"803","Baroness Young of Hornsey","years",0.538411636440705
+"804","Baroness Young of Hornsey","prisons",0.517018445381184
+"805","Bayley, Sir Hugh","york",12.4593664301271
+"806","Bayley, Sir Hugh","1995",5.7276131394452
+"807","Bayley, Sir Hugh","crown",4.85494112336601
+"808","Bayley, Sir Hugh","cathedral",4.53920480163004
+"809","Bayley, Sir Hugh","reburial",4.53920480163004
+"810","Bayley, Sir Hugh","2004",4.35460803187769
+"811","Bayley, Sir Hugh","king",4.18565141103677
+"812","Bayley, Sir Hugh","magristrates",4.05998820009529
+"813","Bayley, Sir Hugh","richard",3.97883593553688
+"814","Bayley, Sir Hugh","since",3.87294240739323
+"815","Bayley, Sir Hugh","leicester",3.83209802044349
+"816","Bayley, Sir Hugh","magistrages",3.70624520066165
+"817","Bebb, Guto","violent",2.01250952291925
+"818","Bebb, Guto","murdered",1.88077780947959
+"819","Bebb, Guto","subject",1.80244229488281
+"820","Bebb, Guto","assaulted",1.67802425207637
+"821","Bebb, Guto","licence",1.49611174342493
+"822","Bebb, Guto","committed",1.44355964704568
+"823","Bebb, Guto","crime",1.39320673690572
+"824","Bebb, Guto","released",1.27186724267799
+"825","Bebb, Guto","england",1.05188637048022
+"826","Bebb, Guto","wales",1.0476291554822
+"827","Bebb, Guto","five",0.960466023337719
+"828","Bebb, Guto","people",0.898289539198011
+"829","Beckett, Margaret","eastern",3.87104686156941
+"830","Beckett, Margaret","europe",2.82798898275925
+"831","Beckett, Margaret","care",2.02925743922007
+"832","Beckett, Margaret","countries",1.91853976767155
+"833","Beckett, Margaret","proceedings",1.86352056492181
+"834","Beckett, Margaret","involving",1.85923492511684
+"835","Beckett, Margaret","families",1.5513732645223
+"836","Beckett, Margaret","children",1.46408373510768
+"837","Beckett, Margaret","estimate",1.40772178928505
+"838","Beckett, Margaret","number",1.25834977796091
+"839","Beckett, Margaret","will",0.814242899404655
+"840","Beckett, Margaret","2010",0
+"841","Beith, Sir Alan","archives",8.95852641884635
+"842","Beith, Sir Alan","targets",7.17243928352983
+"843","Beith, Sir Alan","meet",5.50685014179604
+"844","Beith, Sir Alan","records",5.33008165383345
+"845","Beith, Sir Alan","departments",4.54614288882206
+"846","Beith, Sir Alan","national",4.23843196480473
+"847","Beith, Sir Alan","clearing",3.61293666190285
+"848","Beith, Sir Alan","release",2.75708820098565
+"849","Beith, Sir Alan","encourage",2.69307502496926
+"850","Beith, Sir Alan","obligations",2.56793651051151
+"851","Beith, Sir Alan","material",2.35951705718439
+"852","Beith, Sir Alan","engaged",2.01250952291925
+"853","Bellingham, Sir Henry","beachy",6.52923801341878
+"854","Bellingham, Sir Henry","head",5.53246127022555
+"855","Bellingham, Sir Henry","northmoor",3.20970249642714
+"856","Bellingham, Sir Henry","paid",3.07004891138879
+"857","Bellingham, Sir Henry","leigh",2.70970249642714
+"858","Bellingham, Sir Henry","iraq",2.70970249642714
+"859","Bellingham, Sir Henry","historic",2.6292204727053
+"860","Bellingham, Sir Henry","died",2.59024852532215
+"861","Bellingham, Sir Henry","verdicts",2.50786376591274
+"862","Bellingham, Sir Henry","detailed",2.28459256689187
+"863","Bellingham, Sir Henry","related",2.25394655379697
+"864","Bellingham, Sir Henry","sex",2.09736324608528
+"865","Benn, Hilary","contesting",20.5778480894612
+"866","Benn, Hilary","levied",20.422972545883
+"867","Benn, Hilary","notice",19.7905543120584
+"868","Benn, Hilary","fixed",19.249635904181
+"869","Benn, Hilary","local",18.3588287202964
+"870","Benn, Hilary","consequent",18.2739929838867
+"871","Benn, Hilary","authorities",17.7612455350877
+"872","Benn, Hilary","penalty",16.9814330226193
+"873","Benn, Hilary","upon",16.5103118499838
+"874","Benn, Hilary","guilty",16.082818511092
+"875","Benn, Hilary","area",15.3576945173101
+"876","Benn, Hilary","found",14.8124499032313
+"877","Benton, Joe","shared",9.81462734440326
+"878","Benton, Joe","privatisation",5.06871027956392
+"879","Benton, Joe","services",4.32396646215466
+"880","Benton, Joe","bootle",4.05998820009529
+"881","Benton, Joe","robust",4.05998820009529
+"882","Benton, Joe","shored",3.55877904927178
+"883","Benton, Joe","steria",3.12889493147202
+"884","Benton, Joe","commercial",2.74134213243143
+"885","Benton, Joe","union",2.59147193149936
+"886","Benton, Joe","jobs",2.52375972265384
+"887","Benton, Joe","bid",2.42511436641459
+"888","Benton, Joe","house",2.37704676774681
+"889","Benyon, Richard","upheld",5.21431301217289
+"890","Benyon, Richard","advisory",4.80081068829783
+"891","Benyon, Richard","complaints",4.63696274298326
+"892","Benyon, Richard","family",2.97065363540418
+"893","Benyon, Richard","support",2.86498122194734
+"894","Benyon, Richard","children",2.80350691203448
+"895","Benyon, Richard","three",2.54516635122883
+"896","Benyon, Richard","service",2.01755864350058
+"897","Benyon, Richard","made",1.64798371643259
+"898","Benyon, Richard","court",1.64224775417657
+"899","Benyon, Richard","last",1.40323842367685
+"900","Benyon, Richard","years",1.07682327288141
+"901","Berger, Luciana","health",29.4138420167038
+"902","Berger, Luciana","mental",28.9974793973916
+"903","Berger, Luciana","2010",26.9398738078523
+"904","Berger, Luciana","prison",24.0358088563896
+"905","Berger, Luciana","self",23.8240106645993
+"906","Berger, Luciana","since",22.6736500476176
+"907","Berger, Luciana","year",19.6033945895591
+"908","Berger, Luciana","harm",18.5480797696512
+"909","Berger, Luciana","death",16.7105711129773
+"910","Berger, Luciana","suicide",16.1572634616708
+"911","Berger, Luciana","bill",15.8715401498515
+"912","Berger, Luciana","inflicted",13.9738761234316
+"913","Berry, Jake","grandchildren",14.7932629659731
+"914","Berry, Jake","grandparents",14.5795242846574
+"915","Berry, Jake","gap",10.872567350408
+"916","Berry, Jake","see",9.71254879195799
+"917","Berry, Jake","applications",8.52718437843023
+"918","Berry, Jake","contact",6.97572172461859
+"919","Berry, Jake","order",6.01980002140662
+"920","Berry, Jake","final",5.35669550559654
+"921","Berry, Jake","permission",5.27149805709641
+"922","Berry, Jake","percentage",5.25100157547312
+"923","Berry, Jake","earnings",5.09178603191395
+"924","Berry, Jake","employee",4.98257153482626
+"925","Berry, James","occurrence",3.28349511107287
+"926","Berry, James","dropped",3.00614501296026
+"927","Berry, James","delayed",2.242076693946
+"928","Berry, James","caused",2.00360488304627
+"929","Berry, James","london",1.92929358228349
+"930","Berry, James","two",1.83328173425076
+"931","Berry, James","crown",1.5750541914563
+"932","Berry, James","data",1.53010773369497
+"933","Berry, James","magistrates",1.28125801363119
+"934","Berry, James","cases",1.0963964482409
+"935","Berry, James","courts",0.788910302900534
+"936","Berry, James","last",0.674093934395205
+"937","Bingham, Andrew","drake",6.96099295191551
+"938","Bingham, Andrew","books",6.75577648877802
+"939","Bingham, Andrew","hall",5.56740521847046
+"940","Bingham, Andrew","manchester",5.27889095713502
+"941","Bingham, Andrew","delivered",4.94539581611664
+"942","Bingham, Andrew","contain",4.83655092780413
+"943","Bingham, Andrew","packages",4.80315609441842
+"944","Bingham, Andrew","library",4.62294377805765
+"945","Bingham, Andrew","users",4.48160736167887
+"946","Bingham, Andrew","judiciary",4.42088722104487
+"947","Bingham, Andrew","identify",4.00051912903524
+"948","Bingham, Andrew","access",3.82093487457831
+"949","Blackford, Ian","devolved",3.21907877554606
+"950","Blackford, Ian","administrations",2.98010385267431
+"951","Blackford, Ian","implications",2.82764973026894
+"952","Blackford, Ian","policies",2.76490386645903
+"953","Blackford, Ian","leaving",2.62001925922161
+"954","Blackford, Ian","discuss",2.04892933366492
+"955","Blackford, Ian","plans",1.33096310194277
+"956","Blackford, Ian","2010",0
+"957","Blackford, Ian","accommod",0
+"958","Blackford, Ian","cost",0
+"959","Blackford, Ian","flight",0
+"960","Blackford, Ian","hotel",0
+"961","Blackman-Woods, Dr Roberta","organ",5.93729751413335
+"962","Blackman-Woods, Dr Roberta","durham",5.70644518638869
+"963","Blackman-Woods, Dr Roberta","donors",5.64393218386912
+"964","Blackman-Woods, Dr Roberta","staffing",4.04196124177255
+"965","Blackman-Woods, Dr Roberta","donation",3.87104686156941
+"966","Blackman-Woods, Dr Roberta","register",3.34452147529382
+"967","Blackman-Woods, Dr Roberta","prison",3.25121862199432
+"968","Blackman-Woods, Dr Roberta","newton",3.24870593743824
+"969","Blackman-Woods, Dr Roberta","frankland",3.24870593743824
+"970","Blackman-Woods, Dr Roberta","record",2.99324301045321
+"971","Blackman-Woods, Dr Roberta","occupation",2.89583164068126
+"972","Blackman-Woods, Dr Roberta","increase",2.88099719432886
+"973","Blackman, Bob","came",2.71136028825718
+"974","Blackman, Bob","sex",2.45937640587821
+"975","Blackman, Bob","light",2.4178844580704
+"976","Blackman, Bob","abuse",2.11895858384614
+"977","Blackman, Bob","supporting",1.75443552910661
+"978","Blackman, Bob","victims",1.56753853892208
+"979","Blackman, Bob","cases",1.39763672105354
+"980","Blackman, Bob","2014",1.26290100026325
+"981","Blackman, Bob","2010",0
+"982","Blackman, Bob","accommod",0
+"983","Blackman, Bob","cost",0
+"984","Blackman, Bob","flight",0
+"985","Blackman, Kirsty","scotland",15.2635768229022
+"986","Blackman, Kirsty","24107",11.1958195940834
+"987","Blackman, Kirsty","breach",10.2804051929401
+"988","Blackman, Kirsty","tribunal",10.157029741636
+"989","Blackman, Kirsty","devolved",9.39615487789344
+"990","Blackman, Kirsty","data",8.82129175310498
+"991","Blackman, Kirsty","whose",8.79741164200476
+"992","Blackman, Kirsty","waiting",7.45330297414921
+"993","Blackman, Kirsty","february",6.07844156107979
+"994","Blackman, Kirsty","non",6.027843875748
+"995","Blackman, Kirsty","service",4.97434627638486
+"996","Blackman, Kirsty","appeal",4.64669417847833
+"997","Blackwood, Nicola","modernise",4.70329256384254
+"998","Blackwood, Nicola","2020",2.86944785508927
+"999","Blackwood, Nicola","system",2.50457736649198
+"1000","Blackwood, Nicola","expenditure",2.47087153776466
+"1001","Blackwood, Nicola","research",2.3915636803915
+"1002","Blackwood, Nicola","development",2.20563026934007
+"1003","Blackwood, Nicola","spending",2.11236435062438
+"1004","Blackwood, Nicola","allocated",2.0757891261447
+"1005","Blackwood, Nicola","tribunals",1.84918636368437
+"1006","Blackwood, Nicola","funding",1.61216816111596
+"1007","Blackwood, Nicola","plans",1.57481677989104
+"1008","Blackwood, Nicola","departments",1.53487881744187
+"1009","Blenkinsop, Tom","illegal",4.84233950869169
+"1010","Blenkinsop, Tom","gender",4.7446777943652
+"1011","Blenkinsop, Tom","ethnic",4.49391473344522
+"1012","Blenkinsop, Tom","high",4.31233109185451
+"1013","Blenkinsop, Tom","drugs",3.76656724138238
+"1014","Blenkinsop, Tom","made",3.75256160251134
+"1015","Blenkinsop, Tom","border",3.70624520066165
+"1016","Blenkinsop, Tom","teesside",3.55877904927178
+"1017","Blenkinsop, Tom","availability",3.50721308287814
+"1018","Blenkinsop, Tom","safety",3.33017271293153
+"1019","Blenkinsop, Tom","juries",3.27172915435034
+"1020","Blenkinsop, Tom","movement",3.24870593743824
+"1021","Blomfield, Paul","traffickers",21.8090966263369
+"1022","Blomfield, Paul","tribunal",20.2007769890597
+"1023","Blomfield, Paul","tier",15.9430589331322
+"1024","Blomfield, Paul","chamber",13.4557408898593
+"1025","Blomfield, Paul","fee",13.4418102522088
+"1026","Blomfield, Paul","damages",13.1609252258649
+"1027","Blomfield, Paul","awarded",12.9209984459326
+"1028","Blomfield, Paul","slavery",12.2059896334114
+"1029","Blomfield, Paul","brought",12.1967192797696
+"1030","Blomfield, Paul","tort",11.9141646770998
+"1031","Blomfield, Paul","victims",11.3029066339301
+"1032","Blomfield, Paul","last",11.1806110569904
+"1033","Blunkett, David","books",7.17616440513918
+"1034","Blunkett, David","withheld",4.85261405031394
+"1035","Blunkett, David","withhold",4.85261405031394
+"1036","Blunkett, David","first",3.90790130320735
+"1037","Blunkett, David","arrive",3.71872063128626
+"1038","Blunkett, David","borrowed",3.56953551699164
+"1039","Blunkett, David","reasons",3.31636656620144
+"1040","Blunkett, David","brixton",2.79013999771611
+"1041","Blunkett, David","belmarsh",2.47087153776466
+"1042","Blunkett, David","restrictions",2.42157481515729
+"1043","Blunkett, David","population",2.18711730856058
+"1044","Blunkett, David","yet",2.10527358991712
+"1045","Blunt, Crispin","1617",3.11386880460654
+"1046","Blunt, Crispin","102",2.72945893383498
+"1047","Blunt, Crispin","states",2.04857535311492
+"1048","Blunt, Crispin","oral",1.90119067942487
+"1049","Blunt, Crispin","directive",1.71168311292696
+"1050","Blunt, Crispin","agreement",1.61744218795443
+"1051","Blunt, Crispin","column",1.46914748789063
+"1052","Blunt, Crispin","transfer",1.45359359642075
+"1053","Blunt, Crispin","june",1.44458267072759
+"1054","Blunt, Crispin","member",1.26703039309374
+"1055","Blunt, Crispin","official",1.25303232874688
+"1056","Blunt, Crispin","2016",1.08900480346167
+"1057","Bone, Peter","wellingborough",19.8682007466212
+"1058","Bone, Peter","open",9.63091944235095
+"1059","Bone, Peter","planned",9.02848945002294
+"1060","Bone, Peter","hmp",7.30382798630018
+"1061","Bone, Peter","new",7.05733182190085
+"1062","Bone, Peter","prison",5.86588296683545
+"1063","Bone, Peter","site",5.47226307191551
+"1064","Bone, Peter","completed",5.32393401593973
+"1065","Bone, Peter","will",5.03004427360765
+"1066","Bone, Peter","victorian",4.53920480163004
+"1067","Bone, Peter","encroaching",4.05998820009529
+"1068","Bone, Peter","build",4.04569715772628
+"1069","Boswell, Phil","reconsideration",2.84390560599304
+"1070","Boswell, Phil","accepted",2.56655550788043
+"1071","Boswell, Phil","stage",2.38268209655663
+"1072","Boswell, Phil","mandatory",2.14983689102042
+"1073","Boswell, Phil","april",1.6986485561086
+"1074","Boswell, Phil","october",1.66926790481404
+"1075","Boswell, Phil","independence",1.61939452239718
+"1076","Boswell, Phil","decisions",1.5922053145699
+"1077","Boswell, Phil","payment",1.45924458028842
+"1078","Boswell, Phil","appealed",1.4175057129059
+"1079","Boswell, Phil","personal",1.24655392044434
+"1080","Boswell, Phil","2016",1.24532463649395
+"1081","Bottomley, Sir Peter","mire",16.5624682401073
+"1082","Bottomley, Sir Peter","benjamin",15.4946094860085
+"1083","Bottomley, Sir Peter","judicial",11.2418330898913
+"1084","Bottomley, Sir Peter","conduct",8.27147311987897
+"1085","Bottomley, Sir Peter","investigation",8.27147311987897
+"1086","Bottomley, Sir Peter","office",5.50545604846099
+"1087","Bottomley, Sir Peter","property",4.78733684180741
+"1088","Bottomley, Sir Peter","appointment",4.10079273323634
+"1089","Bottomley, Sir Peter","shown",3.97883593553688
+"1090","Bottomley, Sir Peter","report",3.89146265166767
+"1091","Bottomley, Sir Peter","councillor",3.70624520066165
+"1092","Bottomley, Sir Peter","gurpai",3.70624520066165
+"1093","Brabin, Tracy","code",5.28773162976317
+"1094","Brabin, Tracy","seconded",4.33444249213312
+"1095","Brabin, Tracy","exit",3.62528254494361
+"1096","Brabin, Tracy","crime",3.59709831948395
+"1097","Brabin, Tracy","takes",3.54507180166424
+"1098","Brabin, Tracy","organisations",3.30499564760634
+"1099","Brabin, Tracy","trade",3.12499123925695
+"1100","Brabin, Tracy","victims",2.95565904413393
+"1101","Brabin, Tracy","aware",2.94601228533978
+"1102","Brabin, Tracy","existence",2.92973383856673
+"1103","Brabin, Tracy","union",2.89735370030763
+"1104","Brabin, Tracy","committee",2.6090042421487
+"1105","Bradshaw, Ben","mediation",47.9555778453306
+"1106","Bradshaw, Ben","families",22.7880106115944
+"1107","Bradshaw, Ben","inform",11.9585409426596
+"1108","Bradshaw, Ben","television",11.8309813123795
+"1109","Bradshaw, Ben","221",10.6029345610171
+"1110","Bradshaw, Ben","4460",10.6029345610171
+"1111","Bradshaw, Ben","service",10.2234217826426
+"1112","Bradshaw, Ben","devon",9.96358101288937
+"1113","Bradshaw, Ben","profit",9.32399489687413
+"1114","Bradshaw, Ben","curfew",9.22141963330227
+"1115","Bradshaw, Ben","england",9.17826520305251
+"1116","Bradshaw, Ben","wales",9.14111874942897
+"1117","Brady, Graham","212354",6.12375755597282
+"1118","Brady, Graham","open",5.05979975963983
+"1119","Brady, Graham","offence",3.0229993622042
+"1120","Brady, Graham","serving",2.9964295061354
+"1121","Brady, Graham","recent",2.71164293559315
+"1122","Brady, Graham","broken",2.59147193149936
+"1123","Brady, Graham","robbery",2.50674431074999
+"1124","Brady, Graham","specific",2.3871558688598
+"1125","Brady, Graham","indeterminate",2.16722124606656
+"1126","Brady, Graham","serious",2.06081900172997
+"1127","Brady, Graham","imprisoned",2.03316082283189
+"1128","Brady, Graham","answer",2.02763652332552
+"1129","Brake, Tom","referendum",6.89047330488818
+"1130","Brake, Tom","pool",5.29447678014953
+"1131","Brake, Tom","outcome",5.11489688129469
+"1132","Brake, Tom","redeployment",4.84726318464957
+"1133","Brake, Tom","states",4.4542586817685
+"1134","Brake, Tom","civil",4.22116924470442
+"1135","Brake, Tom","servants",3.80886537284263
+"1136","Brake, Tom","legislation",3.64884770845245
+"1137","Brake, Tom","exceeded",3.54507180166424
+"1138","Brake, Tom","potential",3.48414520892191
+"1139","Brake, Tom","pan",3.20970249642714
+"1140","Brake, Tom","commission",3.09491617872276
+"1141","Brennan, Kevin","blind",8.58017357177562
+"1142","Brennan, Kevin","guide",7.64819549388882
+"1143","Brennan, Kevin","taxi",7.05533087540506
+"1144","Brennan, Kevin","licensed",6.96728857961507
+"1145","Brennan, Kevin","dogs",6.33972261326193
+"1146","Brennan, Kevin","occupancy",4.09532438060057
+"1147","Brennan, Kevin","guitars",3.87104686156941
+"1148","Brennan, Kevin","strung",3.87104686156941
+"1149","Brennan, Kevin","readmission",3.70624520066165
+"1150","Brennan, Kevin","equality",3.4900652320087
+"1151","Brennan, Kevin","steel",3.39316268687164
+"1152","Brennan, Kevin","balance",3.26802417241388
+"1153","Bridgen, Andrew","gastric",6.12375755597282
+"1154","Bridgen, Andrew","holiday",6.12375755597282
+"1155","Bridgen, Andrew","customers",4.44373053672746
+"1156","Bridgen, Andrew","illegitimate",4.40545290406761
+"1157","Bridgen, Andrew","package",4.2096635117451
+"1158","Bridgen, Andrew","declined",3.24255128325494
+"1159","Bridgen, Andrew","illegitimate",3.16405505954568
+"1160","Bridgen, Andrew","molestation",3.00950229978049
+"1161","Bridgen, Andrew","non",2.69366325889348
+"1162","Bridgen, Andrew","claims",2.56680186016078
+"1163","Bridgen, Andrew","handling",2.50674431074999
+"1164","Bridgen, Andrew","fraudulent",2.50674431074999
+"1165","Brock, Deidre ","media",5.52827151497833
+"1166","Brock, Deidre ","leaves",4.40069213251375
+"1167","Brock, Deidre ","portfolio",3.87104686156941
+"1168","Brock, Deidre ","schengen",3.87104686156941
+"1169","Brock, Deidre ","advertising",3.23090179259524
+"1170","Brock, Deidre ","partners",3.09165134229387
+"1171","Brock, Deidre ","month",2.70885897105104
+"1172","Brock, Deidre ","matters",2.61293666190285
+"1173","Brock, Deidre ","continue",2.54671332961504
+"1174","Brock, Deidre ","departmental",2.52375972265384
+"1175","Brock, Deidre ","covered",2.47087153776466
+"1176","Brock, Deidre ","engagements",2.46481071682209
+"1177","Brooke, Annette","guidelines",3.09896479241428
+"1178","Brooke, Annette","violence",2.36556037167411
+"1179","Brooke, Annette","domestic",2.35232435883189
+"1180","Brooke, Annette","review",1.8135226806377
+"1181","Brooke, Annette","sentencing",1.42662939826079
+"1182","Brooke, Annette","will",1.10249009757759
+"1183","Brooke, Annette","2010",0
+"1184","Brooke, Annette","accommod",0
+"1185","Brooke, Annette","cost",0
+"1186","Brooke, Annette","flight",0
+"1187","Brooke, Annette","hotel",0
+"1188","Brooke, Annette","intern",0
+"1189","Brown, Lyn","red",4.27960332856952
+"1190","Brown, Lyn","box",3.7512824949958
+"1191","Brown, Lyn","ict",3.61293666190285
+"1192","Brown, Lyn","gateway",3.61293666190285
+"1193","Brown, Lyn","journeys",3.27960332856952
+"1194","Brown, Lyn","transportation",2.88962832808875
+"1195","Brown, Lyn","car",2.83896063027373
+"1196","Brown, Lyn","ministers",2.32694299686033
+"1197","Brown, Lyn","progress",2.09474037801031
+"1198","Brown, Lyn","made",1.90292768460495
+"1199","Brown, Lyn","management",1.86999709840423
+"1200","Brown, Lyn","system",1.86680174879449
+"1201","Brown, Nicholas","organisations",7.03865714244267
+"1202","Brown, Nicholas","subscriptions",7.01097001691508
+"1203","Brown, Nicholas","rehabilitation",6.49221452190422
+"1204","Brown, Nicholas","probation",4.89598500831734
+"1205","Brown, Nicholas","transforming",4.63952317974655
+"1206","Brown, Nicholas","agencies",4.24534202507046
+"1207","Brown, Nicholas","publish",4.19241235771201
+"1208","Brown, Nicholas","rights",4.16961058677609
+"1209","Brown, Nicholas","report",3.97081304660789
+"1210","Brown, Nicholas","northumbria",3.83209802044349
+"1211","Brown, Nicholas","payroll",3.65449501766502
+"1212","Brown, Nicholas","implement",3.63931684211102
+"1213","Bruce, Fiona","abortions",13.0268610516863
+"1214","Bruce, Fiona","1986",12.0170588030879
+"1215","Bruce, Fiona","1861",8.8108587304109
+"1216","Bruce, Fiona","act",7.88269182404834
+"1217","Bruce, Fiona","section",7.55251490516088
+"1218","Bruce, Fiona","performing",7.12918032048756
+"1219","Bruce, Fiona","vulnerable",6.04932997507678
+"1220","Bruce, Fiona","offence",5.91889928836884
+"1221","Bruce, Fiona","people",5.83287379275022
+"1222","Bruce, Fiona","1929",5.75013677045165
+"1223","Bruce, Fiona","miscarriage",5.55828821636555
+"1224","Bruce, Fiona","preservation",5.46601916160477
+"1225","Bryant, Chris","waive",4.25355453398948
+"1226","Bryant, Chris","universal",2.50786376591274
+"1227","Bryant, Chris","local",2.29448082877032
+"1228","Bryant, Chris","fully",2.23297984752501
+"1229","Bryant, Chris","authorities",2.21979506406568
+"1230","Bryant, Chris","rolled",2.18783678611456
+"1231","Bryant, Chris","age",2.18188337320637
+"1232","Bryant, Chris","extending",2.03459256689187
+"1233","Bryant, Chris","credit",1.98297984752501
+"1234","Bryant, Chris","remission",1.98297984752501
+"1235","Bryant, Chris","fees",1.98011699800062
+"1236","Bryant, Chris","claimants",1.89772061806624
+"1237","Buck, Karen","authorities",8.05875527509829
+"1238","Buck, Karen","judicial",7.53766483450219
+"1239","Buck, Karen","local",6.57745617487274
+"1240","Buck, Karen","2004",6.20248040424858
+"1241","Buck, Karen","review",4.69068606736952
+"1242","Buck, Karen","successful",4.62284301074394
+"1243","Buck, Karen","applications",4.41690036147699
+"1244","Buck, Karen","england",4.30181974690094
+"1245","Buck, Karen","five",3.92794490105935
+"1246","Buck, Karen","mortgage",3.74376043407845
+"1247","Buck, Karen","children",3.72567973001352
+"1248","Buck, Karen","landlord",3.24255128325494
+"1249","Buckland, Robert","injury",4.5290734797705
+"1250","Buckland, Robert","fraud",3.97508763510816
+"1251","Buckland, Robert","12th",3.70624520066165
+"1252","Buckland, Robert","personal",3.62229239001705
+"1253","Buckland, Robert","genuine",3.16405505954568
+"1254","Buckland, Robert","elements",3.00771725513075
+"1255","Buckland, Robert","discourage",2.81075491518716
+"1256","Buckland, Robert","adopt",2.74728716075575
+"1257","Buckland, Robert","exaggerating",2.68101913850003
+"1258","Buckland, Robert","proposal",2.58558192853496
+"1259","Buckland, Robert","treated",2.56346187124685
+"1260","Buckland, Robert","fabricating",2.54349367327473
+"1261","Burden, Richard","week",12.3099021247723
+"1262","Burden, Richard","hours",12.1155053965526
+"1263","Burden, Richard","per",11.8890488847818
+"1264","Burden, Richard","unemployed",10.8129884046653
+"1265","Burden, Richard","classed",10.0189004219312
+"1266","Burden, Richard","proportion",9.82114649548114
+"1267","Burden, Richard","work",9.2891715751534
+"1268","Burden, Richard","cells",8.78715780330809
+"1269","Burden, Richard","spent",8.54512130151281
+"1270","Burden, Richard","drone",7.50747461886003
+"1271","Burden, Richard","last",7.20530510101787
+"1272","Burden, Richard","anti",7.18513808192397
+"1273","Burgon, Richard","prison",27.5730220308856
+"1274","Burgon, Richard","2010",22.9605930692771
+"1275","Burgon, Richard","since",20.7177543312347
+"1276","Burgon, Richard","officer",17.8026384216461
+"1277","Burgon, Richard","2016",17.2665159255683
+"1278","Burgon, Richard","year",16.1104880744591
+"1279","Burgon, Richard","plan",14.5457681610884
+"1280","Burgon, Richard","bedford",14.3609597960366
+"1281","Burgon, Richard","cell",14.237541107667
+"1282","Burgon, Richard","establishment",13.5562354061313
+"1283","Burgon, Richard","incident",13.28454981074
+"1284","Burgon, Richard","service",13.1073697038179
+"1285","Burley, Aidan","growth",5.6269237424937
+"1286","Burley, Aidan","culture",4.6269237424937
+"1287","Burley, Aidan","address",3.87567357222911
+"1288","Burley, Aidan","compensation",2.98422263306258
+"1289","Burley, Aidan","2010",0
+"1290","Burley, Aidan","accommod",0
+"1291","Burley, Aidan","cost",0
+"1292","Burley, Aidan","flight",0
+"1293","Burley, Aidan","hotel",0
+"1294","Burley, Aidan","intern",0
+"1295","Burley, Aidan","made",0
+"1296","Burley, Aidan","oversea",0
+"1297","Burnham, Andy","tenants",3.97883593553688
+"1298","Burnham, Andy","evicted",3.54665495033786
+"1299","Burnham, Andy","manchester",2.93988413450734
+"1300","Burnham, Andy","greater",2.91817576375706
+"1301","Burnham, Andy","2010",1.20429763083465
+"1302","Burnham, Andy","courts",1.00566725724105
+"1303","Burnham, Andy","since",0.978405135115604
+"1304","Burnham, Andy","year",0.659416890428306
+"1305","Burnham, Andy","accommod",0
+"1306","Burnham, Andy","cost",0
+"1307","Burnham, Andy","flight",0
+"1308","Burnham, Andy","hotel",0
+"1309","Burns, Sir Simon","wildlife",3.24870593743824
+"1310","Burns, Sir Simon","chelmsford",3.17229396360707
+"1311","Burns, Sir Simon","00156",3.11386880460654
+"1312","Burns, Sir Simon","sc133/14/00156",3.11386880460654
+"1313","Burns, Sir Simon","ref",2.87133317957021
+"1314","Burns, Sir Simon","recent",2.75781423397039
+"1315","Burns, Sir Simon","trade",2.55154466228239
+"1316","Burns, Sir Simon","illegal",2.26286952768758
+"1317","Burns, Sir Simon","inspectorate",2.25044904815274
+"1318","Burns, Sir Simon","ely",2.16630865205206
+"1319","Burns, Sir Simon","concerning",2.13981749225093
+"1320","Burns, Sir Simon","send",2.06564727275094
+"1321","Burrowes, David","141a",13.2400539238583
+"1322","Burrowes, David","sentence",10.1720837559056
+"1323","Burrowes, David","custodial",9.70806633563314
+"1324","Burrowes, David","knives",9.14508253562604
+"1325","Burrowes, David","criminal",9.09313937768897
+"1326","Burrowes, David","section",9.00429214244862
+"1327","Burrowes, David","implementation",8.21748169969175
+"1328","Burrowes, David","length",7.70466592377708
+"1329","Burrowes, David","1998",7.31293506175139
+"1330","Burrowes, David","suppliers",7.11143426443197
+"1331","Burrowes, David","convicted",7.07457788356101
+"1332","Burrowes, David","act",7.01942850126614
+"1333","Burstow, Paul","stigma",3.87104686156941
+"1334","Burstow, Paul","pledge",3.39316268687164
+"1335","Burstow, Paul","signing",2.3915636803915
+"1336","Burstow, Paul","discrimination",2.35010480806148
+"1337","Burstow, Paul","mental",1.91367950569373
+"1338","Burstow, Paul","health",1.8722206333637
+"1339","Burstow, Paul","reduce",1.73730667557372
+"1340","Burstow, Paul","change",1.67163595138624
+"1341","Burstow, Paul","result",1.66612968898181
+"1342","Burstow, Paul","taken",1.48884588696531
+"1343","Burstow, Paul","time",1.34456922338792
+"1344","Burstow, Paul","2010",0
+"1345","Butler, Dawn","equal",11.1196052369539
+"1346","Butler, Dawn","tribunal",9.64745174146944
+"1347","Butler, Dawn","pay",8.76928910268576
+"1348","Butler, Dawn","fees",8.29408018159106
+"1349","Butler, Dawn","employers",7.88569727546904
+"1350","Butler, Dawn","men",7.14440536324629
+"1351","Butler, Dawn","answer",6.78209684151368
+"1352","Butler, Dawn","2016",6.64599573933845
+"1353","Butler, Dawn","51088",6.01647009066469
+"1354","Butler, Dawn","women",5.9296172030126
+"1355","Butler, Dawn","33501",5.91940499285428
+"1356","Butler, Dawn","brought",5.595213630508
+"1357","Byles, Dan","seat",2.41658696889602
+"1358","Byles, Dan","contributory",2.41658696889602
+"1359","Byles, Dan","faulty",2.41658696889602
+"1360","Byles, Dan","incorrectly",2.41658696889602
+"1361","Byles, Dan","passenger",2.29718199844358
+"1362","Byles, Dan","factor",2.09305785321164
+"1363","Byles, Dan","fitted",1.94262538123713
+"1364","Byles, Dan","accident",1.78636125549044
+"1365","Byles, Dan","traffic",1.78636125549044
+"1366","Byles, Dan","car",1.73850123600519
+"1367","Byles, Dan","inquest",1.68480956274778
+"1368","Byles, Dan","road",1.61909626555275
+"1369","Byrne, Liam","birmingham",17.2588683216385
+"1370","Byrne, Liam","human",11.863095062833
+"1371","Byrne, Liam","rights",10.4665751109143
+"1372","Byrne, Liam","hodge",9.03470388524403
+"1373","Byrne, Liam","european",8.45312692287722
+"1374","Byrne, Liam","signatory",8.15314304615893
+"1375","Byrne, Liam","mortem",7.83002144166192
+"1376","Byrne, Liam","hill",7.76227977585976
+"1377","Byrne, Liam","convention",7.16440955774518
+"1378","Byrne, Liam","city",6.25743679260461
+"1379","Byrne, Liam","midlands",6.15665931631536
+"1380","Byrne, Liam","remaining",5.37021153744439
+"1381","Cadbury, Ruth","hardship",6.13503994443228
+"1382","Cadbury, Ruth","avoidable",5.80682255042869
+"1383","Cadbury, Ruth","exceptional",4.63855062937006
+"1384","Cadbury, Ruth","legislation",4.25603274439022
+"1385","Cadbury, Ruth","enterprise",3.99447578516243
+"1386","Cadbury, Ruth","joint",3.8768432227893
+"1387","Cadbury, Ruth","unsafe",3.56953551699164
+"1388","Cadbury, Ruth","within",3.47447245914423
+"1389","Cadbury, Ruth","review",3.26896874677954
+"1390","Cadbury, Ruth","forthcoming",3.12889493147202
+"1391","Cadbury, Ruth","disqualification",3.00614501296026
+"1392","Cadbury, Ruth","pleading",2.67135566824861
+"1393","Cameron, Dr Lisa","childhood",6.01229002592051
+"1394","Cameron, Dr Lisa","agreed",4.72431605606562
+"1395","Cameron, Dr Lisa","complainants",4.72431605606562
+"1396","Cameron, Dr Lisa","special",4.18987677043882
+"1397","Cameron, Dr Lisa","measures",3.95965538814802
+"1398","Cameron, Dr Lisa","applied",3.68819352096048
+"1399","Cameron, Dr Lisa","military",3.41757006606683
+"1400","Cameron, Dr Lisa","abuse",3.32449574385427
+"1401","Cameron, Dr Lisa","domestic",3.19617941803711
+"1402","Cameron, Dr Lisa","five",3.13724567509596
+"1403","Cameron, Dr Lisa","combat",3.12889493147202
+"1404","Cameron, Dr Lisa","dependencies",2.91711571481941
+"1405","Campbell, Gregory","campaign",8.05039544737695
+"1406","Campbell, Gregory","nspccs",6.11353518847511
+"1407","Campbell, Gregory","population",5.98026522347026
+"1408","Campbell, Gregory","treats",5.29506407252094
+"1409","Campbell, Gregory","10000",5.09797432589595
+"1410","Campbell, Gregory","change",4.82317391375595
+"1411","Campbell, Gregory","way",4.17451962010691
+"1412","Campbell, Gregory","reoffending",4.12351595460503
+"1413","Campbell, Gregory","rays",4.05998820009529
+"1414","Campbell, Gregory","transmission",4.05998820009529
+"1415","Campbell, Gregory","seeking",4.04794407049782
+"1416","Campbell, Gregory","television",4.00695191588376
+"1417","Campbell, Ronnie","northumberland",2.69327453376365
+"1418","Campbell, Ronnie","stalking",2.53976909264296
+"1419","Campbell, Ronnie","harassment",2.50829314895698
+"1420","Campbell, Ronnie","two",2.09026278067585
+"1421","Campbell, Ronnie","received",1.38100927262788
+"1422","Campbell, Ronnie","sentences",1.10506238013479
+"1423","Campbell, Ronnie","people",1.10017550615748
+"1424","Campbell, Ronnie","last",0.768585338205803
+"1425","Campbell, Ronnie","years",0.589800397003689
+"1426","Campbell, Ronnie","prison",0.566365330363054
+"1427","Campbell, Ronnie","2010",0
+"1428","Campbell, Ronnie","accommod",0
+"1429","Carmichael, Alistair","legal",6.33641617711404
+"1430","Carmichael, Alistair","review",5.6151653432762
+"1431","Carmichael, Alistair","will",4.92257464747959
+"1432","Carmichael, Alistair","recognition",4.88993240672096
+"1433","Carmichael, Alistair","aid",4.85582494395137
+"1434","Carmichael, Alistair","obtaining",4.84385557045852
+"1435","Carmichael, Alistair","punishment",4.83143942223843
+"1436","Carmichael, Alistair","civil",4.653388770486
+"1437","Carmichael, Alistair","introduced",4.34438063165724
+"1438","Carmichael, Alistair","effect",4.27693035375809
+"1439","Carmichael, Alistair","gender",3.95823654886345
+"1440","Carmichael, Alistair","reforms",3.87543069637066
+"1441","Carmichael, Neil","drug",3.52030262199161
+"1442","Carmichael, Neil","reduction",3.39468579288825
+"1443","Carmichael, Neil","need",2.92566427961214
+"1444","Carmichael, Neil","use",2.76805729104425
+"1445","Carmichael, Neil","reoffending",2.70642350702279
+"1446","Carmichael, Neil","education",2.52321877287561
+"1447","Carmichael, Neil","receive",1.78287530461526
+"1448","Carmichael, Neil","prisoners",1.76521138821749
+"1449","Carmichael, Neil","2010",0
+"1450","Carmichael, Neil","accommod",0
+"1451","Carmichael, Neil","cost",0
+"1452","Carmichael, Neil","flight",0
+"1453","Carswell, Douglas","2014",7.07979545774534
+"1454","Carswell, Douglas","emergency",6.89873522463511
+"1455","Carswell, Douglas","2015",6.3628286112595
+"1456","Carswell, Douglas","order",6.08369965595404
+"1457","Carswell, Douglas","local",5.89320258360083
+"1458","Carswell, Douglas","authorities",5.70137777687474
+"1459","Carswell, Douglas","president",5.45387601607715
+"1460","Carswell, Douglas","march",5.35564279999083
+"1461","Carswell, Douglas","2011",5.25435553447196
+"1462","Carswell, Douglas","reasons",5.24623649649151
+"1463","Carswell, Douglas","england",5.04367731203359
+"1464","Carswell, Douglas","january",4.90963875474623
+"1465","Caulfield, Maria","modernise",5.2584409454106
+"1466","Caulfield, Maria","estate",3.03531283046582
+"1467","Caulfield, Maria","will",1.35026909276817
+"1468","Caulfield, Maria","prison",0.895502215850485
+"1469","Caulfield, Maria","2010",0
+"1470","Caulfield, Maria","accommod",0
+"1471","Caulfield, Maria","cost",0
+"1472","Caulfield, Maria","flight",0
+"1473","Caulfield, Maria","hotel",0
+"1474","Caulfield, Maria","intern",0
+"1475","Caulfield, Maria","made",0
+"1476","Caulfield, Maria","oversea",0
+"1477","Chalk, Alex","imprisoned",6.00486442815378
+"1478","Chalk, Alex","incentivise",5.91940499285428
+"1479","Chalk, Alex","tariff",5.34203094770625
+"1480","Chalk, Alex","subject",4.41506391327401
+"1481","Chalk, Alex","bring",3.8394007821618
+"1482","Chalk, Alex","recruit",3.65762401482577
+"1483","Chalk, Alex","psychiatric",3.56953551699164
+"1484","Chalk, Alex","arabia",3.45397930234433
+"1485","Chalk, Alex","sentence",3.44562206094913
+"1486","Chalk, Alex","cruelty",3.41846706944372
+"1487","Chalk, Alex","served",3.34690124936034
+"1488","Chalk, Alex","protection",3.29015091286318
+"1489","Champion, Sarah","traffickers",10.3634567770548
+"1490","Champion, Sarah","modern",10.3558035063214
+"1491","Champion, Sarah","slavery",9.94392574633206
+"1492","Champion, Sarah","remote",9.59073863679092
+"1493","Champion, Sarah","probation",9.32939234708609
+"1494","Champion, Sarah","force",8.1664949610942
+"1495","Champion, Sarah","england",7.25253132782854
+"1496","Champion, Sarah","wales",7.22317874183736
+"1497","Champion, Sarah","private",6.7054196943278
+"1498","Champion, Sarah","evidence",6.67569414036262
+"1499","Champion, Sarah","enable",6.57245417675845
+"1500","Champion, Sarah","compensate",6.10022137125047
+"1501","Chapman, Jenny","england",21.6912511983496
+"1502","Chapman, Jenny","wales",21.6034619441877
+"1503","Chapman, Jenny","officer",20.1617610538215
+"1504","Chapman, Jenny","prison",17.170216601561
+"1505","Chapman, Jenny","month",16.9058744782689
+"1506","Chapman, Jenny","2013",15.3903003707032
+"1507","Chapman, Jenny","institution",13.0235342315207
+"1508","Chapman, Jenny","young",11.9731103268814
+"1509","Chapman, Jenny","staff",11.1859899743027
+"1510","Chapman, Jenny","sick",10.0865686280384
+"1511","Chapman, Jenny","offender",10.0162512755364
+"1512","Chapman, Jenny","assault",9.94992551169166
+"1513","Chishti, Rehman","gypsies",10.3754724781212
+"1514","Chishti, Rehman","tobacco",9.61471121569576
+"1515","Chishti, Rehman","traveller",8.61137795997464
+"1516","Chishti, Rehman","install",8.00360916313189
+"1517","Chishti, Rehman","medway",6.48946744374147
+"1518","Chishti, Rehman","kent",6.36169236114788
+"1519","Chishti, Rehman","young",6.28980371450283
+"1520","Chishti, Rehman","selling",6.02370433586522
+"1521","Chishti, Rehman","illicit",5.86892205956251
+"1522","Chishti, Rehman","loops",5.74169037564949
+"1523","Chishti, Rehman","centre",5.54633675814262
+"1524","Chishti, Rehman","induction",5.03287359696938
+"1525","Chope, Christopher","european",7.40230103692566
+"1526","Chope, Christopher","human",6.84175661591861
+"1527","Chope, Christopher","convention",6.51721790162407
+"1528","Chope, Christopher","rights",6.03634710265956
+"1529","Chope, Christopher","accede",5.84720186826207
+"1530","Chope, Christopher","governments",4.43335076867741
+"1531","Chope, Christopher","foreign",4.3359077196182
+"1532","Chope, Christopher","par",4.27960332856952
+"1533","Chope, Christopher","england",4.26490028246611
+"1534","Chope, Christopher","wales",4.2476392950086
+"1535","Chope, Christopher","muslim",4.2232462814649
+"1536","Chope, Christopher","defendants",4.15121783028185
+"1537","Churchill, Jo","edmunds",4.62402710935925
+"1538","Churchill, Jo","suffolk",4.42554045332921
+"1539","Churchill, Jo","bury",4.00733619150154
+"1540","Churchill, Jo","allowance",2.94226746596752
+"1541","Churchill, Jo","successful",2.80320574234587
+"1542","Churchill, Jo","independence",2.79234014100363
+"1543","Churchill, Jo","decisions",2.7454574849441
+"1544","Churchill, Jo","payment",2.51619179929642
+"1545","Churchill, Jo","appealed",2.44422100205073
+"1546","Churchill, Jo","claims",2.3731565299332
+"1547","Churchill, Jo","support",2.3731565299332
+"1548","Churchill, Jo","taken",2.36151150369917
+"1549","Clark, Katy","hardship",6.53604834482776
+"1550","Clark, Katy","compensation",5.19424200856731
+"1551","Clark, Katy","injuries",4.8906836655671
+"1552","Clark, Katy","applications",4.8739426933962
+"1553","Clark, Katy","criminal",3.90764606711501
+"1554","Clark, Katy","authoritys",3.54156775172457
+"1555","Clark, Katy","successful",3.53463562067902
+"1556","Clark, Katy","aimed",3.24870593743824
+"1557","Clark, Katy","emotional",3.24870593743824
+"1558","Clark, Katy","fund",3.22433632223193
+"1559","Clark, Katy","2012",2.83607442524967
+"1560","Clark, Katy","proportion",2.37649102856808
+"1561","Clegg, Nick","cultivation",3.20970249642714
+"1562","Clegg, Nick","cannabis",2.81346187124685
+"1563","Clegg, Nick","mitigation",2.81346187124685
+"1564","Clegg, Nick","cited",2.6292204727053
+"1565","Clegg, Nick","medical",2.23297984752501
+"1566","Clegg, Nick","serious",1.6292204727053
+"1567","Clegg, Nick","purse",1.60735476239271
+"1568","Clegg, Nick","condition",1.60313630775162
+"1569","Clegg, Nick","records",1.49211131653129
+"1570","Clegg, Nick","prosecuted",1.35735476239271
+"1571","Clegg, Nick","cost",1.08975743041986
+"1572","Clegg, Nick","public",1.06346187124685
+"1573","Clwyd, Ann","macur",33.2114197343158
+"1574","Clwyd, Ann","lady",16.3033031106149
+"1575","Clwyd, Ann","review",12.8135987868281
+"1576","Clwyd, Ann","19906",11.1232811174043
+"1577","Clwyd, Ann","updated",10.6310857301553
+"1578","Clwyd, Ann","redactions",9.19548780837629
+"1579","Clwyd, Ann","gordon",9.19548780837629
+"1580","Clwyd, Ann","reinstated",8.92236872282965
+"1581","Clwyd, Ann","report",8.89450224459139
+"1582","Clwyd, Ann","consider",7.27925402582042
+"1583","Clwyd, Ann","publish",6.98358994821045
+"1584","Clwyd, Ann","angelsea",6.6263031112292
+"1585","Coaker, Vernon","nottinghamshire",15.6467993802609
+"1586","Coaker, Vernon","framework",12.0079742753743
+"1587","Coaker, Vernon","true",9.36376711231697
+"1588","Coaker, Vernon","vision",8.75057467277412
+"1589","Coaker, Vernon","portal",8.53171681797913
+"1590","Coaker, Vernon","northern",8.39573091366074
+"1591","Coaker, Vernon","ireland",8.31033543534859
+"1592","Coaker, Vernon","nottingham",8.18638474454292
+"1593","Coaker, Vernon","human",8.09047604666398
+"1594","Coaker, Vernon","police",7.77208899623637
+"1595","Coaker, Vernon","reform",7.71087114219179
+"1596","Coaker, Vernon","rights",7.13806766083853
+"1597","Coffey, Ann","intermediaries",30.5995766893318
+"1598","Coffey, Ann","registered",25.5694061042063
+"1599","Coffey, Ann","greater",17.1374717984402
+"1600","Coffey, Ann","sexual",16.968132977278
+"1601","Coffey, Ann","manchester",15.3050350544743
+"1602","Coffey, Ann","2014",14.9352621412938
+"1603","Coffey, Ann","2013",12.9333484082392
+"1604","Coffey, Ann","complete",12.8561063744801
+"1605","Coffey, Ann","prosecuted",11.9488856897872
+"1606","Coffey, Ann","requester",11.5765766589913
+"1607","Coffey, Ann","old",11.4738926040272
+"1608","Coffey, Ann","offence",10.7788420810538
+"1609","Coffey, Dr Thérèse","dissolved",4.85261405031394
+"1610","Coffey, Dr Thérèse","partnerships",3.65449501766502
+"1611","Coffey, Dr Thérèse","county",2.89856607164657
+"1612","Coffey, Dr Thérèse","can",2.81450963731489
+"1613","Coffey, Dr Thérèse","civil",2.23304156495661
+"1614","Coffey, Dr Thérèse","court",1.07510352048362
+"1615","Coffey, Dr Thérèse","will",1.02070749213754
+"1616","Coffey, Dr Thérèse","2010",0
+"1617","Coffey, Dr Thérèse","accommod",0
+"1618","Coffey, Dr Thérèse","cost",0
+"1619","Coffey, Dr Thérèse","flight",0
+"1620","Coffey, Dr Thérèse","hotel",0
+"1621","Colvile, Oliver","drugs",6.09734299930741
+"1622","Colvile, Oliver","combat",5.41940499285428
+"1623","Colvile, Oliver","supply",4.41940499285428
+"1624","Colvile, Oliver","clerks",4.05998820009529
+"1625","Colvile, Oliver","covenant",3.42753266806161
+"1626","Colvile, Oliver","armed",3.05756989844826
+"1627","Colvile, Oliver","level",2.93651285052324
+"1628","Colvile, Oliver","reduce",2.88099719432886
+"1629","Colvile, Oliver","accordance",2.79507713602794
+"1630","Colvile, Oliver","forces",1.94998204028951
+"1631","Colvile, Oliver","operate",1.90731356060929
+"1632","Colvile, Oliver","given",1.79583808229787
+"1633","Cooper, Julie","lancashire",11.8131913725571
+"1634","Cooper, Julie","burnley",9.76912635745424
+"1635","Cooper, Julie","reduction",4.72948512913235
+"1636","Cooper, Julie","sold",4.58566000146942
+"1637","Cooper, Julie","bargaining",3.87104686156941
+"1638","Cooper, Julie","sanctions",3.53905747505455
+"1639","Cooper, Julie","time",3.50606205640811
+"1640","Cooper, Julie","mothers",3.49762558797103
+"1641","Cooper, Julie","taken",3.33562768688759
+"1642","Cooper, Julie","court",3.28341415493658
+"1643","Cooper, Julie","benefit",2.87057950920898
+"1644","Cooper, Julie","buildings",2.86777740906451
+"1645","Cooper, Rosie","wigan",8.88389579728085
+"1646","Cooper, Rosie","skelmersdale",8.55626119049629
+"1647","Cooper, Rosie","decision",7.98531252946956
+"1648","Cooper, Rosie","lancashire",7.93887945982265
+"1649","Cooper, Rosie","court",6.94817794297208
+"1650","Cooper, Rosie","magistrates",6.42583313603384
+"1651","Cooper, Rosie","ombudsman",5.98718723684745
+"1652","Cooper, Rosie","statutory",5.79509113703716
+"1653","Cooper, Rosie","ormskirk",5.76514273592292
+"1654","Cooper, Rosie","reverse",5.26616575063567
+"1655","Cooper, Rosie","considered",5.10344590039418
+"1656","Cooper, Rosie","proposal",4.9224649687901
+"1657","Corbyn, Jeremy","victims",9.36683133740701
+"1658","Corbyn, Jeremy","will",5.93835253807969
+"1659","Corbyn, Jeremy","romanian",5.74169037564949
+"1660","Corbyn, Jeremy","give",5.47267385538646
+"1661","Corbyn, Jeremy","crown",5.30371929534432
+"1662","Corbyn, Jeremy","mandatory",5.16756476297215
+"1663","Corbyn, Jeremy","trials",4.7016723082282
+"1664","Corbyn, Jeremy","implement",4.40572666575625
+"1665","Corbyn, Jeremy","disappearances",4.27960332856952
+"1666","Corbyn, Jeremy","right",4.16573829596142
+"1667","Corbyn, Jeremy","transcripts",4.09668510429549
+"1668","Corbyn, Jeremy","born",4.03898949161165
+"1669","Costa, Alberto","glen",5.75597149657774
+"1670","Costa, Alberto","parva",5.75597149657774
+"1671","Costa, Alberto","redeveloped",3.94626999523619
+"1672","Costa, Alberto","improve",3.71202681900264
+"1673","Costa, Alberto","leicester",3.61293666190285
+"1674","Costa, Alberto","education",3.56837020943509
+"1675","Costa, Alberto","2020",2.74728716075575
+"1676","Costa, Alberto","ratio",2.60715650608644
+"1677","Costa, Alberto","accommodate",2.34381835455032
+"1678","Costa, Alberto","adequacy",2.33362741099141
+"1679","Costa, Alberto","complete",2.16631999427464
+"1680","Costa, Alberto","hmp",1.75243867974416
+"1681","Cowan, Ronnie","inverclyde",4.27960332856952
+"1682","Cowan, Ronnie","awards",2.11033844850329
+"1683","Cowan, Ronnie","successful",1.95384335406955
+"1684","Cowan, Ronnie","independence",1.94626999523619
+"1685","Cowan, Ronnie","payments",1.75379371922427
+"1686","Cowan, Ronnie","appeals",1.70362984371512
+"1687","Cowan, Ronnie","personal",1.49817135926425
+"1688","Cowan, Ronnie","2016",1.49669394382583
+"1689","Cowan, Ronnie","2015",1.24956585534809
+"1690","Cowan, Ronnie","2010",0
+"1691","Cowan, Ronnie","accommod",0
+"1692","Cowan, Ronnie","cost",0
+"1693","Cox, Geoffrey","constructor",3.02613653442003
+"1694","Cox, Geoffrey","plymouth",3.02613653442003
+"1695","Cox, Geoffrey","geoamey",2.554732013629
+"1696","Cox, Geoffrey","transport",2.0432757859003
+"1697","Cox, Geoffrey","deliver",1.97503842182798
+"1698","Cox, Geoffrey","failure",1.91823226800131
+"1699","Cox, Geoffrey","investigate",1.59634560046833
+"1700","Cox, Geoffrey","defendants",1.52352533034101
+"1701","Cox, Geoffrey","purse",1.51542860301384
+"1702","Cox, Geoffrey","october",1.41860493667682
+"1703","Cox, Geoffrey","crown",1.3385386762003
+"1704","Cox, Geoffrey","2016",1.05832243704008
+"1705","Coyle, Neil","psychiatric",4.83317393779203
+"1706","Coyle, Neil","british",3.10004859416251
+"1707","Coyle, Neil","bill",2.93909823455458
+"1708","Coyle, Neil","introduction",2.93909823455458
+"1709","Coyle, Neil","requested",2.8811920086528
+"1710","Coyle, Neil","assessments",2.64596249083546
+"1711","Coyle, Neil","judges",2.59113429973677
+"1712","Coyle, Neil","universal",2.43298522388647
+"1713","Coyle, Neil","rights",2.32648802161266
+"1714","Coyle, Neil","adjourned",2.24438768376232
+"1715","Coyle, Neil","proposals",2.14657651051519
+"1716","Coyle, Neil","sufficient",1.97384471962158
+"1717","Crausby, David","refusals",4.34352678615272
+"1718","Crausby, David","commissioners",4.34213474529967
+"1719","Crausby, David","review",4.04014017687767
+"1720","Crausby, David","devolution",3.5056272969404
+"1721","Crausby, David","police",3.43717340607689
+"1722","Crausby, David","crime",3.35627464850254
+"1723","Crausby, David","funding",3.32585246284041
+"1724","Crausby, David","fighting",3.24870593743824
+"1725","Crausby, David","external",3.20490464326134
+"1726","Crausby, David","repossession",3.12889493147202
+"1727","Crausby, David","motor",3.03560468063012
+"1728","Crausby, David","eviction",2.89583164068126
+"1729","Crausby, Sir David","capabl",5.70825498810889
+"1730","Crausby, Sir David","bolton",3.97883593553688
+"1731","Crausby, Sir David","repossessions",3.83209802044349
+"1732","Crausby, Sir David","five",3.43191008224232
+"1733","Crausby, Sir David","appeals",2.90827805883786
+"1734","Crausby, Sir David","work",2.52291520013879
+"1735","Crausby, Sir David","outcome",2.48216418764327
+"1736","Crausby, Sir David","resolved",2.36443663355857
+"1737","Crausby, Sir David","nine",2.36443663355857
+"1738","Crausby, Sir David","previous",2.22180768917454
+"1739","Crausby, Sir David","assessments",2.16041932703016
+"1740","Crausby, Sir David","financial",1.98004226355524
+"1741","Crawley, Angela","consent",2.79116667421482
+"1742","Crawley, Angela","scottish",2.50249153962001
+"1743","Crawley, Angela","repeal",2.47997415396931
+"1744","Crawley, Angela","parliament",2.31848137149163
+"1745","Crawley, Angela","seek",2.26286952768758
+"1746","Crawley, Angela","1998",2.07700425544466
+"1747","Crawley, Angela","human",1.7021138914064
+"1748","Crawley, Angela","legislative",1.66956059398892
+"1749","Crawley, Angela","rights",1.50174156047615
+"1750","Crawley, Angela","proposed",1.38560917943089
+"1751","Crawley, Angela","act",1.18573050419023
+"1752","Crawley, Angela","plans",1.01653986030767
+"1753","Creagh, Mary","wakefield",5.56901471172485
+"1754","Creagh, Mary","last",5.49126716330942
+"1755","Creagh, Mary","five",5.27403753466242
+"1756","Creagh, Mary","inmates",4.85825046413459
+"1757","Creagh, Mary","rejected",4.8364688107702
+"1758","Creagh, Mary","hall",4.6426125791966
+"1759","Creagh, Mary","granted",3.80134359206034
+"1760","Creagh, Mary","patients",3.7512824949958
+"1761","Creagh, Mary","year",3.59220853942696
+"1762","Creagh, Mary","received",3.43059829945492
+"1763","Creagh, Mary","force",3.42049477188119
+"1764","Creagh, Mary","applications",3.37900701185932
+"1765","Creasy, Stella","55a",3.20970249642714
+"1766","Creasy, Stella","parentage",3.20970249642714
+"1767","Creasy, Stella","1986",2.31346187124685
+"1768","Creasy, Stella","declaration",2.25786376591274
+"1769","Creasy, Stella","county",1.91722124606656
+"1770","Creasy, Stella","high",1.74520724764525
+"1771","Creasy, Stella","law",1.40010131159587
+"1772","Creasy, Stella","applications",1.40010131159587
+"1773","Creasy, Stella","section",1.3172385943444
+"1774","Creasy, Stella","family",1.28633075705231
+"1775","Creasy, Stella","magistrates",1.1549103663116
+"1776","Creasy, Stella","act",1.02687273867087
+"1777","Cunningham, Alex","substances",13.926855806442
+"1778","Cunningham, Alex","psychoactive",9.68550379778007
+"1779","Cunningham, Alex","families",7.93821254135813
+"1780","Cunningham, Alex","domestic",7.44911549868703
+"1781","Cunningham, Alex","new",7.30915891056006
+"1782","Cunningham, Alex","jail",6.68940788547058
+"1783","Cunningham, Alex","broken",6.59263420021929
+"1784","Cunningham, Alex","abuse",6.29457993573745
+"1785","Cunningham, Alex","involving",6.2857737545256
+"1786","Cunningham, Alex","detect",6.09247932333602
+"1787","Cunningham, Alex","illicit",5.93592983727004
+"1788","Cunningham, Alex","child",5.89508886545509
+"1789","Cunningham, Jim","made",22.9300508553837
+"1790","Cunningham, Jim","prison",21.0712936718719
+"1791","Cunningham, Jim","midlands",19.9031782529535
+"1792","Cunningham, Jim","will",17.7549094372267
+"1793","Cunningham, Jim","last",17.4965156032628
+"1794","Cunningham, Jim","year",16.6951060936094
+"1795","Cunningham, Jim","west",16.3900628974936
+"1796","Cunningham, Jim","england",15.6842954506442
+"1797","Cunningham, Jim","number",15.2167377278458
+"1798","Cunningham, Jim","claim",14.5387866632532
+"1799","Cunningham, Jim","five",14.3830628642806
+"1800","Cunningham, Jim","wales",13.2782476578663
+"1801","Cunningham, Sir Tony","cert",3.02613653442003
+"1802","Cunningham, Sir Tony","gary",3.02613653442003
+"1803","Cunningham, Sir Tony","jbirqk61bb77//e/1",3.02613653442003
+"1804","Cunningham, Sir Tony","owh0080",3.02613653442003
+"1805","Cunningham, Sir Tony","tomlinson",3.02613653442003
+"1806","Cunningham, Sir Tony","workington",3.02613653442003
+"1807","Cunningham, Sir Tony","withdrawn",2.18115276956689
+"1808","Cunningham, Sir Tony","constituent",1.5276471563495
+"1809","Cunningham, Sir Tony","hon",1.46016461274739
+"1810","Cunningham, Sir Tony","reasons",1.27377785596574
+"1811","Cunningham, Sir Tony","funding",1.26028982506398
+"1812","Cunningham, Sir Tony","member",1.23133221190609
+"1813","Curran, Margaret","scotland",2.67715168788365
+"1814","Curran, Margaret","processed",2.01915009072797
+"1815","Curran, Margaret","employment",1.42807371134364
+"1816","Curran, Margaret","tribunals",1.3783021374213
+"1817","Curran, Margaret","service",1.16483802593091
+"1818","Curran, Margaret","2010",1.13542269510677
+"1819","Curran, Margaret","courts",0.9481521829499
+"1820","Curran, Margaret","since",0.922449207717312
+"1821","Curran, Margaret","year",0.621704206467736
+"1822","Curran, Margaret","accommod",0
+"1823","Curran, Margaret","cost",0
+"1824","Curran, Margaret","flight",0
+"1825","Dakin, Nic","embed",5.74169037564949
+"1826","Dakin, Nic","component",5.6269237424937
+"1827","Dakin, Nic","nothing",5.6269237424937
+"1828","Dakin, Nic","independence",4.42697924860887
+"1829","Dakin, Nic","decision",4.35265143214859
+"1830","Dakin, Nic","enhanced",4.1269237424937
+"1831","Dakin, Nic","standard",4.04196124177255
+"1832","Dakin, Nic","payments",3.98917335228416
+"1833","Dakin, Nic","mobility",3.91940499285428
+"1834","Dakin, Nic","appeal",3.8750707681348
+"1835","Dakin, Nic","quarter",3.8146783100398
+"1836","Dakin, Nic","beef",3.70624520066165
+"1837","Danczuk, Simon","albany",2.67707694136014
+"1838","Danczuk, Simon","ashwell",2.67707694136014
+"1839","Danczuk, Simon","askham",2.67707694136014
+"1840","Danczuk, Simon","buckley",2.67707694136014
+"1841","Danczuk, Simon","grange",2.26004811324599
+"1842","Danczuk, Simon","ashfield",2.09170297473705
+"1843","Danczuk, Simon","hall",1.80758747302245
+"1844","Danczuk, Simon","unemployed",1.37827846184364
+"1845","Danczuk, Simon","classed",1.27705997140865
+"1846","Danczuk, Simon","week",1.23940805541367
+"1847","Danczuk, Simon","hours",1.21983544886819
+"1848","Danczuk, Simon","cells",1.21747604296062
+"1849","David, Wayne","spent",8.27034476050625
+"1850","David, Wayne","per",7.79170625047115
+"1851","David, Wayne","number",7.48780885856154
+"1852","David, Wayne","unemployed",7.3189536698724
+"1853","David, Wayne","classed",6.78146181859791
+"1854","David, Wayne","week",6.58152208480817
+"1855","David, Wayne","hours",6.47758735429412
+"1856","David, Wayne","cells",6.46505840386501
+"1857","David, Wayne","last",6.0896708519268
+"1858","David, Wayne","2011",5.99307412258105
+"1859","David, Wayne","christmas",5.51759593994307
+"1860","David, Wayne","2012",5.32079440534643
+"1861","Davidson, Ian","development",2.58633074391407
+"1862","Davidson, Ian","foreign",2.38696167399542
+"1863","Davidson, Ian","action",2.31697953590881
+"1864","Davidson, Ian","home",2.24968729053366
+"1865","Davidson, Ian","discussions",1.91659789407129
+"1866","Davidson, Ian","national",1.6779830752099
+"1867","Davidson, Ian","plan",1.24500198047693
+"1868","Davidson, Ian","offenders",1.226937577369
+"1869","Davidson, Ian","2010",0
+"1870","Davidson, Ian","accommod",0
+"1871","Davidson, Ian","cost",0
+"1872","Davidson, Ian","flight",0
+"1873","Davies, Byron","corruption",3.09165134229387
+"1874","Davies, Byron","corporate",2.86944785508927
+"1875","Davies, Byron","liability",2.72308615973505
+"1876","Davies, Byron","anti",2.72308615973505
+"1877","Davies, Byron","action",1.97592678734819
+"1878","Davies, Byron","expects",1.94369064045952
+"1879","Davies, Byron","introduced",1.89941629602469
+"1880","Davies, Byron","progress",1.89476396374566
+"1881","Davies, Byron","criminal",1.35381061027296
+"1882","Davies, Byron","plan",1.06174125640735
+"1883","Davies, Byron","made",0.860631427229232
+"1884","Davies, Byron","2010",0
+"1885","Davies, David T. C.","seekers",5.55828821636555
+"1886","Davies, David T. C.","wish",4.95454719354179
+"1887","Davies, David T. C.","gwent",4.83317393779203
+"1888","Davies, David T. C.","served",4.16057152962182
+"1889","Davies, David T. C.","spent",4.06304949611488
+"1890","Davies, David T. C.","five",3.88507444117334
+"1891","Davies, David T. C.","magistrates",3.77192146148563
+"1892","Davies, David T. C.","asylum",3.66106461507871
+"1893","Davies, David T. C.","last",3.39772642210709
+"1894","Davies, David T. C.","sufficient",3.32247574889635
+"1895","Davies, David T. C.","translators",3.31611102333525
+"1896","Davies, David T. C.","immigration",3.22765845663281
+"1897","Davies, Mims","vulnerable",6.68405599079222
+"1898","Davies, Mims","intimidated",6.36841585886313
+"1899","Davies, Mims","witness",4.10349033567494
+"1900","Davies, Mims","screens",3.87104686156941
+"1901","Davies, Mims","defines",2.97730646336668
+"1902","Davies, Mims","safeguard",2.59024852532215
+"1903","Davies, Mims","appropriate",2.52647763818148
+"1904","Davies, Mims","give",2.49375266036349
+"1905","Davies, Mims","participate",2.45381096204596
+"1906","Davies, Mims","adequacy",2.43739433747609
+"1907","Davies, Mims","special",2.27743813192595
+"1908","Davies, Mims","measure",2.1522996174682
+"1909","Davies, Philip","offence",219.318062802415
+"1910","Davies, Philip","sentence",195.62067826208
+"1911","Davies, Philip","prison",146.186596396649
+"1912","Davies, Philip","year",133.232197742803
+"1913","Davies, Philip","offender",128.580101526876
+"1914","Davies, Philip","last",123.226847498018
+"1915","Davies, Philip","release",122.279848721083
+"1916","Davies, Philip","proportion",117.738079531244
+"1917","Davies, Philip","convicted",114.654933440248
+"1918","Davies, Philip","commit",107.828123172416
+"1919","Davies, Philip","court",95.1530028414708
+"1920","Davies, Philip","serve",88.9295169349804
+"1921","Day, Martyn","visa",7.25963068850511
+"1922","Day, Martyn","appeals",6.65558785906293
+"1923","Day, Martyn","pension",6.23722890176632
+"1924","Day, Martyn","alpha",5.71919279725448
+"1925","Day, Martyn","scotland",5.07953818528592
+"1926","Day, Martyn","potential",4.72156100915629
+"1927","Day, Martyn","retirement",4.66382334047211
+"1928","Day, Martyn","carries",4.63160761831626
+"1929","Day, Martyn","officers",4.61877226333739
+"1930","Day, Martyn","age",4.47153030046231
+"1931","Day, Martyn","country",4.26186877443389
+"1932","Day, Martyn","manual",4.25355453398948
+"1933","de Bois, Nick","born",17.350605287057
+"1934","de Bois, Nick","blade",15.6693319370776
+"1935","de Bois, Nick","point",14.7305684874787
+"1936","de Bois, Nick","article",13.3648873802938
+"1937","de Bois, Nick","offensive",11.744549586749
+"1938","de Bois, Nick","self",10.5572413298367
+"1939","de Bois, Nick","weapon",10.345240620196
+"1940","de Bois, Nick","inception",9.80755667752211
+"1941","de Bois, Nick","threatening",9.24805421871849
+"1942","de Bois, Nick","certificated",8.57395010423732
+"1943","de Bois, Nick","aged",8.40782797024379
+"1944","de Bois, Nick","economy",8.27245555145204
+"1945","De Piero, Gloria","ashfield",15.7128336551831
+"1946","De Piero, Gloria","constituency",12.312379126184
+"1947","De Piero, Gloria","nottinghamshire",12.0876114300958
+"1948","De Piero, Gloria","last",8.54904127331108
+"1949","De Piero, Gloria","five",8.43395891121216
+"1950","De Piero, Gloria","tribunal",7.8082656794567
+"1951","De Piero, Gloria","year",7.77190549372319
+"1952","De Piero, Gloria","pay",7.58067486759087
+"1953","De Piero, Gloria","discrimination",6.87822540023171
+"1954","De Piero, Gloria","men",6.46198170307233
+"1955","De Piero, Gloria","convicted",6.25273419290266
+"1956","De Piero, Gloria","ethnic",5.7530686089247
+"1957","Debbonaire, Thangam","bristol",5.1269237424937
+"1958","Debbonaire, Thangam","synnex",4.59436399688715
+"1959","Debbonaire, Thangam","private",4.53788951511477
+"1960","Debbonaire, Thangam","concentrix",4.42492564732817
+"1961","Debbonaire, Thangam","plans",4.13943617800461
+"1962","Debbonaire, Thangam","genital",4.08680342436876
+"1963","Debbonaire, Thangam","mutilation",4.08680342436876
+"1964","Debbonaire, Thangam","representation",3.83970968107261
+"1965","Debbonaire, Thangam","intimate",3.43131630145811
+"1966","Debbonaire, Thangam","regardless",3.39316268687164
+"1967","Debbonaire, Thangam","money",3.34572028058623
+"1968","Debbonaire, Thangam","monitoring",3.24818549820487
+"1969","Djanogly, Jonathan","merger",5.23436696999368
+"1970","Djanogly, Jonathan","peterborough",5.0413255607839
+"1971","Djanogly, Jonathan","cambridgeshire",4.76924897572761
+"1972","Djanogly, Jonathan","marital",4.27960332856952
+"1973","Djanogly, Jonathan","east",3.71202717267959
+"1974","Djanogly, Jonathan","south",3.68927843740354
+"1975","Djanogly, Jonathan","law",3.3635730101558
+"1976","Djanogly, Jonathan","coroner",3.27045627597739
+"1977","Djanogly, Jonathan","matrimonial",3.16405505954568
+"1978","Djanogly, Jonathan","plan",3.09159206547613
+"1979","Djanogly, Jonathan","north",2.97483259335722
+"1980","Djanogly, Jonathan","west",2.93733549684433
+"1981","Dobbin, Jim","prescription",5.74169037564949
+"1982","Dobbin, Jim","tranquilisers",5.74169037564949
+"1983","Dobbin, Jim","danny",4.53920480163004
+"1984","Dobbin, Jim","fitzsimons",4.53920480163004
+"1985","Dobbin, Jim","illicit",4.08680342436876
+"1986","Dobbin, Jim","trade",3.95283599364966
+"1987","Dobbin, Jim","iraq",3.83209802044349
+"1988","Dobbin, Jim","achieve",3.27172915435034
+"1989","Dobbin, Jim","regard",2.58633074391407
+"1990","Dobbin, Jim","agreement",2.3578068976639
+"1991","Dobbin, Jim","transfer",2.11895858384614
+"1992","Dobbin, Jim","prisoner",1.43417722085281
+"1993","Dobson, Frank","coroners",2.87057950920898
+"1994","Dobson, Frank","progress",2.565522534865
+"1995","Dobson, Frank","implementation",2.51741598914827
+"1996","Dobson, Frank","hour",2.38830365229018
+"1997","Dobson, Frank","system",2.28635586774091
+"1998","Dobson, Frank","made",1.16530046117449
+"1999","Dobson, Frank","2010",0
+"2000","Dobson, Frank","accommod",0
+"2001","Dobson, Frank","cost",0
+"2002","Dobson, Frank","flight",0
+"2003","Dobson, Frank","hotel",0
+"2004","Dobson, Frank","intern",0
+"2005","Docherty-Hughes, Martin","charter",4.29349905293811
+"2006","Docherty-Hughes, Martin","fundamental",4.29349905293811
+"2007","Docherty-Hughes, Martin","party",3.04001785876796
+"2008","Docherty-Hughes, Martin","remaining",3.02615891854445
+"2009","Docherty-Hughes, Martin","governments",2.81063176345421
+"2010","Docherty-Hughes, Martin","rights",2.1237832820047
+"2011","Docherty-Hughes, Martin","2010",0
+"2012","Docherty-Hughes, Martin","accommod",0
+"2013","Docherty-Hughes, Martin","cost",0
+"2014","Docherty-Hughes, Martin","flight",0
+"2015","Docherty-Hughes, Martin","hotel",0
+"2016","Docherty-Hughes, Martin","intern",0
+"2017","Dodds, Nigel","topics",3.94626999523619
+"2018","Dodds, Nigel","correspondence",3.12645945569042
+"2019","Dodds, Nigel","europe",3.12645945569042
+"2020","Dodds, Nigel","message",3.00771725513075
+"2021","Dodds, Nigel","origin",2.94601228533978
+"2022","Dodds, Nigel","content",2.62953257572083
+"2023","Dodds, Nigel","arrangements",2.62001925922161
+"2024","Dodds, Nigel","return",2.51308027289728
+"2025","Dodds, Nigel","countries",2.40501687673049
+"2026","Dodds, Nigel","commissioner",2.32694299686033
+"2027","Dodds, Nigel","prohibit",2.31685696689096
+"2028","Dodds, Nigel","sending",2.27623243136231
+"2029","Donaldson, Stuart Blair","band",3.50721308287814
+"2030","Donaldson, Stuart Blair","adviser",3.47700247201039
+"2031","Donaldson, Stuart Blair","name",3.25815979188913
+"2032","Donaldson, Stuart Blair","special",3.08366580799147
+"2033","Donaldson, Stuart Blair","pay",2.64596249083546
+"2034","Donaldson, Stuart Blair","affairs",2.40431610091321
+"2035","Donaldson, Stuart Blair","responsibilities",2.2522576006188
+"2036","Donaldson, Stuart Blair","missing",2.242076693946
+"2037","Donaldson, Stuart Blair","help",2.1999186210656
+"2038","Donaldson, Stuart Blair","forward",1.78320000420559
+"2039","Donaldson, Stuart Blair","bring",1.68368862266434
+"2040","Donaldson, Stuart Blair","legislative",1.60406193348702
+"2041","Donelan, Michelle","chippenham",3.56084520918548
+"2042","Donelan, Michelle","retrospectively",3.31496648398472
+"2043","Donelan, Michelle","wiltshire",3.28349511107287
+"2044","Donelan, Michelle","225",3.05676759423755
+"2045","Donelan, Michelle","abolition",3.05676759423755
+"2046","Donelan, Michelle","upheld",2.50487494800326
+"2047","Donelan, Michelle","initial",2.18679837643053
+"2048","Donelan, Michelle","2003",1.81551389074173
+"2049","Donelan, Michelle","constituency",1.79757753694861
+"2050","Donelan, Michelle","assessments",1.79757753694861
+"2051","Donelan, Michelle","applied",1.71676065515218
+"2052","Donelan, Michelle","imprisonment",1.66006886031844
+"2053","Dorries, Nadine","stalking",13.7442114321647
+"2054","Dorries, Nadine","attorney",12.0724969422781
+"2055","Dorries, Nadine","elderly",11.3177580296469
+"2056","Dorries, Nadine","power",9.84519898943613
+"2057","Dorries, Nadine","protect",8.87898538141419
+"2058","Dorries, Nadine","abuse",8.42222400552278
+"2059","Dorries, Nadine","vulnerable",7.87902760721171
+"2060","Dorries, Nadine","new",7.02527250317015
+"2061","Dorries, Nadine","people",5.93799038091018
+"2062","Dorries, Nadine","laws",5.60040524638348
+"2063","Dorries, Nadine","better",5.24973406365559
+"2064","Dorries, Nadine","training",4.93191939010004
+"2065","Doughty, Stephen","lessons",12.8503050897092
+"2066","Doughty, Stephen","car",11.319250450095
+"2067","Doughty, Stephen","tests",9.80746627388518
+"2068","Doughty, Stephen","drive",8.63735773887031
+"2069","Doughty, Stephen","abscond",7.7162495511777
+"2070","Doughty, Stephen","2013",6.55758672843436
+"2071","Doughty, Stephen","missing",6.11087100268113
+"2072","Doughty, Stephen","prison",5.63445513563307
+"2073","Doughty, Stephen","parking",5.59604540355695
+"2074","Doughty, Stephen","202937",4.53920480163004
+"2075","Doughty, Stephen","offence",4.46017513030911
+"2076","Doughty, Stephen","type",4.3017718280461
+"2077","Dowd, Jim","passed",2.1025134380271
+"2078","Dowd, Jim","maximum",1.79780629071224
+"2079","Dowd, Jim","fraud",1.78976214463722
+"2080","Dowd, Jim","forward",1.55936316780817
+"2081","Dowd, Jim","length",1.47556794221921
+"2082","Dowd, Jim","bring",1.47234298903566
+"2083","Dowd, Jim","legislative",1.4027114693044
+"2084","Dowd, Jim","increase",1.39748891050895
+"2085","Dowd, Jim","proposals",1.16414456292208
+"2086","Dowd, Jim","average",1.15237094944577
+"2087","Dowd, Jim","custodial",1.11230343573148
+"2088","Dowd, Jim","convictions",0.974661187024856
+"2089","Dowd, Peter","probate",12.3830754821841
+"2090","Dowd, Peter","registries",11.8959958917161
+"2091","Dowd, Peter","cafcass",9.00251380347396
+"2092","Dowd, Peter","fee",7.61706685653821
+"2093","Dowd, Peter","grant",6.17449990420698
+"2094","Dowd, Peter","proposals",5.73944965937654
+"2095","Dowd, Peter","liquid",5.70400598431232
+"2096","Dowd, Peter","expended",5.66176745359472
+"2097","Dowd, Peter","reflect",5.02957135680283
+"2098","Dowd, Peter","departments",4.88721426377332
+"2099","Dowd, Peter","filed",4.74039460931804
+"2100","Dowd, Peter","recent",4.65201878907493
+"2101","Dowden, Oliver","specialise",4.18565141103677
+"2102","Dowden, Oliver","belief",3.54665495033786
+"2103","Dowden, Oliver","religion",3.47854462985022
+"2104","Dowden, Oliver","characteristic",3.36472586037556
+"2105","Dowden, Oliver","judges",2.24398812818924
+"2106","Dowden, Oliver","protected",1.83925027434876
+"2107","Dowden, Oliver","train",1.74369682250258
+"2108","Dowden, Oliver","plans",1.24500198047693
+"2109","Dowden, Oliver","2010",0
+"2110","Dowden, Oliver","accommod",0
+"2111","Dowden, Oliver","cost",0
+"2112","Dowden, Oliver","flight",0
+"2113","Drax, Richard","marine",3.70624520066165
+"2114","Drax, Richard","sergeant",3.41757006606683
+"2115","Drax, Richard","expediting",3.24870593743824
+"2116","Drax, Richard","blackman",3.24870593743824
+"2117","Drax, Richard","alexander",3.12889493147202
+"2118","Drax, Richard","former",2.15965315462981
+"2119","Drax, Richard","investigations",1.95511608714211
+"2120","Drax, Richard","commission",1.90814012681606
+"2121","Drax, Richard","criminal",1.29617497704349
+"2122","Drax, Richard","review",1.28235418531452
+"2123","Drax, Richard","case",1.14116560411926
+"2124","Drax, Richard","will",0.779578224188134
+"2125","Drew, Dr David","stroud",3.56084520918548
+"2126","Drew, Dr David","district",2.27287123933059
+"2127","Drew, Dr David","allowance",1.70634363194117
+"2128","Drew, Dr David","successful",1.62569593784361
+"2129","Drew, Dr David","independence",1.61939452239718
+"2130","Drew, Dr David","payment",1.45924458028842
+"2131","Drew, Dr David","appeals",1.4175057129059
+"2132","Drew, Dr David","support",1.37629246127001
+"2133","Drew, Dr David","personal",1.24655392044434
+"2134","Drew, Dr David","employment",1.18822915185961
+"2135","Drew, Dr David","2010",0.944728787661453
+"2136","Drew, Dr David","since",0.7675241347929
+"2137","Dromey, Jack","unfairly",4.53920480163004
+"2138","Dromey, Jack","dangerous",4.25975132855612
+"2139","Dromey, Jack","people",4.17454569105242
+"2140","Dromey, Jack","citizenship",3.70624520066165
+"2141","Dromey, Jack","treated",3.62528254494361
+"2142","Dromey, Jack","release",3.52895949094715
+"2143","Dromey, Jack","mappa",3.43131630145811
+"2144","Dromey, Jack","press",3.39272736038399
+"2145","Dromey, Jack","drivers",3.32929977823252
+"2146","Dromey, Jack","marketing",3.31611102333525
+"2147","Dromey, Jack","knives",3.23090179259524
+"2148","Dromey, Jack","unlawful",3.06491367885045
+"2149","Drummond, Flick","electronic",3.8146783100398
+"2150","Drummond, Flick","monitoring",3.37567357222911
+"2151","Drummond, Flick","progress",3.14211056701546
+"2152","Drummond, Flick","made",1.42719576345371
+"2153","Drummond, Flick","2010",0
+"2154","Drummond, Flick","accommod",0
+"2155","Drummond, Flick","cost",0
+"2156","Drummond, Flick","flight",0
+"2157","Drummond, Flick","hotel",0
+"2158","Drummond, Flick","intern",0
+"2159","Drummond, Flick","oversea",0
+"2160","Drummond, Flick","sinc",0
+"2161","Duddridge, James","entrustment",4.18565141103677
+"2162","Duddridge, James","rwanda",4.18565141103677
+"2163","Duddridge, James","jersey",3.71827925096883
+"2164","Duddridge, James","facilitate",3.41846706944372
+"2165","Duddridge, James","trade",3.12499123925695
+"2166","Duddridge, James","agreement",2.3578068976639
+"2167","Duddridge, James","decision",2.02967149215951
+"2168","Duddridge, James","plans",1.24500198047693
+"2169","Duddridge, James","2010",0
+"2170","Duddridge, James","accommod",0
+"2171","Duddridge, James","cost",0
+"2172","Duddridge, James","flight",0
+"2173","Dugher, Michael","south",7.52487944687093
+"2174","Dugher, Michael","yorkshire",7.52487944687093
+"2175","Dugher, Michael","breathalysed",3.94626999523619
+"2176","Dugher, Michael","probation",3.17406095391772
+"2177","Dugher, Michael","influence",3.17229396360707
+"2178","Dugher, Michael","alcohol",2.71279008918916
+"2179","Dugher, Michael","staff",2.60643371994269
+"2180","Dugher, Michael","five",2.4162821405571
+"2181","Dugher, Michael","year",2.3911053974788
+"2182","Dugher, Michael","people",2.25986231461955
+"2183","Dugher, Michael","service",2.21012476026958
+"2184","Dugher, Michael","drive",2.16631999427464
+"2185","Eagle, Maria","remit",4.3865981390758
+"2186","Eagle, Maria","resources",3.90089587868028
+"2187","Eagle, Maria","engagement",3.78576540474892
+"2188","Eagle, Maria","process",3.59556839463329
+"2189","Eagle, Maria","independence",3.46578836037461
+"2190","Eagle, Maria","bodies",3.21989349534064
+"2191","Eagle, Maria","organisations",3.21048771327948
+"2192","Eagle, Maria","payments",3.12303938994237
+"2193","Eagle, Maria","adequately",3.05756989844826
+"2194","Eagle, Maria","unsuccessful",3.05756989844826
+"2195","Eagle, Maria","appeal",3.03371089169884
+"2196","Eagle, Maria","65647",3.02613653442003
+"2197","Edwards, Jonathan","carmarthen",5.83103567599735
+"2198","Edwards, Jonathan","guildhall)",5.83103567599735
+"2199","Edwards, Jonathan","election",5.80182737834049
+"2200","Edwards, Jonathan","general",5.28636873791987
+"2201","Edwards, Jonathan","capacity",4.6924944297891
+"2202","Edwards, Jonathan","visited",4.60144047612294
+"2203","Edwards, Jonathan","financial",4.52940273833707
+"2204","Edwards, Jonathan","probate",4.19486774545624
+"2205","Edwards, Jonathan","wales",3.91864029465555
+"2206","Edwards, Jonathan","2008",3.66766286881103
+"2207","Edwards, Jonathan","official",3.35588248885169
+"2208","Edwards, Jonathan","write",3.23090179259524
+"2209","Elliott, Tom","covers",4.09747689796692
+"2210","Elliott, Tom","future",3.41940499285428
+"2211","Elliott, Tom","bill",3.28601172250683
+"2212","Elliott, Tom","statutes",3.24870593743824
+"2213","Elliott, Tom","fully",3.15791038487567
+"2214","Elliott, Tom","consumers",2.63802026696727
+"2215","Elliott, Tom","rights",2.60109268258246
+"2216","Elliott, Tom","considered",2.54380030971435
+"2217","Elliott, Tom","passed",2.50249153962001
+"2218","Elliott, Tom","industry",2.33362741099141
+"2219","Elliott, Tom","defendant",2.28528799551152
+"2220","Elliott, Tom","mental",2.24398812818924
+"2221","Ellman, Louise","danish",3.87104686156941
+"2222","Ellman, Louise","diver",3.87104686156941
+"2223","Ellman, Louise","omalley",3.87104686156941
+"2224","Ellman, Louise","reopening",3.87104686156941
+"2225","Ellman, Louise","stephen",3.26802417241388
+"2226","Ellman, Louise","counterpart",3.02459750431282
+"2227","Ellman, Louise","commercial",2.6137671675961
+"2228","Ellman, Louise","inquest",2.48862865313834
+"2229","Ellman, Louise","commissioners",1.93613360544502
+"2230","Ellman, Louise","death",1.86352056492181
+"2231","Ellman, Louise","commissioners",1.83328173425076
+"2232","Ellman, Louise","announce",1.79272739742963
+"2233","Elmore, Chris","pregnant",6.85506533612322
+"2234","Elmore, Chris","obstacles",3.74376043407845
+"2235","Elmore, Chris","women",3.56650379686895
+"2236","Elmore, Chris","barriers",3.55877904927178
+"2237","Elmore, Chris","justice",3.54200727970565
+"2238","Elmore, Chris","accessing",3.51815126830965
+"2239","Elmore, Chris","faced",3.17222462467664
+"2240","Elmore, Chris","experienced",2.88980641474755
+"2241","Elmore, Chris","remove",2.43796649037868
+"2242","Elmore, Chris","potential",1.8254946009211
+"2243","Elmore, Chris","reduce",1.82210261332679
+"2244","Elmore, Chris","taken",1.56151473981095
+"2245","Elphicke, Charlie","1998",2.54380030971435
+"2246","Elphicke, Charlie","human",2.08465525902437
+"2247","Elphicke, Charlie","reform",1.98684329395642
+"2248","Elphicke, Charlie","rights",1.83925027434876
+"2249","Elphicke, Charlie","recent",1.69315355320945
+"2250","Elphicke, Charlie","received",1.54401530557673
+"2251","Elphicke, Charlie","act",1.45221735385955
+"2252","Elphicke, Charlie","will",0.95478443192298
+"2253","Elphicke, Charlie","2010",0
+"2254","Elphicke, Charlie","accommod",0
+"2255","Elphicke, Charlie","cost",0
+"2256","Elphicke, Charlie","flight",0
+"2257","Esterson, Bill","james",10.52127382747
+"2258","Esterson, Bill","thompson",10.1332533585231
+"2259","Esterson, Bill","unemployed",8.32724632426749
+"2260","Esterson, Bill","commission",8.26997407558179
+"2261","Esterson, Bill","criminal",8.02981977111452
+"2262","Esterson, Bill","classed",7.71570712826554
+"2263","Esterson, Bill","week",7.48822277894808
+"2264","Esterson, Bill","hours",7.36996952285773
+"2265","Esterson, Bill","cells",7.35571452670476
+"2266","Esterson, Bill","per",7.23221401573063
+"2267","Esterson, Bill","spent",6.03999008727728
+"2268","Esterson, Bill","date",5.80160432291655
+"2269","Evans, Chris","dangerous",6.49044131203159
+"2270","Evans, Chris","forward",6.00486442815378
+"2271","Evans, Chris","internet",5.87895015486976
+"2272","Evans, Chris","bring",5.66976328761757
+"2273","Evans, Chris","legislative",5.40162316186339
+"2274","Evans, Chris","drive",5.07274325520368
+"2275","Evans, Chris","death",4.82424717983454
+"2276","Evans, Chris","proposals",4.48293920199826
+"2277","Evans, Chris","reoffending",4.1824842194837
+"2278","Evans, Chris","trolling",3.74376043407845
+"2279","Evans, Chris","rate",3.71262329744683
+"2280","Evans, Chris","porn",3.56953551699164
+"2281","Evans, Graham","complex",2.50786376591274
+"2282","Evans, Graham","disputes",2.20970249642714
+"2283","Evans, Graham","skilled",2.16722124606656
+"2284","Evans, Graham","relevantly",2.07881200741289
+"2285","Evans, Graham","judiciary",2.02098062088627
+"2286","Evans, Graham","proceedings",1.54514962573919
+"2287","Evans, Graham","potential",1.4431801988127
+"2288","Evans, Graham","increase",1.44049859716443
+"2289","Evans, Graham","management",1.40249782380317
+"2290","Evans, Graham","provision",1.40249782380317
+"2291","Evans, Graham","members",1.30602503539834
+"2292","Evans, Graham","time",1.11485790465932
+"2293","Evans, Jonathan","alternative",3.41846706944372
+"2294","Evans, Jonathan","resolution",3.12499123925695
+"2295","Evans, Jonathan","dispute",3.12499123925695
+"2296","Evans, Jonathan","awareness",2.75574215724209
+"2297","Evans, Jonathan","raise",2.58633074391407
+"2298","Evans, Jonathan","public",1.50396220138397
+"2299","Evans, Jonathan","services",1.23549730067955
+"2300","Evans, Jonathan","will",0.95478443192298
+"2301","Evans, Jonathan","2010",0
+"2302","Evans, Jonathan","accommod",0
+"2303","Evans, Jonathan","cost",0
+"2304","Evans, Jonathan","flight",0
+"2305","Evans, Nigel","wrongfully",6.60654554833578
+"2306","Evans, Nigel","english",6.01787267708722
+"2307","Evans, Nigel","terrorism",5.29958420325753
+"2308","Evans, Nigel","recalled",4.97484860155784
+"2309","Evans, Nigel","limb",4.05998820009529
+"2310","Evans, Nigel","people",3.97101986820443
+"2311","Evans, Nigel","repetitive",3.87104686156941
+"2312","Evans, Nigel","strain",3.87104686156941
+"2313","Evans, Nigel","compensation",3.68694207032871
+"2314","Evans, Nigel","released",3.41953588492628
+"2315","Evans, Nigel","population",3.24401921496954
+"2316","Evans, Nigel","capacity",3.23071579857372
+"2317","Fabricant, Michael","meals",3.55877904927178
+"2318","Fabricant, Michael","served",3.20109505136091
+"2319","Fabricant, Michael","soldiers",3.03596229535056
+"2320","Fabricant, Michael","daily",3.00950229978049
+"2321","Fabricant, Michael","vexatious",2.96003080284342
+"2322","Fabricant, Michael","minimised",2.89583164068126
+"2323","Fabricant, Michael","overseas",2.57842303212715
+"2324","Fabricant, Michael","defence",2.41891817793516
+"2325","Fabricant, Michael","ways",2.33362741099141
+"2326","Fabricant, Michael","remand",2.24866071082662
+"2327","Fabricant, Michael","can",2.14961724286303
+"2328","Fabricant, Michael","operations",1.74113110230201
+"2329","Farrelly, Paul","yet",3.37594820524006
+"2330","Farrelly, Paul","war",2.94542501489603
+"2331","Farrelly, Paul","implemented",2.33067432224227
+"2332","Farrelly, Paul","armed",2.2181943443755
+"2333","Farrelly, Paul","crime",2.03944583426802
+"2334","Farrelly, Paul","sections",1.99147756455519
+"2335","Farrelly, Paul","complainants",1.95390670927164
+"2336","Farrelly, Paul","favour",1.95390670927164
+"2337","Farrelly, Paul","pensions",1.86707018744435
+"2338","Farrelly, Paul","quarter",1.75029444795579
+"2339","Farrelly, Paul","took",1.56893061167266
+"2340","Farrelly, Paul","2013",1.56154164465491
+"2341","Farron, Tim","five",14.0504535252607
+"2342","Farron, Tim","last",13.4096223655582
+"2343","Farron, Tim","people",12.1034157188608
+"2344","Farron, Tim","year",10.06695868452
+"2345","Farron, Tim","guards",8.25702366777166
+"2346","Farron, Tim","transsexual",8.00483702898528
+"2347","Farron, Tim","prison",7.93133348142598
+"2348","Farron, Tim","disqualified",7.75118012196051
+"2349","Farron, Tim","possession",7.56222674349368
+"2350","Farron, Tim","gender",7.15773699154716
+"2351","Farron, Tim","explicit",6.95194173614341
+"2352","Farron, Tim","served",6.71894562077141
+"2353","Fernandes, Suella","college",3.08938400695214
+"2354","Fernandes, Suella","progress",2.81038912826679
+"2355","Fernandes, Suella","secure",2.14412795791248
+"2356","Fernandes, Suella","plans",1.57481677989104
+"2357","Fernandes, Suella","made",1.27652269771288
+"2358","Fernandes, Suella","2010",0
+"2359","Fernandes, Suella","accommod",0
+"2360","Fernandes, Suella","cost",0
+"2361","Fernandes, Suella","flight",0
+"2362","Fernandes, Suella","hotel",0
+"2363","Fernandes, Suella","intern",0
+"2364","Fernandes, Suella","oversea",0
+"2365","Ferrier, Margaret","129",7.34358585370391
+"2366","Ferrier, Margaret","oral",7.27070750498659
+"2367","Ferrier, Margaret","parliamentary",7.15079402280207
+"2368","Ferrier, Margaret","contribution",6.75631139978364
+"2369","Ferrier, Margaret","2016",6.65532117212136
+"2370","Ferrier, Margaret","column",5.61844836593134
+"2371","Ferrier, Margaret","official",4.79196098277042
+"2372","Ferrier, Margaret","1998",3.99104228243596
+"2373","Ferrier, Margaret","report",3.9880423330821
+"2374","Ferrier, Margaret","50967",3.56084520918548
+"2375","Ferrier, Margaret","42839",3.56084520918548
+"2376","Ferrier, Margaret","employ",3.5599299677281
+"2377","Field, Frank","outsource",13.5043242508304
+"2378","Field, Frank","income",12.2885433646626
+"2379","Field, Frank","wage",8.53928096056396
+"2380","Field, Frank","low",8.44483854330961
+"2381","Field, Frank","birkenhead",7.88994153202959
+"2382","Field, Frank","less",7.86594531244466
+"2383","Field, Frank","people",7.81808424376985
+"2384","Field, Frank","liverpool",7.63102577021036
+"2385","Field, Frank","direct",7.45498869664548
+"2386","Field, Frank","foundation",7.42650652094955
+"2387","Field, Frank","call",7.14228013920635
+"2388","Field, Frank","employed",7.14137041598788
+"2389","Field, Mark","traffickers",3.97513648208136
+"2390","Field, Mark","human",2.86012341946056
+"2391","Field, Mark","orders",2.38363890149753
+"2392","Field, Mark","victim",2.15064513265193
+"2393","Field, Mark","august",2.06564727275094
+"2394","Field, Mark","convicted",1.94932237404971
+"2395","Field, Mark","confiscation",1.84105942498813
+"2396","Field, Mark","money",1.81447158050183
+"2397","Field, Mark","purse",1.55936316780817
+"2398","Field, Mark","awarded",1.53549676393785
+"2399","Field, Mark","value",1.48210841196432
+"2400","Field, Mark","compensation",1.44756060311481
+"2401","Fitzpatrick, Jim","fraud",14.6800388147081
+"2402","Fitzpatrick, Jim","insurance",9.4736201250313
+"2403","Fitzpatrick, Jim","injury",7.98510665713505
+"2404","Fitzpatrick, Jim","personal",6.38638149873436
+"2405","Fitzpatrick, Jim","20722",5.54292080508183
+"2406","Fitzpatrick, Jim","exaggerated",5.403695406594
+"2407","Fitzpatrick, Jim","fabricated",5.12650763346105
+"2408","Fitzpatrick, Jim","project",4.65294408863351
+"2409","Fitzpatrick, Jim","reform",4.32648173330903
+"2410","Fitzpatrick, Jim","estimate",4.07130724206274
+"2411","Fitzpatrick, Jim","motor",3.95577773972655
+"2412","Fitzpatrick, Jim","scale",3.94626999523619
+"2413","Flello, Robert","fenton",6.01647009066469
+"2414","Flello, Robert","urban",6.01647009066469
+"2415","Flello, Robert","town",5.50827120091753
+"2416","Flello, Robert","trent",5.50827120091753
+"2417","Flello, Robert","stoke",5.34466770051736
+"2418","Flello, Robert","vision",5.34466770051736
+"2419","Flello, Robert","hall",4.40551772434994
+"2420","Flello, Robert","city",3.96111348950678
+"2421","Flello, Robert","council",3.20940203714686
+"2422","Flello, Robert","make",3.15618771128552
+"2423","Flello, Robert","regulation",3.03855514891239
+"2424","Flello, Robert","introduce",2.81728965218864
+"2425","Fletcher, Colleen","coventry",25.1851722721572
+"2426","Fletcher, Colleen","midlands",22.6775704935227
+"2427","Fletcher, Colleen","jobseekers",20.9369481507215
+"2428","Fletcher, Colleen","credits",19.6614374273033
+"2429","Fletcher, Colleen","tax",19.2138395970448
+"2430","Fletcher, Colleen","west",18.6747464162427
+"2431","Fletcher, Colleen","allowance",18.0730593573934
+"2432","Fletcher, Colleen","appellants",17.7509990014968
+"2433","Fletcher, Colleen","income",17.4938259075145
+"2434","Fletcher, Colleen","appeal",17.3961806672299
+"2435","Fletcher, Colleen","support",16.8903956359497
+"2436","Fletcher, Colleen","independence",16.1287928158203
+"2437","Flint, Caroline","prison",7.6511321952287
+"2438","Flint, Caroline","officers",7.10036317484354
+"2439","Flint, Caroline","private",6.12782253615904
+"2440","Flint, Caroline","staff",6.06120581560225
+"2441","Flint, Caroline","reduce",6.01029583062485
+"2442","Flint, Caroline","safety",5.96844826650218
+"2443","Flint, Caroline","incidence",5.93422147238036
+"2444","Flint, Caroline","2010",5.36519830869771
+"2445","Flint, Caroline","run",5.23790007102884
+"2446","Flint, Caroline","violent",4.94824343017818
+"2447","Flint, Caroline","causes",4.58618152758734
+"2448","Flint, Caroline","recent",4.48417288230708
+"2449","Flynn, Paul","rainsbrook",27.9216053494167
+"2450","Flynn, Paul","centre",21.0258985248798
+"2451","Flynn, Paul","secure",19.164992032757
+"2452","Flynn, Paul","training",18.2276130652648
+"2453","Flynn, Paul","drug",15.9665584265323
+"2454","Flynn, Paul","prison",13.8912474863274
+"2455","Flynn, Paul","contract",13.6203432650498
+"2456","Flynn, Paul","run",12.2899593743548
+"2457","Flynn, Paul","made",10.4853647346617
+"2458","Flynn, Paul","reduce",10.2042520069894
+"2459","Flynn, Paul","medway",10.0443633382926
+"2460","Flynn, Paul","g4s",9.57071258274522
+"2461","Foster, Kevin","certificate",4.5758974018423
+"2462","Foster, Kevin","declaration",4.52236126908619
+"2463","Foster, Kevin","recognition",4.3821015660822
+"2464","Foster, Kevin","statutory",4.16373168743197
+"2465","Foster, Kevin","gender",3.54716448756184
+"2466","Foster, Kevin","six",3.30028233674464
+"2467","Foster, Kevin","within",3.07369385749182
+"2468","Foster, Kevin","application",2.80431620363877
+"2469","Foster, Kevin","date",2.30597773483716
+"2470","Foster, Kevin","panel",2.28217092499607
+"2471","Foster, Kevin","states",2.18087500200613
+"2472","Foster, Kevin","administrative",2.03579849705334
+"2473","Fovargue, Yvonne","jobseekers",4.88934887065109
+"2474","Fovargue, Yvonne","directly",4.62308679353091
+"2475","Fovargue, Yvonne","1300",3.87104686156941
+"2476","Fovargue, Yvonne","allowance",3.56133472903964
+"2477","Fovargue, Yvonne","april",3.54527422382127
+"2478","Fovargue, Yvonne","hindley",3.27172915435034
+"2479","Fovargue, Yvonne","march",3.19351021047318
+"2480","Fovargue, Yvonne","chain",3.09165134229387
+"2481","Fovargue, Yvonne","went",3.02459750431282
+"2482","Fovargue, Yvonne","appeals",2.95849688742995
+"2483","Fovargue, Yvonne","employed",2.80644218257813
+"2484","Fovargue, Yvonne","2012",2.78165324234285
+"2485","Fox, Dr Liam","spread",4.85261405031394
+"2486","Fox, Dr Liam","population",4.55515851319942
+"2487","Fox, Dr Liam","islamic",3.79153362664858
+"2488","Fox, Dr Liam","extremism",3.37594820524006
+"2489","Fox, Dr Liam","among",3.21907877554606
+"2490","Fox, Dr Liam","extremists",2.6292204727053
+"2491","Fox, Dr Liam","prevent",2.57637297359491
+"2492","Fox, Dr Liam","radicalising",2.31346187124685
+"2493","Fox, Dr Liam","overseas",2.23297984752501
+"2494","Fox, Dr Liam","terrorist",2.20970249642714
+"2495","Fox, Dr Liam","muslim",2.11162314073245
+"2496","Fox, Dr Liam","recruiting",1.82881200741289
+"2497","Foxcroft, Vicky","reduce",6.41801590607367
+"2498","Foxcroft, Vicky","violence",6.05287045875958
+"2499","Foxcroft, Vicky","offender",5.67331334411552
+"2500","Foxcroft, Vicky","abuse",5.44049603863836
+"2501","Foxcroft, Vicky","tagging",5.38928165569673
+"2502","Foxcroft, Vicky","live",5.13848658351433
+"2503","Foxcroft, Vicky","electronic",5.08623774671974
+"2504","Foxcroft, Vicky","immigration",4.98911161865308
+"2505","Foxcroft, Vicky","make",4.7047758801337
+"2506","Foxcroft, Vicky","contact",4.46808408815607
+"2507","Foxcroft, Vicky","estimate",4.44044785240454
+"2508","Foxcroft, Vicky","leave",4.40069213251375
+"2509","Freer, Mike","division",2.42174508089634
+"2510","Freer, Mike","president",2.21815631628716
+"2511","Freer, Mike","implications",1.93165250462965
+"2512","Freer, Mike","committee",1.90534730140202
+"2513","Freer, Mike","policies",1.88878891948114
+"2514","Freer, Mike","evidence",1.5885194715722
+"2515","Freer, Mike","given",1.46629565409601
+"2516","Freer, Mike","december",1.43627924088068
+"2517","Freer, Mike","access",1.43627924088068
+"2518","Freer, Mike","2011",1.39751316935216
+"2519","Freer, Mike","family",1.32851669327413
+"2520","Freer, Mike","aid",1.24647650112223
+"2521","Fuller, Richard","six",8.43270548869737
+"2522","Fuller, Richard","building",8.15195612941048
+"2523","Fuller, Richard","listed",7.07923132994473
+"2524","Fuller, Richard","closed",6.60113374707762
+"2525","Fuller, Richard","shire",6.52923801341878
+"2526","Fuller, Richard","months",6.39403132307965
+"2527","Fuller, Richard","preceding",5.7158475093874
+"2528","Fuller, Richard","three",5.64027352735049
+"2529","Fuller, Richard","counted",5.54607869696334
+"2530","Fuller, Richard","bedford",5.33249975824043
+"2531","Fuller, Richard","fewer",4.87230039947131
+"2532","Fuller, Richard","hall",4.78098841366266
+"2533","Garnier, Sir Edward","trafficking",4.51960998674812
+"2534","Garnier, Sir Edward","continuance",3.77738630843149
+"2535","Garnier, Sir Edward","human",3.25187384840627
+"2536","Garnier, Sir Edward","birds",2.94542501489603
+"2537","Garnier, Sir Edward","638",2.80165802822211
+"2538","Garnier, Sir Edward","england",2.73030792271056
+"2539","Garnier, Sir Edward","wales",2.71925776732878
+"2540","Garnier, Sir Edward","will",2.69720253226689
+"2541","Garnier, Sir Edward","consideration",2.69464082784836
+"2542","Garnier, Sir Edward","court",2.52583950185094
+"2543","Garnier, Sir Edward","search",2.4572483380649
+"2544","Garnier, Sir Edward","report",2.37147786627221
+"2545","Ghani, Nusrat","attacker",2.00769672750193
+"2546","Ghani, Nusrat","speech",1.97088360697041
+"2547","Ghani, Nusrat","cross",1.89356247802408
+"2548","Ghani, Nusrat","examined",1.88005133912951
+"2549","Ghani, Nusrat","social",1.52087871408523
+"2550","Ghani, Nusrat","2017",1.4245463008108
+"2551","Ghani, Nusrat","abuse",1.37496189115499
+"2552","Ghani, Nusrat","february",1.35002296486867
+"2553","Ghani, Nusrat","domestic",1.32189217123197
+"2554","Ghani, Nusrat","centre",1.30516053248592
+"2555","Ghani, Nusrat","reform",1.28923417083894
+"2556","Ghani, Nusrat","justice",1.28482107957161
+"2557","Gibb, Nick","ford",7.67731134376329
+"2558","Gibb, Nick","open",4.54522883421532
+"2559","Gibb, Nick","absconders",3.16802644410919
+"2560","Gibb, Nick","subsidiaries",3.05676759423755
+"2561","Gibb, Nick","failed",2.30033757278347
+"2562","Gibb, Nick","departmental",2.06064118462997
+"2563","Gibb, Nick","temporary",2.02299849783268
+"2564","Gibb, Nick","return",2.00474453612103
+"2565","Gibb, Nick","testing",1.90534730140202
+"2566","Gibb, Nick","executive",1.85772908189224
+"2567","Gibb, Nick","2013",1.8476409908822
+"2568","Gibb, Nick","licence",1.74708211890595
+"2569","Gillan, Cheryl","midlands)",3.02613653442003
+"2570","Gillan, Cheryl","petitioners",2.79043427402451
+"2571","Gillan, Cheryl","rail",2.41685502996241
+"2572","Gillan, Cheryl","select",2.2107406822235
+"2573","Gillan, Cheryl","speed",2.12873437316306
+"2574","Gillan, Cheryl","appearing",1.89303211276754
+"2575","Gillan, Cheryl","committee",1.73933616143247
+"2576","Gillan, Cheryl","high",1.64539717251449
+"2577","Gillan, Cheryl","london",1.63958427058547
+"2578","Gillan, Cheryl","bill",1.54904078136204
+"2579","Gillan, Cheryl","west",1.4885182355472
+"2580","Gillan, Cheryl","decision",1.35311432810634
+"2581","Gilmore, Sheila","pensions",5.3716708939302
+"2582","Gilmore, Sheila","sorting",5.29944941901159
+"2583","Gilmore, Sheila","147",5.23067852806089
+"2584","Gilmore, Sheila","sadler",5.23067852806089
+"2585","Gilmore, Sheila","kevin",4.97222765369627
+"2586","Gilmore, Sheila","purpose",4.85008549198672
+"2587","Gilmore, Sheila","january",4.7880755992519
+"2588","Gilmore, Sheila","interpretation",4.73737018943293
+"2589","Gilmore, Sheila","visit",4.57072894889494
+"2590","Gilmore, Sheila","2014",4.4293555379364
+"2591","Gilmore, Sheila","support",4.41375279070512
+"2592","Gilmore, Sheila","treasury",4.34702915208894
+"2593","Glass, Pat","unemployed",7.47969368522194
+"2594","Glass, Pat","classed",6.93039735309935
+"2595","Glass, Pat","week",6.72606651132779
+"2596","Glass, Pat","hours",6.61984914986242
+"2597","Glass, Pat","cells",6.60704503664705
+"2598","Glass, Pat","per",6.49611448937083
+"2599","Glass, Pat","spent",5.42523590096694
+"2600","Glass, Pat","date",5.2111131973861
+"2601","Glass, Pat","working",5.01702361917917
+"2602","Glass, Pat","three",4.98838225180324
+"2603","Glass, Pat","2011",4.81195992146394
+"2604","Glass, Pat","proportion",4.45949263622368
+"2605","Glen, John","outstanding",5.59692410898315
+"2606","Glen, John","imposed",5.31800726019699
+"2607","Glen, John","penalties",4.93743322535971
+"2608","Glen, John","financial",4.26639813129614
+"2609","Glen, John","current",4.20276989862126
+"2610","Glen, John","balance",3.83209802044349
+"2611","Glen, John","despatch",3.70624520066165
+"2612","Glen, John","total",3.61533339987152
+"2613","Glen, John","hire",2.84021979687721
+"2614","Glen, John","ministerial",2.57842303212715
+"2615","Glen, John","car",2.45861202616093
+"2616","Glen, John","2007",2.45861202616093
+"2617","Glindon, Mary","insolvency",7.86981905387757
+"2618","Glindon, Mary","punishment",6.99277412342559
+"2619","Glindon, Mary","service",6.87337706634968
+"2620","Glindon, Mary","officer",6.63346630441051
+"2621","Glindon, Mary","commence",6.10811468847159
+"2622","Glindon, Mary","noms",5.49112874088494
+"2623","Glindon, Mary","ordinated",5.46324418461591
+"2624","Glindon, Mary","staff",5.30707259308136
+"2625","Glindon, Mary","aid",4.8185242954747
+"2626","Glindon, Mary","agreements",4.80675564101813
+"2627","Glindon, Mary","2012",4.79637019726806
+"2628","Glindon, Mary","conditional",4.62199273718852
+"2629","Godsiff, Roger","benefit",13.6344993818404
+"2630","Godsiff, Roger","tribunal",12.4390389489528
+"2631","Godsiff, Roger","reach",10.5004297239817
+"2632","Godsiff, Roger","disabled",9.89182420098698
+"2633","Godsiff, Roger","concentrix",9.10567522201801
+"2634","Godsiff, Roger","contract",8.66277009513067
+"2635","Godsiff, Roger","collect",7.13161136237257
+"2636","Godsiff, Roger","appeal",7.05460609024624
+"2637","Godsiff, Roger","birmingham",6.42416825874551
+"2638","Godsiff, Roger","synnex",6.33309217463156
+"2639","Godsiff, Roger","fines",6.19991474764074
+"2640","Godsiff, Roger","tender",5.60146839694024
+"2641","Goldsmith, Zac","breached",14.8675392113965
+"2642","Goldsmith, Zac","issued",12.0464619876658
+"2643","Goldsmith, Zac","order",11.3632428819122
+"2644","Goldsmith, Zac","resulted",9.51695568489088
+"2645","Goldsmith, Zac","imposition",7.74876677627462
+"2646","Goldsmith, Zac","five",7.57020599972084
+"2647","Goldsmith, Zac","contempt",7.47977961875785
+"2648","Goldsmith, Zac","sequestration",6.83514013213367
+"2649","Goldsmith, Zac","courts",6.5775879514276
+"2650","Goldsmith, Zac","twice",6.20692149501759
+"2651","Goldsmith, Zac","last",5.62029944938792
+"2652","Goldsmith, Zac","molestation",5.49457432151149
+"2653","Goodman, Helen","libraries",13.5799032406865
+"2654","Goodman, Helen","probate",10.1730837195668
+"2655","Goodman, Helen","stalking",8.7483610491439
+"2656","Goodman, Helen","book",8.33767211279749
+"2657","Goodman, Helen","planning",7.04260417246334
+"2658","Goodman, Helen","prison",6.10370196821655
+"2659","Goodman, Helen","help",5.99596746446167
+"2660","Goodman, Helen","foreign",5.95370983163847
+"2661","Goodman, Helen","serious",5.30562337333218
+"2662","Goodman, Helen","building",5.13495451781957
+"2663","Goodman, Helen","newspapers",5.1269237424937
+"2664","Goodman, Helen","order",5.01322582440048
+"2665","Gove, Michael","triggering",2.46856252730307
+"2666","Gove, Michael","lisbon",2.46856252730307
+"2667","Gove, Michael","treaty",2.34658941421983
+"2668","Gove, Michael","white",1.82478202203676
+"2669","Gove, Michael","documents",1.82478202203676
+"2670","Gove, Michael","papers",1.68561435993922
+"2671","Gove, Michael","article",1.62524805728916
+"2672","Gove, Michael","assist",1.54562252551488
+"2673","Gove, Michael","make",1.47158010824137
+"2674","Gove, Michael","list",1.44540510991759
+"2675","Gove, Michael","leave",1.44540510991759
+"2676","Gove, Michael","governments",1.43554118651903
+"2677","Graham, Richard","stalking",11.1240537879462
+"2678","Graham, Richard","offences",7.55119384240588
+"2679","Graham, Richard","people",4.8187103080072
+"2680","Graham, Richard","restraining",4.58900861826705
+"2681","Graham, Richard","convicted",4.56139065044183
+"2682","Graham, Richard","orders",3.93968688244044
+"2683","Graham, Richard","hospitalisation",3.56084520918548
+"2684","Graham, Richard","therapeutic",3.56084520918548
+"2685","Graham, Richard","psychological",3.41794916166247
+"2686","Graham, Richard","breaches",3.37144201251516
+"2687","Graham, Richard","motoring",3.27882779967284
+"2688","Graham, Richard","section",3.07355672013694
+"2689","Grant, Peter","exemption",6.24875991970746
+"2690","Grant, Peter","individual)",5.17128115982578
+"2691","Grant, Peter","2000",5.08285474739779
+"2692","Grant, Peter","freedom",4.96102646130534
+"2693","Grant, Peter","wholly",4.91576514404079
+"2694","Grant, Peter","endanger",4.7344736457202
+"2695","Grant, Peter","request",4.70183744276453
+"2696","Grant, Peter","application",4.42970866680781
+"2697","Grant, Peter","disclosur",4.09698294837614
+"2698","Grant, Peter","likely",3.75256201668334
+"2699","Grant, Peter","section",3.51029989873467
+"2700","Grant, Peter","information",3.25424318788154
+"2701","Greatrex, Tom","handling",4.19458552309246
+"2702","Greatrex, Tom","share",3.54726218966247
+"2703","Greatrex, Tom","governments",3.07889283536879
+"2704","Greatrex, Tom","data",2.46722458634275
+"2705","Greatrex, Tom","personal",2.01000780075487
+"2706","Greatrex, Tom","2010",0
+"2707","Greatrex, Tom","accommod",0
+"2708","Greatrex, Tom","cost",0
+"2709","Greatrex, Tom","flight",0
+"2710","Greatrex, Tom","hotel",0
+"2711","Greatrex, Tom","intern",0
+"2712","Greatrex, Tom","made",0
+"2713","Green, Damian","submission",3.12889493147202
+"2714","Green, Damian","final",2.67135566824861
+"2715","Green, Damian","papers",2.33362741099141
+"2716","Green, Damian","immigration",1.88650044472543
+"2717","Green, Damian","hearing",1.85114235765612
+"2718","Green, Damian","appeal",1.47538672330261
+"2719","Green, Damian","average",1.37159577643316
+"2720","Green, Damian","date",1.32940393227054
+"2721","Green, Damian","time",1.28732702272649
+"2722","Green, Damian","months",1.16751601676027
+"2723","Green, Damian","will",0.779578224188134
+"2724","Green, Damian","last",0.701619211838426
+"2725","Green, Kate","women",24.8092788948754
+"2726","Green, Kate","recall",15.6103953401804
+"2727","Green, Kate","bench",15.5919995634499
+"2728","Green, Kate","half",12.7495834900658
+"2729","Green, Kate","community",12.2948451470585
+"2730","Green, Kate","number",12.2296919591616
+"2731","Green, Kate","rehabilitation",11.7441826813126
+"2732","Green, Kate","member",11.7005242828412
+"2733","Green, Kate","service",11.6795909518629
+"2734","Green, Kate","year",11.1950792652658
+"2735","Green, Kate","training",11.1068280117251
+"2736","Green, Kate","sit",11.0713500977808
+"2737","Griffith, Nia","welsh",7.11337776170266
+"2738","Griffith, Nia","website",4.13844640596946
+"2739","Griffith, Nia","forms",3.46650782644149
+"2740","Griffith, Nia","cremation",3.30024753414967
+"2741","Griffith, Nia","allow",2.51166981884763
+"2742","Griffith, Nia","application",2.28635586774091
+"2743","Griffith, Nia","departments",2.27659319275752
+"2744","Griffith, Nia","members",2.13272995201751
+"2745","Griffith, Nia","proportion",1.7624529170663
+"2746","Griffith, Nia","public",1.73662596364011
+"2747","Griffith, Nia","2010",0
+"2748","Griffith, Nia","accommod",0
+"2749","Griffiths, Andrew","deradicalisation",10.7434238891788
+"2750","Griffiths, Andrew","recent",9.42514013450177
+"2751","Griffiths, Andrew","programme",7.95841889539273
+"2752","Griffiths, Andrew","drug",7.70120735538733
+"2753","Griffiths, Andrew","needles",7.6032214771036
+"2754","Griffiths, Andrew","year",7.31045592042585
+"2755","Griffiths, Andrew","neglect",7.14596692123155
+"2756","Griffiths, Andrew","national",6.6506392012797
+"2757","Griffiths, Andrew","management",5.87784386176162
+"2758","Griffiths, Andrew","visitors",5.80707987022547
+"2759","Griffiths, Andrew","prosecuted",5.49896529758649
+"2760","Griffiths, Andrew","last",5.41713220134152
+"2761","Gwynne, Andrew","reuse",9.66634787558406
+"2762","Gwynne, Andrew","since",9.06928841719557
+"2763","Gwynne, Andrew","graves",8.03335471372861
+"2764","Gwynne, Andrew","freedom",7.64066014089225
+"2765","Gwynne, Andrew","request",7.24147355755749
+"2766","Gwynne, Andrew","ward",6.49741187487647
+"2767","Gwynne, Andrew","valuation",6.45855803366276
+"2768","Gwynne, Andrew","admitted",6.25778986294404
+"2769","Gwynne, Andrew","month",5.84369186502113
+"2770","Gwynne, Andrew","respond",5.67971711677211
+"2771","Gwynne, Andrew","2010",5.46006669226939
+"2772","Gwynne, Andrew","owned",5.13673560672775
+"2773","Haigh, Louise","contractual",10.5030012502211
+"2774","Haigh, Louise","servants",10.0747546314414
+"2775","Haigh, Louise","internships",9.07840960326008
+"2776","Haigh, Louise","limited",8.59565472238535
+"2777","Haigh, Louise","civil",8.56775164652612
+"2778","Haigh, Louise","remedies",8.49335911591682
+"2779","Haigh, Louise","heeley",7.97994490882702
+"2780","Haigh, Louise","payroll",7.74252388773299
+"2781","Haigh, Louise","pip",7.73011843053268
+"2782","Haigh, Louise","sheffield",7.68564765770817
+"2783","Haigh, Louise","g4s",7.6639968464055
+"2784","Haigh, Louise","agreement",7.56910111615313
+"2785","Halfon, Robert","bereaved",3.84195943893919
+"2786","Halfon, Robert","homicide",3.48576874441235
+"2787","Halfon, Robert","assistance",3.31499100456447
+"2788","Halfon, Robert","makes",3.15618771128552
+"2789","Halfon, Robert","families",2.30105841145418
+"2790","Halfon, Robert","2010",0
+"2791","Halfon, Robert","accommod",0
+"2792","Halfon, Robert","cost",0
+"2793","Halfon, Robert","flight",0
+"2794","Halfon, Robert","hotel",0
+"2795","Halfon, Robert","intern",0
+"2796","Halfon, Robert","made",0
+"2797","Hames, Duncan","type",3.16550767275493
+"2798","Hames, Duncan","aged",2.88636039762539
+"2799","Hames, Duncan","2010",1.70313404266015
+"2800","Hames, Duncan","prison",0.895502215850485
+"2801","Hames, Duncan","accommod",0
+"2802","Hames, Duncan","cost",0
+"2803","Hames, Duncan","flight",0
+"2804","Hames, Duncan","hotel",0
+"2805","Hames, Duncan","intern",0
+"2806","Hames, Duncan","made",0
+"2807","Hames, Duncan","oversea",0
+"2808","Hames, Duncan","sinc",0
+"2809","Hamilton, Fabian","afforded",2.89583164068126
+"2810","Hamilton, Fabian","comparable",2.60715650608644
+"2811","Hamilton, Fabian","disordered",2.50249153962001
+"2812","Hamilton, Fabian","extend",2.34934513237246
+"2813","Hamilton, Fabian","mentally",1.83220863430892
+"2814","Hamilton, Fabian","justice",1.61669773828525
+"2815","Hamilton, Fabian","system",1.61669773828525
+"2816","Hamilton, Fabian","rights",1.50174156047615
+"2817","Hamilton, Fabian","criminal",1.29617497704349
+"2818","Hamilton, Fabian","victims",1.27988985750232
+"2819","Hamilton, Fabian","offenders",1.00179033693354
+"2820","Hamilton, Fabian","will",0.779578224188134
+"2821","Hammond, Stephen","general",11.6503570158316
+"2822","Hammond, Stephen","regulation",9.72644005550631
+"2823","Hammond, Stephen","data",7.89760621956249
+"2824","Hammond, Stephen","protection",7.44710731683397
+"2825","Hammond, Stephen","knife",4.95715132153883
+"2826","Hammond, Stephen","implement",4.91269528165335
+"2827","Hammond, Stephen","sector",4.10887012259818
+"2828","Hammond, Stephen","london",3.86718624097204
+"2829","Hammond, Stephen","enact",3.61293666190285
+"2830","Hammond, Stephen","fca",3.43131630145811
+"2831","Hammond, Stephen","crime",3.26397529102942
+"2832","Hammond, Stephen","financial",3.18535697737875
+"2833","Hancock, Mike","portsmouth",4.47464957730471
+"2834","Hancock, Mike","overdoses",4.27960332856952
+"2835","Hancock, Mike","kingston",3.0760148293351
+"2836","Hancock, Mike","sale",3.01646982360171
+"2837","Hancock, Mike","died",2.86362749075499
+"2838","Hancock, Mike","site",2.85491978601987
+"2839","Hancock, Mike","former",2.82764973026894
+"2840","Hancock, Mike","raised",2.76490386645903
+"2841","Hancock, Mike","waiting",2.52375972265384
+"2842","Hancock, Mike","asylum",2.34405261889994
+"2843","Hancock, Mike","two",2.09026278067585
+"2844","Hancock, Mike","one",2.04955373233904
+"2845","Hanson, David","2010",47.6405844492548
+"2846","Hanson, David","since",43.6449797631712
+"2847","Hanson, David","year",36.3493226304237
+"2848","Hanson, David","wales",21.4825074641449
+"2849","Hanson, David","prison",20.4678194001962
+"2850","Hanson, David","immediate",19.5039805827903
+"2851","Hanson, David","offender",19.2458043819847
+"2852","Hanson, David","police",18.6613008349485
+"2853","Hanson, David","absconded",18.4403036922183
+"2854","Hanson, David","sentence",16.3533780713473
+"2855","Hanson, David","force",15.6040549377833
+"2856","Hanson, David","hostel",14.319303093599
+"2857","Harman, Harriet","history",14.4124813279737
+"2858","Harman, Harriet","right",13.4072975911846
+"2859","Harman, Harriet","rape",12.2635330596025
+"2860","Harman, Harriet","complainants",12.0188951968792
+"2861","Harman, Harriet","previous",10.3494031558824
+"2862","Harman, Harriet","evidence",10.2201236285904
+"2863","Harman, Harriet","1999",9.9485971923666
+"2864","Harman, Harriet","sexual",9.40294670872208
+"2865","Harman, Harriet","subsection",9.32644988574124
+"2866","Harman, Harriet","proposal",7.52838043350364
+"2867","Harman, Harriet","bill",7.11997876944829
+"2868","Harman, Harriet","use",6.7658073185233
+"2869","Harrington, Richard","exercised",2.72879491484764
+"2870","Harrington, Richard","attorney",2.38268209655663
+"2871","Harrington, Richard","among",2.36215802803281
+"2872","Harrington, Richard","awareness",2.16178200526272
+"2873","Harrington, Richard","raise",2.02888475874197
+"2874","Harrington, Richard","power",1.9430925914768
+"2875","Harrington, Richard","bodies",1.83865270900259
+"2876","Harrington, Richard","may",1.3972648565759
+"2877","Harrington, Richard","communities",1.36953902481732
+"2878","Harrington, Richard","companies",1.32521040167599
+"2879","Harrington, Richard","public",1.17980501731736
+"2880","Harrington, Richard","will",0.748994530715365
+"2881","Harris, Carolyn","establishment",7.779157928807
+"2882","Harris, Carolyn","autonomy",7.10012219285737
+"2883","Harris, Carolyn","999",7.04046932996447
+"2884","Harris, Carolyn","plus",6.49668926546436
+"2885","Harris, Carolyn","january",6.4093077917239
+"2886","Harris, Carolyn","governors",5.13492798734426
+"2887","Harris, Carolyn","calls",4.83695189547955
+"2888","Harris, Carolyn","regardless",4.59436399688715
+"2889","Harris, Carolyn","grades",4.40965050018207
+"2890","Harris, Carolyn","prison",4.07617982544446
+"2891","Harris, Carolyn","justice",3.78312712910221
+"2892","Harris, Carolyn","increasing",3.77447932826308
+"2893","Harris, Rebecca","leigh",4.09668510429549
+"2894","Harris, Rebecca","day",2.29448082877032
+"2895","Harris, Rebecca","paid",2.15411728588221
+"2896","Harris, Rebecca","claims",1.87557047345725
+"2897","Harris, Rebecca","aid",1.82465476256073
+"2898","Harris, Rebecca","legal",1.58964857013461
+"2899","Harris, Rebecca","2013",1.56154164465491
+"2900","Harris, Rebecca","2010",0
+"2901","Harris, Rebecca","accommod",0
+"2902","Harris, Rebecca","cost",0
+"2903","Harris, Rebecca","flight",0
+"2904","Harris, Rebecca","hotel",0
+"2905","Hayes, Helen","beneficial",9.4451333693533
+"2906","Hayes, Helen","ownership",8.63963304782118
+"2907","Hayes, Helen","dependencies",8.06113422907212
+"2908","Hayes, Helen","central",7.7803233251641
+"2909","Hayes, Helen","leaders",6.22260980408955
+"2910","Hayes, Helen","registers",6.14291447122589
+"2911","Hayes, Helen","crown",5.23104454343134
+"2912","Hayes, Helen","accessible",5.12396027695015
+"2913","Hayes, Helen","discussions",3.42851454134108
+"2914","Hayes, Helen","nine",2.78222504611588
+"2915","Hayes, Helen","proposed",2.75718533310312
+"2916","Hayes, Helen","adopted",2.74728716075575
+"2917","Hayman, Sue","manorial",5.24142222825589
+"2918","Hayman, Sue","cumbria",4.09532438060057
+"2919","Hayman, Sue","feudal",3.70624520066165
+"2920","Hayman, Sue","tenure",3.41757006606683
+"2921","Hayman, Sue","rights",3.25899319700754
+"2922","Hayman, Sue","supreme",3.22296166142208
+"2923","Hayman, Sue","royal",3.08461582832913
+"2924","Hayman, Sue","legislation",2.93162977411691
+"2925","Hayman, Sue","abolish",2.89583164068126
+"2926","Hayman, Sue","7ws",2.80165802822211
+"2927","Hayman, Sue","land",2.60715650608644
+"2928","Hayman, Sue","purse",2.14313968319029
+"2929","Heald, Sir Oliver","paperless",5.24142222825589
+"2930","Heald, Sir Oliver","progress",2.565522534865
+"2931","Heald, Sir Oliver","working",1.81003759482355
+"2932","Heald, Sir Oliver","plans",1.43760445713995
+"2933","Heald, Sir Oliver","made",1.16530046117449
+"2934","Heald, Sir Oliver","courts",1.16124452336663
+"2935","Heald, Sir Oliver","2010",0
+"2936","Heald, Sir Oliver","accommod",0
+"2937","Heald, Sir Oliver","cost",0
+"2938","Heald, Sir Oliver","flight",0
+"2939","Heald, Sir Oliver","hotel",0
+"2940","Heald, Sir Oliver","intern",0
+"2941","Healey, John","must",6.90061755606622
+"2942","Healey, John","mark",6.67482778407169
+"2943","Healey, John","exceeded",6.57838733737254
+"2944","Healey, John","met",5.37870356625951
+"2945","Healey, John","performance",4.89612373430037
+"2946","Healey, John","improve",4.50938294704551
+"2947","Healey, John","civil",4.14372773714794
+"2948","Healey, John","management",3.93466328523015
+"2949","Healey, John","system",3.9279399460316
+"2950","Healey, John","officials",3.62353217774796
+"2951","Healey, John","service",3.42014100174312
+"2952","Healey, John","received",3.06296461832561
+"2953","Heaton-Harris, Chris","stillbirth",7.75518692802841
+"2954","Heaton-Harris, Chris","coroner",4.34360479720565
+"2955","Heaton-Harris, Chris","coronial",4.18565141103677
+"2956","Heaton-Harris, Chris","lorry",4.05998820009529
+"2957","Heaton-Harris, Chris","retrieve",4.05998820009529
+"2958","Heaton-Harris, Chris","neonatal",4.05998820009529
+"2959","Heaton-Harris, Chris","perinatal",3.87104686156941
+"2960","Heaton-Harris, Chris","deaths",3.81799742215884
+"2961","Heaton-Harris, Chris","balance",3.42753266806161
+"2962","Heaton-Harris, Chris","jurisdictions",3.19310155974459
+"2963","Heaton-Harris, Chris","consistency",3.05756989844826
+"2964","Heaton-Harris, Chris","unpaid",3.00950229978049
+"2965","Hemming, John","contempt",20.534600921819
+"2966","Hemming, John","yardley",18.8326419932301
+"2967","Hemming, John","birmingham",18.3701233798463
+"2968","Hemming, John","committal",16.0537965189585
+"2969","Hemming, John","analysis",15.4582890451452
+"2970","Hemming, John","name",13.6600315770605
+"2971","Hemming, John","hon",12.8366921228236
+"2972","Hemming, John","team",12.4157259624348
+"2973","Hemming, John","letter",12.0350778491198
+"2974","Hemming, John","performance",11.9484259790478
+"2975","Hemming, John","sent",11.9484259790478
+"2976","Hemming, John","judge",11.9069202272909
+"2977","Henderson, Gordon","kent",3.5056272969404
+"2978","Henderson, Gordon","deportation",3.08461582832913
+"2979","Henderson, Gordon","stalking",3.03560468063012
+"2980","Henderson, Gordon","awaiting",2.94626999523619
+"2981","Henderson, Gordon","guidelines",2.86908389330461
+"2982","Henderson, Gordon","sentence",2.48564019776717
+"2983","Henderson, Gordon","foreign",2.25044904815274
+"2984","Henderson, Gordon","completed",2.16631999427464
+"2985","Henderson, Gordon","officers",2.01599108477657
+"2986","Henderson, Gordon","employed",1.91596193726688
+"2987","Henderson, Gordon","system",1.86680174879449
+"2988","Henderson, Gordon","england",1.82192063746097
+"2989","Hendrick, Mark","lancashire",39.8290470327194
+"2990","Hendrick, Mark","magistrates",36.7142792385225
+"2991","Hendrick, Mark","court",29.7409434474629
+"2992","Hendrick, Mark","preston",29.4263101404941
+"2993","Hendrick, Mark","2014",24.9236517748933
+"2994","Hendrick, Mark","people",19.625918631696
+"2995","Hendrick, Mark","crown",18.0361526857297
+"2996","Hendrick, Mark","convicted",15.3884072415986
+"2997","Hendrick, Mark","2013",15.3843433413722
+"2998","Hendrick, Mark","2011",14.1090013739792
+"2999","Hendrick, Mark","west",13.1355896826062
+"3000","Hendrick, Mark","cost",12.7538262660301
+"3001","Hepburn, Stephen","jarrow",3.87104686156941
+"3002","Hepburn, Stephen","tyneside",3.87104686156941
+"3003","Hepburn, Stephen","repossessed",3.26802417241388
+"3004","Hepburn, Stephen","1997",2.43739433747609
+"3005","Hepburn, Stephen","east",2.40631047979527
+"3006","Hepburn, Stephen","south",2.3915636803915
+"3007","Hepburn, Stephen","constituency",1.95417280843395
+"3008","Hepburn, Stephen","north",1.9284263050975
+"3009","Hepburn, Stephen","homes",1.91853976767155
+"3010","Hepburn, Stephen","since",0.834386702770618
+"3011","Hepburn, Stephen","year",0.562352613665216
+"3012","Hepburn, Stephen","2010",0
+"3013","Herbert, Nick","unimplemented",3.87104686156941
+"3014","Herbert, Nick","judgements",3.02459750431282
+"3015","Herbert, Nick","europe",2.82798898275925
+"3016","Herbert, Nick","european",1.92345494902595
+"3017","Herbert, Nick","council",1.90411892476231
+"3018","Herbert, Nick","human",1.77779997831394
+"3019","Herbert, Nick","member",1.5751254579007
+"3020","Herbert, Nick","rights",1.56851790419364
+"3021","Herbert, Nick","court",0.857635918636699
+"3022","Herbert, Nick","last",0.732817366621904
+"3023","Herbert, Nick","years",0.562352613665216
+"3024","Herbert, Nick","2010",0
+"3025","Hillier, Meg","hearing",10.7132215918478
+"3026","Hillier, Meg","tier",7.48818869604893
+"3027","Hillier, Meg","immigration",6.99294835370733
+"3028","Hillier, Meg","chamber",6.62627319592743
+"3029","Hillier, Meg","first",6.5343560373616
+"3030","Hillier, Meg","asylum",5.95086714010112
+"3031","Hillier, Meg","appeal",5.85302092336326
+"3032","Hillier, Meg","tribunal",5.80294752727072
+"3033","Hillier, Meg","time",5.10696746840906
+"3034","Hillier, Meg","upper",4.74566956682366
+"3035","Hillier, Meg","taken",4.00898067716236
+"3036","Hillier, Meg","london",3.6551883942188
+"3037","Hilling, Julie","girls",3.32573006579733
+"3038","Hilling, Julie","youth",1.83582455686766
+"3039","Hilling, Julie","potential",1.8254946009211
+"3040","Hilling, Julie","young",1.63375427427267
+"3041","Hilling, Julie","children",1.53554397584294
+"3042","Hilling, Julie","recent",1.51440257652865
+"3043","Hilling, Julie","custody",1.45026624670716
+"3044","Hilling, Julie","effect",1.42694000448588
+"3045","Hilling, Julie","plans",1.11356362418732
+"3046","Hilling, Julie","made",0.902637855891325
+"3047","Hilling, Julie","2010",0
+"3048","Hilling, Julie","accommod",0
+"3049","Hodge, Margaret","barking",6.47433766030439
+"3050","Hodge, Margaret","dagenham",6.47433766030439
+"3051","Hodge, Margaret","kpmg",5.6069408865019
+"3052","Hodge, Margaret","borough",5.38058961162044
+"3053","Hodge, Margaret","deloitte",5.32989866973154
+"3054","Hodge, Margaret","ernst",5.32989866973154
+"3055","Hodge, Margaret","pwc",5.32989866973154
+"3056","Hodge, Margaret","list",3.92504523046515
+"3057","Hodge, Margaret","london",3.80414700647451
+"3058","Hodge, Margaret","firms",3.6710906993353
+"3059","Hodge, Margaret","civil",3.23097146519617
+"3060","Hodge, Margaret","secondees",3.20970249642714
+"3061","Hodgson, Sharon","white",12.8692563092182
+"3062","Hodgson, Sharon","departments",10.548354648887
+"3063","Hodgson, Sharon","members",10.3936721988887
+"3064","Hodgson, Sharon","british",10.1937045661054
+"3065","Hodgson, Sharon","marriages",9.49729918716789
+"3066","Hodgson, Sharon","executive",8.69880905340646
+"3067","Hodgson, Sharon","proportion",8.54838104227144
+"3068","Hodgson, Sharon","satisfaction",8.03963867570976
+"3069","Hodgson, Sharon","board",7.54292195538583
+"3070","Hodgson, Sharon","formal",7.53388358606782
+"3071","Hodgson, Sharon","inciting",7.43655850193767
+"3072","Hodgson, Sharon","hatred",7.43655850193767
+"3073","Hoey, Kate","paralegal",14.3120314946052
+"3074","Hoey, Kate","mercy",11.7721112654571
+"3075","Hoey, Kate","prerogative",11.7721112654571
+"3076","Hoey, Kate","royal",10.8595733655407
+"3077","Hoey, Kate","britain",10.5848092169432
+"3078","Hoey, Kate","great",10.5848092169432
+"3079","Hoey, Kate","survivors",9.50898711728703
+"3080","Hoey, Kate","patent",9.03085518946198
+"3081","Hoey, Kate","terrorism",9.01472042867622
+"3082","Hoey, Kate","northern",8.2503559457951
+"3083","Hoey, Kate","list",8.24582917841971
+"3084","Hoey, Kate","ireland",8.16643911955543
+"3085","Hollern, Kate","blackburn",9.57626166008654
+"3086","Hollern, Kate","overturned",8.07389602219882
+"3087","Hollern, Kate","dismissed",7.52480111950451
+"3088","Hollern, Kate","consideration",7.14227457113445
+"3089","Hollern, Kate","mandatory",6.84843894960523
+"3090","Hollern, Kate","lancashire",6.81149015673492
+"3091","Hollern, Kate","refused",6.0826660925342
+"3092","Hollern, Kate","constituency",5.72629489725197
+"3093","Hollern, Kate","local",5.36349468679396
+"3094","Hollern, Kate","authorities",5.18891196762295
+"3095","Hollern, Kate","applications",4.94804744364043
+"3096","Hollern, Kate","2011",4.78207012093709
+"3097","Hollingbery, George","support",2.02584765001109
+"3098","Hollingbery, George","victims",1.81003759482355
+"3099","Hollingbery, George","five",1.51863012447582
+"3100","Hollingbery, George","made",1.16530046117449
+"3101","Hollingbery, George","last",0.992239405003423
+"3102","Hollingbery, George","years",0.761429038393937
+"3103","Hollingbery, George","2010",0
+"3104","Hollingbery, George","accommod",0
+"3105","Hollingbery, George","cost",0
+"3106","Hollingbery, George","flight",0
+"3107","Hollingbery, George","hotel",0
+"3108","Hollingbery, George","intern",0
+"3109","Hollinrake, Kevin","forward",4.93304404474914
+"3110","Hollinrake, Kevin","guardianship",4.85158890251781
+"3111","Hollinrake, Kevin","bring",4.65775578379184
+"3112","Hollinrake, Kevin","legislation",4.43747653080683
+"3113","Hollinrake, Kevin","missing",4.1814997833623
+"3114","Hollinrake, Kevin","proposals",3.6827703269546
+"3115","Hollinrake, Kevin","address",3.46650782644149
+"3116","Hollinrake, Kevin","needs",3.20490464326134
+"3117","Hollinrake, Kevin","families",2.6614761796121
+"3118","Hollinrake, Kevin","landlords",2.64753203626047
+"3119","Hollinrake, Kevin","eviction",2.59011055998321
+"3120","Hollinrake, Kevin","women",2.5218990198936
+"3121","Hollobone, Philip","foreign",26.7472817022254
+"3122","Hollobone, Philip","national",18.8027677583447
+"3123","Hollobone, Philip","countries",12.8596397114635
+"3124","Hollobone, Philip","offenders",11.5094138432511
+"3125","Hollobone, Philip","return",11.3636874410921
+"3126","Hollobone, Philip","compulsory",10.9769112185763
+"3127","Hollobone, Philip","transfer",9.19688419265132
+"3128","Hollobone, Philip","agreements",8.0105922889764
+"3129","Hollobone, Philip","largest",7.58620386569535
+"3130","Hollobone, Philip","prison",7.09554686488931
+"3131","Hollobone, Philip","column",6.25728481372187
+"3132","Hollobone, Philip","detention",5.89622538144127
+"3133","Hopkins, Kelvin","electronic",12.4588720461763
+"3134","Hopkins, Kelvin","monitoring",9.58567525506336
+"3135","Hopkins, Kelvin","agenda",7.81570913362251
+"3136","Hopkins, Kelvin","transforming",7.7718465824555
+"3137","Hopkins, Kelvin","introduction",7.07032806160427
+"3138","Hopkins, Kelvin","following",6.44774603612927
+"3139","Hopkins, Kelvin","homicide",6.36411390520368
+"3140","Hopkins, Kelvin","technology",5.96485532280645
+"3141","Hopkins, Kelvin","rehabilitation",5.25497534019389
+"3142","Hopkins, Kelvin","introduce",5.24941411861768
+"3143","Hopkins, Kelvin","tagging",5.21105263810059
+"3144","Hopkins, Kelvin","398w",5.10748290773714
+"3145","Horwood, Martin","programme",5.31430632278051
+"3146","Horwood, Martin","transforming",4.58618152758734
+"3147","Horwood, Martin","rehabilitation",4.45571907752242
+"3148","Horwood, Martin","successor",3.56084520918548
+"3149","Horwood, Martin","shortage",3.27960332856952
+"3150","Horwood, Martin","mutuals",3.26802417241388
+"3151","Horwood, Martin","become",3.01048502121699
+"3152","Horwood, Martin","indicated",2.82798898275925
+"3153","Horwood, Martin","work",2.81469086517693
+"3154","Horwood, Martin","withdrawn",2.79013999771611
+"3155","Horwood, Martin","signed",2.64397313003335
+"3156","Horwood, Martin","interventions",2.50786376591274
+"3157","Howarth, George","insurance",6.99756368760057
+"3158","Howarth, George","billion",5.6773763477186
+"3159","Howarth, George","save",5.10906969733125
+"3160","Howarth, George","injury",4.56799552247411
+"3161","Howarth, George","whiplash",3.93227433827061
+"3162","Howarth, George","reform",3.83774226106444
+"3163","Howarth, George","claims",3.78841975404908
+"3164","Howarth, George","genuine",3.74376043407845
+"3165","Howarth, George","personal",3.65342171916548
+"3166","Howarth, George","fraudulent",2.9660198676456
+"3167","Howarth, George","vow",2.87084518782474
+"3168","Howarth, George","comes",2.82452091497381
+"3169","Howell, John","gambling",5.24142222825589
+"3170","Howell, John","problems",3.30024753414967
+"3171","Howell, John","help",3.23819253110551
+"3172","Howell, John","improve",3.21470952478543
+"3173","Howell, John","education",3.09029925147838
+"3174","Howell, John","programmes",2.45190656104554
+"3175","Howell, John","prison",1.62667671330561
+"3176","Howell, John","service",1.42662939826079
+"3177","Howell, John","will",1.35026909276817
+"3178","Howell, John","2010",0
+"3179","Howell, John","accommod",0
+"3180","Howell, John","cost",0
+"3181","Howlett, Ben","intersex",4.27960332856952
+"3182","Howlett, Ben","bias",3.94626999523619
+"3183","Howlett, Ben","charge",3.46024487767565
+"3184","Howlett, Ben","court",3.30151407433889
+"3185","Howlett, Ben","unsold",3.20970249642714
+"3186","Howlett, Ben","will",2.70053818553634
+"3187","Howlett, Ben","criminal",2.59234995408697
+"3188","Howlett, Ben","sold",2.56346187124685
+"3189","Howlett, Ben","gender",2.36130749451503
+"3190","Howlett, Ben","make",2.3524834240613
+"3191","Howlett, Ben","people",2.31937361692415
+"3192","Howlett, Ben","arranging",2.31063979670001
+"3193","Huddleston, Nigel","just",4.2584409454106
+"3194","Huddleston, Nigel","solutions",4.1269237424937
+"3195","Huddleston, Nigel","international",3.67347844468944
+"3196","Huddleston, Nigel","future",3.41940499285428
+"3197","Huddleston, Nigel","2010",0
+"3198","Huddleston, Nigel","accommod",0
+"3199","Huddleston, Nigel","cost",0
+"3200","Huddleston, Nigel","flight",0
+"3201","Huddleston, Nigel","hotel",0
+"3202","Huddleston, Nigel","made",0
+"3203","Huddleston, Nigel","oversea",0
+"3204","Huddleston, Nigel","sinc",0
+"3205","Hunt, Tristram","abolished",6.74625158277387
+"3206","Hunt, Tristram","relocated",6.30772363059964
+"3207","Hunt, Tristram","jobs",5.3671855047875
+"3208","Hunt, Tristram","trent",4.97836360595378
+"3209","Hunt, Tristram","stoke",4.8304991159005
+"3210","Hunt, Tristram","2020",4.15704552076611
+"3211","Hunt, Tristram","ministerial",3.90152950498111
+"3212","Hunt, Tristram","advisory",3.63216282100349
+"3213","Hunt, Tristram","statutory",3.63216282100349
+"3214","Hunt, Tristram","departmental",3.4860860718775
+"3215","Hunt, Tristram","accountable",3.332560299442
+"3216","Hunt, Tristram","executive",3.14280988170643
+"3217","Huppert, Dr Julian","guardianship",3.82911518397058
+"3218","Huppert, Dr Julian","private",3.75931076342241
+"3219","Huppert, Dr Julian","launch",3.47700247201039
+"3220","Huppert, Dr Julian","fund",3.38171246423325
+"3221","Huppert, Dr Julian","missing",3.30024753414967
+"3222","Huppert, Dr Julian","contractors",2.8559968586598
+"3223","Huppert, Dr Julian","longer",2.79507713602794
+"3224","Huppert, Dr Julian","people",2.52049597724189
+"3225","Huppert, Dr Julian","enable",2.40044780630072
+"3226","Huppert, Dr Julian","sector",2.28446104925799
+"3227","Huppert, Dr Julian","consultation",2.26716922706375
+"3228","Huppert, Dr Julian","2014",2.25914598835288
+"3229","Huq, Dr Rupa","fraud",5.12270719125771
+"3230","Huq, Dr Rupa","benefit",4.88118153424702
+"3231","Huq, Dr Rupa","overturned",3.45397930234433
+"3232","Huq, Dr Rupa","model",3.34381835455032
+"3233","Huq, Dr Rupa","convictions",2.78970246787963
+"3234","Huq, Dr Rupa","house",2.5056272969404
+"3235","Huq, Dr Rupa","2014",2.47967095314763
+"3236","Huq, Dr Rupa","merits",2.38879488124569
+"3237","Huq, Dr Rupa","2010",2.36460486887153
+"3238","Huq, Dr Rupa","conducted",2.14172236693794
+"3239","Huq, Dr Rupa","health",2.06981778854298
+"3240","Huq, Dr Rupa","abuse",1.99777331158806
+"3241","Hussain, Imran","humber",8.69921418139776
+"3242","Hussain, Imran","bradford",8.69921418139776
+"3243","Hussain, Imran","yorkshire",6.72932435801164
+"3244","Hussain, Imran","discount",6.47603696789199
+"3245","Hussain, Imran","2008",6.31749534015928
+"3246","Hussain, Imran","brought",5.92243317853965
+"3247","Hussain, Imran","motor",5.37931726179428
+"3248","Hussain, Imran","invasive",4.59436399688715
+"3249","Hussain, Imran","insurance",4.5219250990916
+"3250","Hussain, Imran","mortems",4.09532438060057
+"3251","Hussain, Imran","rate",3.94140335366064
+"3252","Hussain, Imran","olds",3.87567357222911
+"3253","Irranca-Davies, Huw","ogmore",4.53920480163004
+"3254","Irranca-Davies, Huw","books",2.58633074391407
+"3255","Irranca-Davies, Huw","rules",2.48599477855804
+"3256","Irranca-Davies, Huw","governing",2.4340785078348
+"3257","Irranca-Davies, Huw","successful",2.07236382755827
+"3258","Irranca-Davies, Huw","independence",2.06433106747713
+"3259","Irranca-Davies, Huw","provision",1.98343144362119
+"3260","Irranca-Davies, Huw","changed",1.96016690276736
+"3261","Irranca-Davies, Huw","reason",1.91066678394862
+"3262","Irranca-Davies, Huw","payment",1.86017914749879
+"3263","Irranca-Davies, Huw","appeals",1.80697232268411
+"3264","Irranca-Davies, Huw","recently",1.69315355320945
+"3265","Jackson, Stewart","meaningful",3.28349511107287
+"3266","Jackson, Stewart","improve",2.87532361013451
+"3267","Jackson, Stewart","medical",2.82452091497381
+"3268","Jackson, Stewart","education",2.76404767884895
+"3269","Jackson, Stewart","general",2.57357864873072
+"3270","Jackson, Stewart","research",2.50829314895698
+"3271","Jackson, Stewart","encourage",2.47726871917821
+"3272","Jackson, Stewart","taken",2.20831532288614
+"3273","Jackson, Stewart","regulation",2.14858295080525
+"3274","Jackson, Stewart","recent",2.14168866261958
+"3275","Jackson, Stewart","enable",2.10533199844402
+"3276","Jackson, Stewart","potential",1.8254946009211
+"3277","James, Margot","nine",2.89583164068126
+"3278","James, Margot","comply",2.41891817793516
+"3279","James, Margot","wage",2.33362741099141
+"3280","James, Margot","minimum",2.31848137149163
+"3281","James, Margot","employees",2.09400539905898
+"3282","James, Margot","successfully",1.69207797963962
+"3283","James, Margot","legislation",1.66956059398892
+"3284","James, Margot","taken",1.42546141145211
+"3285","James, Margot","companies",1.37932271765388
+"3286","James, Margot","tribunal",1.19364466509723
+"3287","James, Margot","last",0.701619211838426
+"3288","James, Margot","years",0.538411636440705
+"3289","James, Siân C.","english",13.9233191088792
+"3290","James, Siân C.","postcode",9.72944736626902
+"3291","James, Siân C.","welsh",8.56684048025435
+"3292","James, Siân C.","home",5.50116024848311
+"3293","James, Siân C.","women",4.8752831368297
+"3294","James, Siân C.","speakers",4.83317393779203
+"3295","James, Siân C.","recent",4.35413471272306
+"3296","James, Siân C.","wales",3.50784466531371
+"3297","James, Siân C.","held",3.34950849539869
+"3298","James, Siân C.","prisoners",2.87657827658906
+"3299","James, Siân C.","language",2.45861202616093
+"3300","James, Siân C.","whose",2.45861202616093
+"3301","Jamieson, Cathy","scotland",13.4541280842178
+"3302","Jamieson, Cathy","ordinarily",7.13907103398329
+"3303","Jamieson, Cathy","accommodated",6.46366826778517
+"3304","Jamieson, Cathy","units",5.94182402422666
+"3305","Jamieson, Cathy","england",5.59623903778314
+"3306","Jamieson, Cathy","resident",4.75460094144493
+"3307","Jamieson, Cathy","transferred",4.53052402143768
+"3308","Jamieson, Cathy","secure",4.40726896742794
+"3309","Jamieson, Cathy","three",3.33240498878876
+"3310","Jamieson, Cathy","last",3.30290510312086
+"3311","Jamieson, Cathy","people",3.19812787960845
+"3312","Jamieson, Cathy","young",3.19147785481174
+"3313","Jarvis, Dan","secure",66.0776564901709
+"3314","Jarvis, Dan","youth",60.4186317755645
+"3315","Jarvis, Dan","college",60.0510538907783
+"3316","Jarvis, Dan","offender",53.8965254336974
+"3317","Jarvis, Dan","2014",50.566514127082
+"3318","Jarvis, Dan","2010",48.0767962634425
+"3319","Jarvis, Dan","estimate",44.2760755477007
+"3320","Jarvis, Dan","victim",43.5502243321824
+"3321","Jarvis, Dan","official",42.4809079452609
+"3322","Jarvis, Dan","may",40.9921973314718
+"3323","Jarvis, Dan","since",40.3255398628053
+"3324","Jarvis, Dan","homicide",39.4937298984342
+"3325","Jenkin, Bernard","renegotiation",2.23732478865236
+"3326","Jenkin, Bernard","referendum",1.89576681332429
+"3327","Jenkin, Bernard","europe",1.77253590083212
+"3328","Jenkin, Bernard","strategy",1.72698965117216
+"3329","Jenkin, Bernard","specific",1.68797410262003
+"3330","Jenkin, Bernard","relationship",1.62352418315692
+"3331","Jenkin, Bernard","communications",1.5598305574809
+"3332","Jenkin, Bernard","consequences",1.49899186611542
+"3333","Jenkin, Bernard","equivalent",1.49005192633715
+"3334","Jenkin, Bernard","matters",1.4813958426339
+"3335","Jenkin, Bernard","deal",1.44928303582328
+"3336","Jenkin, Bernard","guidelines",1.43454194665231
+"3337","Jenkyns, Andrea","incestuous",3.70624520066165
+"3338","Jenkyns, Andrea","juvenile",2.79116667421482
+"3339","Jenkyns, Andrea","eligibility",2.26286952768758
+"3340","Jenkyns, Andrea","limitations",2.1912990193745
+"3341","Jenkyns, Andrea","apply",1.91939676300868
+"3342","Jenkyns, Andrea","abuse",1.73012243883783
+"3343","Jenkyns, Andrea","compensation",1.72294174052045
+"3344","Jenkyns, Andrea","sexual",1.64819846618054
+"3345","Jenkyns, Andrea","injury",1.6222507563546
+"3346","Jenkyns, Andrea","claim",1.43249061097367
+"3347","Jenkyns, Andrea","criminal",1.29617497704349
+"3348","Jenkyns, Andrea","victims",1.27988985750232
+"3349","Johnson, Alan","ashes",16.1810003887952
+"3350","Johnson, Alan","loss",15.401336951454
+"3351","Johnson, Alan","1996",12.3840172278194
+"3352","Johnson, Alan","son",11.7787339347249
+"3353","Johnson, Alan","hull",11.0741640430826
+"3354","Johnson, Alan","jenni",8.50327192829856
+"3355","Johnson, Alan","murray",8.50327192829856
+"3356","Johnson, Alan","chloe",8.50327192829856
+"3357","Johnson, Alan","louise",8.50327192829856
+"3358","Johnson, Alan","medlam",8.50327192829856
+"3359","Johnson, Alan","angela",8.50327192829856
+"3360","Johnson, Alan","reece",8.50327192829856
+"3361","Johnson, Diana","contrary",71.5598921703988
+"3362","Johnson, Diana","four",63.5846495303506
+"3363","Johnson, Diana","section",63.3017232305761
+"3364","Johnson, Diana","ashes",55.3898559815004
+"3365","Johnson, Diana","convicted",55.3612194147268
+"3366","Johnson, Diana","act",54.9218466124512
+"3367","Johnson, Diana","2003",51.2932352627667
+"3368","Johnson, Diana","hull",49.7683570842388
+"3369","Johnson, Diana","offence",48.9102641268146
+"3370","Johnson, Diana","loss",44.1897669920046
+"3371","Johnson, Diana","people",41.2653486642301
+"3372","Johnson, Diana","sexual",39.3974655318932
+"3373","Johnson, Gareth","video",5.17626973981025
+"3374","Johnson, Gareth","link",4.73737018943293
+"3375","Johnson, Gareth","spaces",3.34075615827703
+"3376","Johnson, Gareth","availability",3.24704836631384
+"3377","Johnson, Gareth","efficiency",3.05756989844826
+"3378","Johnson, Gareth","scope",3.02459750431282
+"3379","Johnson, Gareth","east",3.01646982360171
+"3380","Johnson, Gareth","south",2.99798373223083
+"3381","Johnson, Gareth","infanticide",2.91685822425804
+"3382","Johnson, Gareth","sufficient",2.87734840200197
+"3383","Johnson, Gareth","via",2.86944785508927
+"3384","Johnson, Gareth","manslaughter",2.63950812614542
+"3385","Jones, David","fitting",2.63950812614542
+"3386","Jones, David","contractors",2.50487494800326
+"3387","Jones, David","possible",2.36215802803281
+"3388","Jones, David","construction",2.25717779218662
+"3389","Jones, David","based",2.16178200526272
+"3390","Jones, David","carried",1.89054090537179
+"3391","Jones, David","north",1.77389419847781
+"3392","Jones, David","locally",1.68368862266434
+"3393","Jones, David","new",1.46134501351657
+"3394","Jones, David","work",1.22967839973421
+"3395","Jones, David","wales",1.12533423107726
+"3396","Jones, David","will",0.748994530715365
+"3397","Jones, Gerald","justice",2.11675421758744
+"3398","Jones, Gerald","access",2.10249752392489
+"3399","Jones, Gerald","fees",1.98011699800062
+"3400","Jones, Gerald","effect",1.70551951716527
+"3401","Jones, Gerald","employment",1.61928338317899
+"3402","Jones, Gerald","tribunal",1.5628477230538
+"3403","Jones, Gerald","made",1.07885858922957
+"3404","Jones, Gerald","2010",0
+"3405","Jones, Gerald","accommod",0
+"3406","Jones, Gerald","cost",0
+"3407","Jones, Gerald","flight",0
+"3408","Jones, Gerald","hotel",0
+"3409","Jones, Graham","xiy",4.47514592995118
+"3410","Jones, Graham","xiiy",4.47514592995118
+"3411","Jones, Graham","viiy",4.0934963179748
+"3412","Jones, Graham","191341",4.05998820009529
+"3413","Jones, Graham","hyndburn",4.05998820009529
+"3414","Jones, Graham","100",3.89820921013117
+"3415","Jones, Graham","viy",3.85757293455629
+"3416","Jones, Graham","2004",3.52811301838103
+"3417","Jones, Graham","two",2.88483670983917
+"3418","Jones, Graham","one",2.8286528854175
+"3419","Jones, Graham","previously",2.74265895528933
+"3420","Jones, Graham","submitted",2.53976909264296
+"3421","Jones, Graham P","coroners",5.52821971682987
+"3422","Jones, Graham P","mergers",4.25355453398948
+"3423","Jones, Graham P","offices",3.54416309756273
+"3424","Jones, Graham P","2010",2.67805144448987
+"3425","Jones, Graham P","closed",2.63882327876879
+"3426","Jones, Graham P","subject",2.63850535059248
+"3427","Jones, Graham P","since",2.17572402228897
+"3428","Jones, Graham P","year",1.46637534668953
+"3429","Jones, Graham P","accommod",0
+"3430","Jones, Graham P","cost",0
+"3431","Jones, Graham P","flight",0
+"3432","Jones, Graham P","hotel",0
+"3433","Jones, Helen","warrington",8.33695705818638
+"3434","Jones, Helen","pharmacies",7.24241900527432
+"3435","Jones, Helen","risley",6.95194173614341
+"3436","Jones, Helen","helplines",6.20692149501759
+"3437","Jones, Helen","fraudulent",5.56739137798815
+"3438","Jones, Helen","claims",5.46733911645211
+"3439","Jones, Helen","library",5.39831005274559
+"3440","Jones, Helen","will",5.38982092746641
+"3441","Jones, Helen","region",5.23869107311265
+"3442","Jones, Helen","north",5.07014006902488
+"3443","Jones, Helen","west",5.0062320925133
+"3444","Jones, Helen","officer",4.96968406441986
+"3445","Jones, Kevan","budget",5.05645624230068
+"3446","Jones, Kevan","financial",4.23350843517489
+"3447","Jones, Kevan","departments",3.84814484628999
+"3448","Jones, Kevan","seabrook",3.56084520918548
+"3449","Jones, Kevan","steering",3.56084520918548
+"3450","Jones, Kevan","advertising",3.45397930234433
+"3451","Jones, Kevan","communications",3.1196611149618
+"3452","Jones, Kevan","2014",2.70019591794238
+"3453","Jones, Kevan","2010",2.57489664359247
+"3454","Jones, Kevan","dealing",2.1269660028006
+"3455","Jones, Kevan","contact",2.09493838521941
+"3456","Jones, Kevan","solicitors",2.08480792992019
+"3457","Jones, Susan Elan","motoring",11.0331823904244
+"3458","Jones, Susan Elan","penalties",8.90360474634322
+"3459","Jones, Susan Elan","review",6.10246335798531
+"3460","Jones, Susan Elan","offences",4.98247057566081
+"3461","Jones, Susan Elan","volunteering",4.84726318464957
+"3462","Jones, Susan Elan","sentencing",4.80057609494565
+"3463","Jones, Susan Elan","gcse",3.74376043407845
+"3464","Jones, Susan Elan","transport",3.06491367885045
+"3465","Jones, Susan Elan","purpose",2.84111430253684
+"3466","Jones, Susan Elan","introduce",2.81728965218864
+"3467","Jones, Susan Elan","english",2.74134213243143
+"3468","Jones, Susan Elan","recent",2.69172104103271
+"3469","Kane, Mike","bilateral",4.53920480163004
+"3470","Kane, Mike","indonesia",4.53920480163004
+"3471","Kane, Mike","bribery",4.18611570642329
+"3472","Kane, Mike","corporate",3.88525076247425
+"3473","Kane, Mike","sanctioned",3.53905747505455
+"3474","Kane, Mike","benefits",2.87057950920898
+"3475","Kane, Mike","bodies",2.70642350702279
+"3476","Kane, Mike","length",2.48375095322194
+"3477","Kane, Mike","agreement",2.3578068976639
+"3478","Kane, Mike","progress",2.22180768917454
+"3479","Kane, Mike","prosecuted",2.21655104519923
+"3480","Kane, Mike","establishing",2.17024162081542
+"3481","Kaufman, Sir Gerald","gorton",9.03470388524403
+"3482","Kaufman, Sir Gerald","reply",7.25054451482692
+"3483","Kaufman, Sir Gerald","manchester",6.67556618129739
+"3484","Kaufman, Sir Gerald","intends",6.00603043878435
+"3485","Kaufman, Sir Gerald","regard",5.87275595152519
+"3486","Kaufman, Sir Gerald","letter",5.64492405528252
+"3487","Kaufman, Sir Gerald","hon",4.97337228034181
+"3488","Kaufman, Sir Gerald","member",4.19396103502554
+"3489","Kaufman, Sir Gerald","right",4.17636762832562
+"3490","Kaufman, Sir Gerald","dated",3.69709389007194
+"3491","Kaufman, Sir Gerald","sherratt",3.56084520918548
+"3492","Kaufman, Sir Gerald","lawson",3.43131630145811
+"3493","Kawczynski, Daniel","crematorium",18.3346918000166
+"3494","Kawczynski, Daniel","cremation",14.4128189450783
+"3495","Kawczynski, Daniel","infant",10.3742726366263
+"3496","Kawczynski, Daniel","emstrey",8.08032338579613
+"3497","Kawczynski, Daniel","shrewsbury",7.84032627198999
+"3498","Kawczynski, Daniel","practice",5.73747415187666
+"3499","Kawczynski, Daniel","amending",5.59618052464054
+"3500","Kawczynski, Daniel","sexual",5.17519657778046
+"3501","Kawczynski, Daniel","baby",4.98242670723986
+"3502","Kawczynski, Daniel","regulations",4.82240212562169
+"3503","Kawczynski, Daniel","appoint",4.82240212562169
+"3504","Kawczynski, Daniel","inspector",4.79183368528999
+"3505","Kendall, Liz","gender",4.0899045527932
+"3506","Kendall, Liz","diagnosis",2.74045601321832
+"3507","Kendall, Liz","work",2.55977971500464
+"3508","Kendall, Liz","contesting",2.3871558688598
+"3509","Kendall, Liz","terminal",2.29600991866122
+"3510","Kendall, Liz","dismissal",2.27623243136231
+"3511","Kendall, Liz","appellant",2.17507094485323
+"3512","Kendall, Liz","occurred",2.07163466432223
+"3513","Kendall, Liz","people",2.00863647312371
+"3514","Kendall, Liz","took",1.82774884998356
+"3515","Kendall, Liz","condition",1.71382480225838
+"3516","Kendall, Liz","place",1.31972082617252
+"3517","Kennedy, Seema","enforcement",2.39831793197795
+"3518","Kennedy, Seema","powers",2.33530665718127
+"3519","Kennedy, Seema","child",1.9351289947237
+"3520","Kennedy, Seema","orders",1.63799916070093
+"3521","Kennedy, Seema","custody",1.5287148510861
+"3522","Kennedy, Seema","effectiveness",1.50412683286209
+"3523","Kennedy, Seema","relating",1.50263103586465
+"3524","Kennedy, Seema","made",0.951463842302474
+"3525","Kennedy, Seema","court",0.9481521829499
+"3526","Kennedy, Seema","2010",0
+"3527","Kennedy, Seema","accommod",0
+"3528","Kennedy, Seema","cost",0
+"3529","Khan, Sadiq","prison",140.08961391733
+"3530","Khan, Sadiq","since",137.055922478471
+"3531","Khan, Sadiq","2010",132.749070825404
+"3532","Khan, Sadiq","2014",114.018507964318
+"3533","Khan, Sadiq","2013",102.456749598029
+"3534","Khan, Sadiq","month",94.0496900693222
+"3535","Khan, Sadiq","staff",92.5118071348633
+"3536","Khan, Sadiq","four",78.8814978514677
+"3537","Khan, Sadiq","year",71.2357729491146
+"3538","Khan, Sadiq","2011",67.5203109296565
+"3539","Khan, Sadiq","january",67.2975679789036
+"3540","Khan, Sadiq","2012",59.834654401595
+"3541","Kinahan, Danny","maghaberry",4.53920480163004
+"3542","Kinahan, Danny","accurate",3.74376043407845
+"3543","Kinahan, Danny","reflection",3.32573006579733
+"3544","Kinahan, Danny","motion",2.94542501489603
+"3545","Kinahan, Danny","made",2.92099746072899
+"3546","Kinahan, Danny","inspections",2.79507713602794
+"3547","Kinahan, Danny","staff",2.76025760413122
+"3548","Kinahan, Danny","implications",2.64502412511753
+"3549","Kinahan, Danny","policies",2.58633074391407
+"3550","Kinahan, Danny","bisexual",2.4865935471549
+"3551","Kinahan, Danny","gay",2.41273817701277
+"3552","Kinahan, Danny","inspectorate",2.38696167399542
+"3553","Kinnock, Stephen","existing",5.32429744607477
+"3554","Kinnock, Stephen","determines",5.24050377443425
+"3555","Kinnock, Stephen","steel",3.7512824949958
+"3556","Kinnock, Stephen","category",3.74017004545608
+"3557","Kinnock, Stephen","consistency",3.65449501766502
+"3558","Kinnock, Stephen","incarcerated",3.17229396360707
+"3559","Kinnock, Stephen","public",3.11176542430886
+"3560","Kinnock, Stephen","land",3.01048502121699
+"3561","Kinnock, Stephen","port",2.94626999523619
+"3562","Kinnock, Stephen","talbot",2.94626999523619
+"3563","Kinnock, Stephen","procurement",2.7512824949958
+"3564","Kinnock, Stephen","disturbances",2.68166619902583
+"3565","Kirby, Simon","will",16.466546920421
+"3566","Kirby, Simon","energy",12.9369852867613
+"3567","Kirby, Simon","departmental",8.20050587644921
+"3568","Kirby, Simon","replies",8.03139942389104
+"3569","Kirby, Simon","reduce",7.63566859472221
+"3570","Kirby, Simon","finance",6.72945172075112
+"3571","Kirby, Simon","letter",6.4465950939392
+"3572","Kirby, Simon","member",6.09453870391384
+"3573","Kirby, Simon","email",5.85324376317667
+"3574","Kirby, Simon","initiative",5.57526379685615
+"3575","Kirby, Simon","hon",5.50898476458582
+"3576","Kirby, Simon","porn",5.29447678014953
+"3577","Knight, Julian","landowner",6.12375755597282
+"3578","Knight, Julian","evict",5.18888290441277
+"3579","Knight, Julian","potential",4.38609517400149
+"3580","Knight, Julian","travellers",3.72167073598725
+"3581","Knight, Julian","faster",3.43131630145811
+"3582","Knight, Julian","substantially",3.16405505954568
+"3583","Knight, Julian","whereabouts",3.11386880460654
+"3584","Knight, Julian","easier",3.00771725513075
+"3585","Knight, Julian","get",2.74045601321832
+"3586","Knight, Julian","deny",2.55071852282361
+"3587","Knight, Julian","order",2.54182044034701
+"3588","Knight, Julian","disclose",2.48692330879865
+"3589","Knight, Sir Greg","whiplash",4.77345624840413
+"3590","Knight, Sir Greg","pedal",4.18565141103677
+"3591","Knight, Sir Greg","progress",4.11814167728229
+"3592","Knight, Sir Greg","cyclists",3.41846706944372
+"3593","Knight, Sir Greg","traffic",3.09406845518197
+"3594","Knight, Sir Greg","tackling",3.00614501296026
+"3595","Knight, Sir Greg","bailiffs",2.89583164068126
+"3596","Knight, Sir Greg","methods",2.84021979687721
+"3597","Knight, Sir Greg","road",2.8043569942824
+"3598","Knight, Sir Greg","made",2.69451621748545
+"3599","Knight, Sir Greg","recommendations",2.60213937966508
+"3600","Knight, Sir Greg","scheduled",2.56655550788043
+"3601","Kwarteng, Kwasi","intimidating",3.34381835455032
+"3602","Kwarteng, Kwasi","bailiffs",3.34381835455032
+"3603","Kwarteng, Kwasi","threatening",3.22296166142208
+"3604","Kwarteng, Kwasi","sutton",3.12125570410566
+"3605","Kwarteng, Kwasi","behaviour",2.8154975209766
+"3606","Kwarteng, Kwasi","exercise",2.72879491484764
+"3607","Kwarteng, Kwasi","restrictions",2.67715168788365
+"3608","Kwarteng, Kwasi","put",2.67715168788365
+"3609","Kwarteng, Kwasi","half",2.60137151034255
+"3610","Kwarteng, Kwasi","permitted",2.45144481673503
+"3611","Kwarteng, Kwasi","prevent",2.27214739089337
+"3612","Kwarteng, Kwasi","part",2.14313968319029
+"3613","Lady Hermon","comfort",4.27960332856952
+"3614","Lady Hermon","became",3.5056272969404
+"3615","Lady Hermon","irish",3.26802417241388
+"3616","Lady Hermon","republic",3.09165134229387
+"3617","Lady Hermon","aware",2.5981386221167
+"3618","Lady Hermon","citizens",2.56793651051151
+"3619","Lady Hermon","called",2.48216418764327
+"3620","Lady Hermon","letters",2.34381835455032
+"3621","Lady Hermon","ireland",2.28873718074439
+"3622","Lady Hermon","runs",2.17834307917715
+"3623","Lady Hermon","requested",2.12790132085687
+"3624","Lady Hermon","first",1.91711571481941
+"3625","Lamb, Norman","discount",3.94730576551841
+"3626","Lamb, Norman","nhs",3.60842906640044
+"3627","Lamb, Norman","impact",2.8601548515094
+"3628","Lamb, Norman","illness",2.83896063027373
+"3629","Lamb, Norman","lost",2.79312612235709
+"3630","Lamb, Norman","carried",2.78280086404243
+"3631","Lamb, Norman","rate",2.40238347299035
+"3632","Lamb, Norman","due",2.36130749451503
+"3633","Lamb, Norman","change",2.26340577793866
+"3634","Lamb, Norman","mental",2.11565229645963
+"3635","Lamb, Norman","days",2.02354188697721
+"3636","Lamb, Norman","working",1.47788950752407
+"3637","Lammy, David","unsuccessful",5.47283287324065
+"3638","Lammy, David","claim",3.70003721228442
+"3639","Lammy, David","independence",3.30491378089514
+"3640","Lammy, David","appeal",2.89289243620851
+"3641","Lammy, David","overturned",2.63802026696727
+"3642","Lammy, David","date",2.60665391628477
+"3643","Lammy, David","personal",2.54400837678945
+"3644","Lammy, David","payment",2.46380186574762
+"3645","Lammy, David","died",2.38268209655663
+"3646","Lammy, David","whose",2.36215802803281
+"3647","Lammy, David","2013",2.33850543084391
+"3648","Lammy, David","nicolson",2.30591834514756
+"3649","Latham, Pauline","vulnerable",3.6174821476478
+"3650","Latham, Pauline","traumatisation",3.28349511107287
+"3651","Latham, Pauline","exploitation",2.84390560599304
+"3652","Latham, Pauline","criminal",2.27542005500123
+"3653","Latham, Pauline","old",2.14983689102042
+"3654","Latham, Pauline","limit",2.10533199844402
+"3655","Latham, Pauline","roll",2.00769672750193
+"3656","Latham, Pauline","1999",2.00769672750193
+"3657","Latham, Pauline","start",1.90764872903825
+"3658","Latham, Pauline","cross",1.89356247802408
+"3659","Latham, Pauline","examination",1.88005133912951
+"3660","Latham, Pauline","pre",1.85457900911523
+"3661","Lavery, Ian","oakwood",17.1970676971106
+"3662","Lavery, Ian","prison",17.0002639531601
+"3663","Lavery, Ian","noms",14.2047242082839
+"3664","Lavery, Ian","office",11.6380575577222
+"3665","Lavery, Ian","hour",10.4662817656702
+"3666","Lavery, Ian","staff",10.2633224773084
+"3667","Lavery, Ian","service",10.2160964226202
+"3668","Lavery, Ian","per",10.0035100109598
+"3669","Lavery, Ian","three",9.5948009833522
+"3670","Lavery, Ian","retired",9.46266757204374
+"3671","Lavery, Ian","cells",9.10132325303819
+"3672","Lavery, Ian","increase",8.90668066957461
+"3673","Law, Chris","2952",3.70624520066165
+"3674","Law, Chris","foundation",2.84021979687721
+"3675","Law, Chris","accredited",2.79116667421482
+"3676","Law, Chris","election",2.69307502496926
+"3677","Law, Chris","general",2.45381096204596
+"3678","Law, Chris","scotland",2.42157481515729
+"3679","Law, Chris","status",2.40040534414891
+"3680","Law, Chris","wage",2.33362741099141
+"3681","Law, Chris","2015",2.21243061798648
+"3682","Law, Chris","capacity",2.17814814705622
+"3683","Law, Chris","visit",2.13588299289833
+"3684","Law, Chris","live",2.08541808070087
+"3685","Leech, John","evasion",2.68101913850003
+"3686","Leech, John","unpaid",2.54349367327473
+"3687","Leech, John","television",2.10725164286616
+"3688","Leech, John","outstanding",1.96355682253244
+"3689","Leech, John","imprisoned",1.71833451996371
+"3690","Leech, John","licence",1.54862278059779
+"3691","Leech, John","fines",1.52869926926065
+"3692","Leech, John","non",1.46025410388323
+"3693","Leech, John","payment",1.40616326237426
+"3694","Leech, John","2012",1.28429369325937
+"3695","Leech, John","average",1.26985093858496
+"3696","Leech, John","relating",1.20478511034402
+"3697","Lefroy, Jeremy","staffordshire",2.86944785508927
+"3698","Lefroy, Jeremy","monetary",2.82798898275925
+"3699","Lefroy, Jeremy","value",1.84250251910182
+"3700","Lefroy, Jeremy","written",1.81468553235063
+"3701","Lefroy, Jeremy","fines",1.72460536676267
+"3702","Lefroy, Jeremy","total",1.69731488362794
+"3703","Lefroy, Jeremy","2011",1.63194379018872
+"3704","Lefroy, Jeremy","service",1.05363563824121
+"3705","Lefroy, Jeremy","courts",0.857635918636699
+"3706","Lefroy, Jeremy","since",0.834386702770618
+"3707","Lefroy, Jeremy","year",0.562352613665216
+"3708","Lefroy, Jeremy","2010",0
+"3709","Leslie, Charlotte","grandparents",10.7102576732728
+"3710","Leslie, Charlotte","premises",8.5475979437133
+"3711","Leslie, Charlotte","grandchildren",8.22776402215009
+"3712","Leslie, Charlotte","appeal",8.03649316417496
+"3713","Leslie, Charlotte","approved",7.97081969860007
+"3714","Leslie, Charlotte","cafcass",6.71693388723748
+"3715","Leslie, Charlotte","parental",6.22980888814336
+"3716","Leslie, Charlotte","shorten",5.24142222825589
+"3717","Leslie, Charlotte","immigration",5.13792339621705
+"3718","Leslie, Charlotte","involving",5.13488479589423
+"3719","Leslie, Charlotte","breakdown",4.98242670723986
+"3720","Leslie, Charlotte","process",4.94588743637788
+"3721","Leslie, Chris","confiscation",17.008806781068
+"3722","Leslie, Chris","2012",12.4663385701716
+"3723","Leslie, Chris","2013",11.8270938568228
+"3724","Leslie, Chris","order",11.0107400557345
+"3725","Leslie, Chris","issued",9.6874107519753
+"3726","Leslie, Chris","drug",9.57202729909399
+"3727","Leslie, Chris","crimes",7.32039875445724
+"3728","Leslie, Chris","related",7.0767998277591
+"3729","Leslie, Chris","financial",6.99125164066187
+"3730","Leslie, Chris","collected",6.32286808158941
+"3731","Leslie, Chris","value",5.83798821199433
+"3732","Leslie, Chris","100001",5.17128115982578
+"3733","Lewell-Buck, Emma","remote",7.76641071934013
+"3734","Lewell-Buck, Emma","video",7.36272123471971
+"3735","Lewell-Buck, Emma","conferencing",6.71693388723748
+"3736","Lewell-Buck, Emma","courtrooms",6.57125245465068
+"3737","Lewell-Buck, Emma","reoffending",6.34314021850691
+"3738","Lewell-Buck, Emma","disabled",6.21710080533681
+"3739","Lewell-Buck, Emma","availability",5.62758415157976
+"3740","Lewell-Buck, Emma","recent",5.39110373904582
+"3741","Lewell-Buck, Emma","survey",5.38679528690117
+"3742","Lewell-Buck, Emma","rate",5.18065374333917
+"3743","Lewell-Buck, Emma","sites",4.94797105842804
+"3744","Lewell-Buck, Emma","illiterate",4.85261405031394
+"3745","Lilley, Peter","dickinson",2.94542501489603
+"3746","Lilley, Peter","harpenden",2.94542501489603
+"3747","Lilley, Peter","hitchin",2.94542501489603
+"3748","Lilley, Peter","farm",2.58180967963576
+"3749","Lilley, Peter","hertfordshire",2.58180967963576
+"3750","Lilley, Peter","william",2.4865935471549
+"3751","Lilley, Peter","rural",2.3523939457652
+"3752","Lilley, Peter","behalf",2.2181943443755
+"3753","Lilley, Peter","reply",2.07195789134648
+"3754","Lilley, Peter","cross",1.89356247802408
+"3755","Lilley, Peter","letter",1.61312642360536
+"3756","Lilley, Peter","constituent",1.48690255613631
+"3757","Llwyd, Elfyn","harass",22.7867720816366
+"3758","Llwyd, Elfyn","1997",20.9813689941268
+"3759","Llwyd, Elfyn","victim",17.835226602848
+"3760","Llwyd, Elfyn","court",17.1545469824096
+"3761","Llwyd, Elfyn","england",14.1194230889058
+"3762","Llwyd, Elfyn","wales",14.0622786848861
+"3763","Llwyd, Elfyn","protection",13.5019813641886
+"3764","Llwyd, Elfyn","proceeded",13.265991410854
+"3765","Llwyd, Elfyn","agenda",13.2450696267243
+"3766","Llwyd, Elfyn","stalk",12.691145686777
+"3767","Llwyd, Elfyn","tagging",12.0909917693712
+"3768","Llwyd, Elfyn","act",11.95966589299
+"3769","Lord Ahmed","asylum",7.41254523100646
+"3770","Lord Ahmed","immigration",6.53502923753146
+"3771","Lord Ahmed","hear",4.27503015400431
+"3772","Lord Ahmed","tribunals",4.1349064122639
+"3773","Lord Ahmed","cases",3.95311361236916
+"3774","Lord Ahmed","faith",3.36472586037556
+"3775","Lord Ahmed","handled",3.12645945569042
+"3776","Lord Ahmed","speed",3.01048502121699
+"3777","Lord Ahmed","awaiting",2.94626999523619
+"3778","Lord Ahmed","broken",2.89735370030763
+"3779","Lord Ahmed","england",2.71595892998165
+"3780","Lord Ahmed","wales",2.7049668481226
+"3781","Lord Allen of Kensington","mandatory",7.1513074891339
+"3782","Lord Allen of Kensington","charge",5.52937095133162
+"3783","Lord Allen of Kensington","deterrent",4.85261405031394
+"3784","Lord Allen of Kensington","criminal",4.14250003642603
+"3785","Lord Allen of Kensington","guilty",3.97234016937482
+"3786","Lord Allen of Kensington","reduce",3.53594427438405
+"3787","Lord Allen of Kensington","crime",3.3112637627204
+"3788","Lord Allen of Kensington","knife",3.0974013928151
+"3789","Lord Allen of Kensington","pleaded",3.08461582832913
+"3790","Lord Allen of Kensington","world",2.71544722781206
+"3791","Lord Allen of Kensington","made",2.70310896647793
+"3792","Lord Allen of Kensington","innocent",2.65255729035792
+"3793","Lord Alton of Liverpool","commissioner",20.3110412682731
+"3794","Lord Alton of Liverpool","data",14.9254914166946
+"3795","Lord Alton of Liverpool","information",14.2120069225149
+"3796","Lord Alton of Liverpool","office",13.1159211985916
+"3797","Lord Alton of Liverpool","registration",11.6266529016199
+"3798","Lord Alton of Liverpool","activities",10.4567529953034
+"3799","Lord Alton of Liverpool","income",9.87847710051583
+"3800","Lord Alton of Liverpool","controller",8.58046628957896
+"3801","Lord Alton of Liverpool","financial",8.38972110697669
+"3802","Lord Alton of Liverpool","protection",8.10757116747021
+"3803","Lord Alton of Liverpool","fee",6.96016712279361
+"3804","Lord Alton of Liverpool","spend",5.61683865566567
+"3805","Lord Ashcroft","enquirer",3.43131630145811
+"3806","Lord Ashcroft","excess",2.89679381763326
+"3807","Lord Ashcroft","validly",2.81075491518716
+"3808","Lord Ashcroft","threshold",2.68101913850003
+"3809","Lord Ashcroft","exceed",2.50674431074999
+"3810","Lord Ashcroft","submitted",2.14649665467518
+"3811","Lord Ashcroft","basis",2.06045775222909
+"3812","Lord Ashcroft","freedom",1.99015885026025
+"3813","Lord Ashcroft","can",1.99015885026025
+"3814","Lord Ashcroft","request",1.88618292447905
+"3815","Lord Ashcroft","pays",1.73218905718105
+"3816","Lord Ashcroft","financial",1.49677126136131
+"3817","Lord Avebury","torture",6.15080171414266
+"3818","Lord Avebury","degrading",6.07392938509738
+"3819","Lord Avebury","inhuman",6.07392938509738
+"3820","Lord Avebury","petition",5.77381299446358
+"3821","Lord Avebury","convention",4.59556687315612
+"3822","Lord Avebury","united",4.11188788265532
+"3823","Lord Avebury","article",3.99894344342411
+"3824","Lord Avebury","treatment",3.91425940783146
+"3825","Lord Avebury","1864",3.87104686156941
+"3826","Lord Avebury","149",3.39316268687164
+"3827","Lord Avebury","individual",3.33430674703778
+"3828","Lord Avebury","aston",3.11386880460654
+"3829","Lord Bassam of Brighton","television",4.13451317957031
+"3830","Lord Bassam of Brighton","licences",3.0384606974873
+"3831","Lord Bassam of Brighton","fines",2.99936996027726
+"3832","Lord Bassam of Brighton","non",2.86507777012102
+"3833","Lord Bassam of Brighton","payment",2.75894934551167
+"3834","Lord Bassam of Brighton","sole",2.65255729035792
+"3835","Lord Bassam of Brighton","relating",2.36383724465497
+"3836","Lord Bassam of Brighton","failure",2.34934513237246
+"3837","Lord Bassam of Brighton","guidance",1.93687360077536
+"3838","Lord Bassam of Brighton","broken",1.93156913353842
+"3839","Lord Bassam of Brighton","pay",1.870978020035
+"3840","Lord Bassam of Brighton","sentence",1.83244418886999
+"3841","Lord Beecham","lay",35.1101376621081
+"3842","Lord Beecham","magistracy",31.6438383119018
+"3843","Lord Beecham","light",28.3830820455732
+"3844","Lord Beecham","secure",23.6931751215619
+"3845","Lord Beecham","service",18.743004921739
+"3846","Lord Beecham","estimate",18.3280092356546
+"3847","Lord Beecham","trained",17.4397697186356
+"3848","Lord Beecham","judge",17.2637211147314
+"3849","Lord Beecham","district",17.1441323858037
+"3850","Lord Beecham","college",17.1391248703377
+"3851","Lord Beecham","report",16.6166228754758
+"3852","Lord Beecham","ethnic",16.4773576181512
+"3853","Lord Beith","following",3.09493710611128
+"3854","Lord Beith","liberty",2.71544722781206
+"3855","Lord Beith","deployed",2.64753203626047
+"3856","Lord Beith","riot",2.38933314651331
+"3857","Lord Beith","lack",2.28217092499607
+"3858","Lord Beith","reserve",2.19904944831774
+"3859","Lord Beith","delayed",2.08725981005346
+"3860","Lord Beith","representation",2.06064118462997
+"3861","Lord Beith","birmingham",2.01250952291925
+"3862","Lord Beith","assist",1.91391094884648
+"3863","Lord Beith","disabl",1.85035255851401
+"3864","Lord Beith","rule",1.81551389074173
+"3865","Lord Berkeley","137",3.83209802044349
+"3866","Lord Berkeley","intend",2.64502412511753
+"3867","Lord Berkeley","coroners",2.48599477855804
+"3868","Lord Berkeley","2009",2.33022884507106
+"3869","Lord Berkeley","force",2.18014619849554
+"3870","Lord Berkeley","bring",2.14629028544491
+"3871","Lord Berkeley","section",1.86285668500313
+"3872","Lord Berkeley","act",1.45221735385955
+"3873","Lord Berkeley","2010",0
+"3874","Lord Berkeley","accommod",0
+"3875","Lord Berkeley","cost",0
+"3876","Lord Berkeley","flight",0
+"3877","Lord Bird","juvenile",3.22296166142208
+"3878","Lord Bird","opportunities",3.01048502121699
+"3879","Lord Bird","encourage",2.97730646336668
+"3880","Lord Bird","enterprise",2.97730646336668
+"3881","Lord Bird","adult",2.34381835455032
+"3882","Lord Bird","social",2.20978554002654
+"3883","Lord Bird","systems",1.86680174879449
+"3884","Lord Bird","plans",1.17379912398123
+"3885","Lord Bird","prison",0.597001477233657
+"3886","Lord Bird","2010",0
+"3887","Lord Bird","accommod",0
+"3888","Lord Bird","cost",0
+"3889","Lord Birt","bbc",3.97883593553688
+"3890","Lord Birt","panoramas",3.83209802044349
+"3891","Lord Birt","forgotten",3.70624520066165
+"3892","Lord Birt","retirement",3.6870760901367
+"3893","Lord Birt","drawn",3.62528254494361
+"3894","Lord Birt","lessons",3.41846706944372
+"3895","Lord Birt","mandatory",3.16447422051701
+"3896","Lord Birt","northumberland",3.01117246978229
+"3897","Lord Birt","raise",2.98643750242439
+"3898","Lord Birt","clarify",2.84021979687721
+"3899","Lord Birt","judges",2.59113429973677
+"3900","Lord Birt","plan",2.45414431744762
+"3901","Lord Black of Brentwood","800th",3.55877904927178
+"3902","Lord Black of Brentwood","anniversary",3.55877904927178
+"3903","Lord Black of Brentwood","carta",3.55877904927178
+"3904","Lord Black of Brentwood","magna",3.55877904927178
+"3905","Lord Black of Brentwood","marking",3.00950229978049
+"3906","Lord Black of Brentwood","make",2.23176173334764
+"3907","Lord Black of Brentwood","organisations",2.09026278067585
+"3908","Lord Black of Brentwood","funding",1.69085623211663
+"3909","Lord Black of Brentwood","used",1.51612741877158
+"3910","Lord Black of Brentwood","will",0.853985157455321
+"3911","Lord Black of Brentwood","2010",0
+"3912","Lord Black of Brentwood","accommod",0
+"3913","Lord Blencathra","lawyers",12.8152486247665
+"3914","Lord Blencathra","legal",10.030554740199
+"3915","Lord Blencathra","law",8.75783698306504
+"3916","Lord Blencathra","ethics",8.6743701757097
+"3917","Lord Blencathra","soldiers",8.01682904997713
+"3918","Lord Blencathra","firm",7.98034654387512
+"3919","Lord Blencathra","competition",7.67173404085804
+"3920","Lord Blencathra","regulators",7.65592178583115
+"3921","Lord Blencathra","investigate",7.37536861967986
+"3922","Lord Blencathra","plan",6.47954331732459
+"3923","Lord Blencathra","aid",6.0737231921969
+"3924","Lord Blencathra","representative",5.90096160336178
+"3925","Lord Boateng","inquest",10.0625716277809
+"3926","Lord Boateng","deceased",7.06275265987552
+"3927","Lord Boateng","families",6.27285415845127
+"3928","Lord Boateng","cherry",5.43973698486743
+"3929","Lord Boateng","groce",5.43973698486743
+"3930","Lord Boateng","representation",5.29289150366493
+"3931","Lord Boateng","legal",5.12746481445144
+"3932","Lord Boateng","aid",4.67858949278359
+"3933","Lord Boateng","victims",4.12535989582389
+"3934","Lord Boateng","absence",4.11226662040536
+"3935","Lord Boateng","agency",4.0612999536031
+"3936","Lord Boateng","funded",3.54610563935864
+"3937","Lord Boswell of Aynho","printing",2.52404276975102
+"3938","Lord Boswell of Aynho","competences",2.52404276975102
+"3939","Lord Boswell of Aynho","balance",2.31084205339541
+"3940","Lord Boswell of Aynho","expenses",2.06141320500557
+"3941","Lord Boswell of Aynho","events",1.83158229721375
+"3942","Lord Boswell of Aynho","broken",1.74717001979422
+"3943","Lord Boswell of Aynho","union",1.74717001979422
+"3944","Lord Boswell of Aynho","kingdom",1.71231197294828
+"3945","Lord Boswell of Aynho","engagement",1.66177504627938
+"3946","Lord Boswell of Aynho","associated",1.6436766725033
+"3947","Lord Boswell of Aynho","running",1.39327291484657
+"3948","Lord Boswell of Aynho","united",1.3780805125482
+"3949","Lord Bourne of Aberystwyth","temporary",3.3547634843818
+"3950","Lord Bourne of Aberystwyth","licence",2.89720793317505
+"3951","Lord Bourne of Aberystwyth","training",2.84744498749579
+"3952","Lord Bourne of Aberystwyth","provide",2.75553163590497
+"3953","Lord Bourne of Aberystwyth","magistrates",2.66715124351957
+"3954","Lord Bourne of Aberystwyth","release",2.4629603247393
+"3955","Lord Bourne of Aberystwyth","prisoners",0.895502215850485
+"3956","Lord Bourne of Aberystwyth","2010",0
+"3957","Lord Bourne of Aberystwyth","accommod",0
+"3958","Lord Bourne of Aberystwyth","cost",0
+"3959","Lord Bourne of Aberystwyth","flight",0
+"3960","Lord Bourne of Aberystwyth","hotel",0
+"3961","Lord Bradley","england",12.9470470761607
+"3962","Lord Bradley","month",11.770697919051
+"3963","Lord Bradley","january",11.5948849800775
+"3964","Lord Bradley","wales",11.0801006103794
+"3965","Lord Bradley","licence",10.0149274824841
+"3966","Lord Bradley","2013",9.4719067653769
+"3967","Lord Bradley","prison",7.90933750755755
+"3968","Lord Bradley","place",7.542736709286
+"3969","Lord Bradley","learning",7.54231950597284
+"3970","Lord Bradley","grant",7.43903690389085
+"3971","Lord Bradley","mental",7.12104196522364
+"3972","Lord Bradley","health",6.96676829044447
+"3973","Lord Bradshaw","sharia",5.42424291780459
+"3974","Lord Bradshaw","law",3.3635730101558
+"3975","Lord Bradshaw","concentrated",3.02613653442003
+"3976","Lord Bradshaw","equitable",3.02613653442003
+"3977","Lord Bradshaw","fit",3.00950229978049
+"3978","Lord Bradshaw","escalation",2.89679381763326
+"3979","Lord Bradshaw","compliant",2.81075491518716
+"3980","Lord Bradshaw","march",2.77479023762668
+"3981","Lord Bradshaw","decided",2.7512824949958
+"3982","Lord Bradshaw","availability",2.71667557231756
+"3983","Lord Bradshaw","kingdom",2.67715168788365
+"3984","Lord Bradshaw","profile",2.554732013629
+"3985","Lord Brooke of Alverthorpe","alcohol",5.49754669374958
+"3986","Lord Brooke of Alverthorpe","powdered",5.24142222825589
+"3987","Lord Brooke of Alverthorpe","vaporised",5.24142222825589
+"3988","Lord Brooke of Alverthorpe","prohibit",3.53905747505455
+"3989","Lord Brooke of Alverthorpe","exceeding",2.50674431074999
+"3990","Lord Brooke of Alverthorpe","sales",2.13296626751336
+"3991","Lord Brooke of Alverthorpe","maximum",1.98108604417081
+"3992","Lord Brooke of Alverthorpe","applied",1.77701610263181
+"3993","Lord Brooke of Alverthorpe","introduced",1.6836525965388
+"3994","Lord Brooke of Alverthorpe","previous",1.67952874473341
+"3995","Lord Brooke of Alverthorpe","age",1.5428245289524
+"3996","Lord Brooke of Alverthorpe","fine",1.52869926926065
+"3997","Lord Browne of Belmont","northern",9.27786154287957
+"3998","Lord Browne of Belmont","ireland",9.18349365135044
+"3999","Lord Browne of Belmont","last",6.24219568633448
+"4000","Lord Browne of Belmont","annual",6.17945170387078
+"4001","Lord Browne of Belmont","year",6.03938086584385
+"4002","Lord Browne of Belmont","prison",5.81969593532991
+"4003","Lord Browne of Belmont","britain",5.68043959375442
+"4004","Lord Browne of Belmont","great",5.68043959375442
+"4005","Lord Browne of Belmont","transfer",5.52063078682714
+"4006","Lord Browne of Belmont","past",5.15188655992458
+"4007","Lord Browne of Belmont","five",5.11156409990413
+"4008","Lord Browne of Belmont","three",4.25754252435664
+"4009","Lord Campbell-Savours","polygraph",5.45152583126225
+"4010","Lord Campbell-Savours","test",3.71155798835761
+"4011","Lord Campbell-Savours","detector",3.16405505954568
+"4012","Lord Campbell-Savours","furtherance",3.02613653442003
+"4013","Lord Campbell-Savours","lie",3.00771725513075
+"4014","Lord Campbell-Savours","sexual",2.91069896043512
+"4015","Lord Campbell-Savours","accumulation",2.79043427402451
+"4016","Lord Campbell-Savours","threshold",2.36443663355857
+"4017","Lord Campbell-Savours","persons",2.29128919531582
+"4018","Lord Campbell-Savours","repeat",2.15393452839683
+"4019","Lord Campbell-Savours","criminal",2.14732724050175
+"4020","Lord Campbell-Savours","statistics",2.14649665467518
+"4021","Lord Clinton-Davis","suicides",3.65762401482577
+"4022","Lord Clinton-Davis","reduce",2.88099719432886
+"4023","Lord Clinton-Davis","number",2.08673703426169
+"4024","Lord Clinton-Davis","prisons",0.895502215850485
+"4025","Lord Clinton-Davis","2010",0
+"4026","Lord Clinton-Davis","accommod",0
+"4027","Lord Clinton-Davis","cost",0
+"4028","Lord Clinton-Davis","flight",0
+"4029","Lord Clinton-Davis","hotel",0
+"4030","Lord Clinton-Davis","intern",0
+"4031","Lord Clinton-Davis","made",0
+"4032","Lord Clinton-Davis","oversea",0
+"4033","Lord Condon","whilst",3.21907877554606
+"4034","Lord Condon","suicide",2.76490386645903
+"4035","Lord Condon","reduce",2.17782917259114
+"4036","Lord Condon","committing",2.11315494728616
+"4037","Lord Condon","number",1.57742492692712
+"4038","Lord Condon","people",1.31496124024836
+"4039","Lord Condon","prison",0.676936046185048
+"4040","Lord Condon","2010",0
+"4041","Lord Condon","accommod",0
+"4042","Lord Condon","cost",0
+"4043","Lord Condon","flight",0
+"4044","Lord Condon","hotel",0
+"4045","Lord Cormack","taylor",4.42492564732817
+"4046","Lord Cormack","intend",3.05421078129932
+"4047","Lord Cormack","youth",2.37003931176902
+"4048","Lord Cormack","system",2.28635586774091
+"4049","Lord Cormack","publish",1.8532847425453
+"4050","Lord Cormack","review",1.8135226806377
+"4051","Lord Cormack","2010",0
+"4052","Lord Cormack","accommod",0
+"4053","Lord Cormack","cost",0
+"4054","Lord Cormack","flight",0
+"4055","Lord Cormack","hotel",0
+"4056","Lord Cormack","intern",0
+"4057","Lord Donoughue","374)",2.94542501489603
+"4058","Lord Donoughue","mauley",2.94542501489603
+"4059","Lord Donoughue","owner",2.4865935471549
+"4060","Lord Donoughue","rspca",2.41273817701277
+"4061","Lord Donoughue","permission",2.0491228417525
+"4062","Lord Donoughue","entry",2.02776207941378
+"4063","Lord Donoughue","attempting",1.89356247802408
+"4064","Lord Donoughue","property",1.81970710788194
+"4065","Lord Donoughue","without",1.63765445357379
+"4066","Lord Donoughue","make",1.61909013344806
+"4067","Lord Donoughue","inspector",1.5488652597608
+"4068","Lord Donoughue","home",1.45978987748074
+"4069","Lord Eames","disaster",3.56953551699164
+"4070","Lord Eames","advocate",2.91527851217387
+"4071","Lord Eames","remit",2.72308615973505
+"4072","Lord Eames","bereavement",2.59024852532215
+"4073","Lord Eames","extend",2.45381096204596
+"4074","Lord Eames","consequences",2.3915636803915
+"4075","Lord Eames","areas",1.76731781033951
+"4076","Lord Eames","proposed",1.44722158815617
+"4077","Lord Eames","public",1.28258327482729
+"4078","Lord Eames","cases",1.19190860053409
+"4079","Lord Eames","planning",1.06174125640735
+"4080","Lord Eames","2010",0
+"4081","Lord Empey","1970",5.71919279725448
+"4082","Lord Empey","lodged",4.70279501776016
+"4083","Lord Empey","damage",4.16466642062286
+"4084","Lord Empey","1987",3.70624520066165
+"4085","Lord Empey","1998",3.6564675308757
+"4086","Lord Empey","respect",3.34947915485908
+"4087","Lord Empey","troubles",3.05676759423755
+"4088","Lord Empey","whole",3.03596229535056
+"4089","Lord Empey","compensation",3.0331572577615
+"4090","Lord Empey","paid",2.89635690982995
+"4091","Lord Empey","pardons",2.89583164068126
+"4092","Lord Empey","injuries",2.85589555341533
+"4093","Lord Falconer of Thoroton","written",30.2572733722049
+"4094","Lord Falconer of Thoroton","faulks",25.2153967624031
+"4095","Lord Falconer of Thoroton","lord",22.6545768983189
+"4096","Lord Falconer of Thoroton","july",16.2360678341544
+"4097","Lord Falconer of Thoroton","hlws108",15.0566333928281
+"4098","Lord Falconer of Thoroton","prison",14.9010107836745
+"4099","Lord Falconer of Thoroton","june",14.5224306648487
+"4100","Lord Falconer of Thoroton","year",13.7749391130138
+"4101","Lord Falconer of Thoroton","offender",13.4475396376906
+"4102","Lord Falconer of Thoroton","hc38271",13.4470370287552
+"4103","Lord Falconer of Thoroton","court",13.4281377232945
+"4104","Lord Falconer of Thoroton","since",13.2952464967754
+"4105","Lord Fellowes","encouraged",2.57842303212715
+"4106","Lord Fellowes","behaviour",2.43829237745785
+"4107","Lord Fellowes","chancellor",2.16993689156612
+"4108","Lord Fellowes","books",2.1117302095541
+"4109","Lord Fellowes","considers",2.07700425544466
+"4110","Lord Fellowes","preventing",1.96773736165619
+"4111","Lord Fellowes","post",1.93096612321457
+"4112","Lord Fellowes","lord",1.76800947214676
+"4113","Lord Fellowes","rehabilitation",1.41006651016715
+"4114","Lord Fellowes","receiving",1.26068321790348
+"4115","Lord Fellowes","will",0.779578224188134
+"4116","Lord Fellowes","prisoners",0.517018445381184
+"4117","Lord Foulkes of Cumnock","writs",10.460179092108
+"4118","Lord Foulkes of Cumnock","summons",7.14596692123155
+"4119","Lord Foulkes of Cumnock","hl5044",6.52923801341878
+"4120","Lord Foulkes of Cumnock","sent",6.48851173345523
+"4121","Lord Foulkes of Cumnock","peers",6.29939739256132
+"4122","Lord Foulkes of Cumnock","undelivered",4.85261405031394
+"4123","Lord Foulkes of Cumnock","faulks",3.98417318245456
+"4124","Lord Foulkes of Cumnock","lord",3.37776678472328
+"4125","Lord Foulkes of Cumnock","written",3.31934328817397
+"4126","Lord Foulkes of Cumnock","corrected",2.56346187124685
+"4127","Lord Foulkes of Cumnock","returned",2.51308027289728
+"4128","Lord Foulkes of Cumnock","house",2.26642516593374
+"4129","Lord German","429)",5.70400598431232
+"4130","Lord German","buscombe",5.70400598431232
+"4131","Lord German","baroness",4.83321210353902
+"4132","Lord German","community",4.59581076752826
+"4133","Lord German","rehabilitation",4.54617627548094
+"4134","Lord German","companies",4.44705563178481
+"4135","Lord German","col",4.2585889218209
+"4136","Lord German","deb",4.2585889218209
+"4137","Lord German","concerning",3.57140645112872
+"4138","Lord German","contract",3.4255480768552
+"4139","Lord German","vocational",3.12889493147202
+"4140","Lord German","deliver",2.96255763274197
+"4141","Lord Goodlad","affirmative",3.20970249642714
+"4142","Lord Goodlad","drafts",3.20970249642714
+"4143","Lord Goodlad","superseded",3.20970249642714
+"4144","Lord Goodlad","instrument",2.81346187124685
+"4145","Lord Goodlad","laid",2.70970249642714
+"4146","Lord Goodlad","corrected",2.56346187124685
+"4147","Lord Goodlad","calendar",2.50786376591274
+"4148","Lord Goodlad","errors",2.3792204727053
+"4149","Lord Goodlad","drafts",2.23297984752501
+"4150","Lord Goodlad","statutory",2.07881200741289
+"4151","Lord Goodlad","percentage",2.02098062088627
+"4152","Lord Goodlad","need",1.79159616093427
+"4153","Lord Hamilton of Epsom","european",3.35210899666758
+"4154","Lord Hamilton of Epsom","650/13)",3.31496648398472
+"4155","Lord Hamilton of Epsom","commune",3.31496648398472
+"4156","Lord Hamilton of Epsom","idelvigne",3.31496648398472
+"4157","Lord Hamilton of Epsom","lesparre",3.31496648398472
+"4158","Lord Hamilton of Epsom","mdoc",3.31496648398472
+"4159","Lord Hamilton of Epsom","charter",2.81075491518716
+"4160","Lord Hamilton of Epsom","fundamental",2.81075491518716
+"4161","Lord Hamilton of Epsom","settlement",2.50674431074999
+"4162","Lord Hamilton of Epsom","affect",2.29600991866122
+"4163","Lord Hamilton of Epsom","judgment",2.21815631628716
+"4164","Lord Hamilton of Epsom","concerning",1.98108604417081
+"4165","Lord Hardie","646)",4.55910644768486
+"4166","Lord Hardie","remarks",4.33383834118504
+"4167","Lord Hardie","forum",4.17400807604206
+"4168","Lord Hardie","chair",3.72347186304243
+"4169","Lord Hardie","col",3.40381133275647
+"4170","Lord Hardie","deb",3.40381133275647
+"4171","Lord Hardie","capacity",2.7819892011121
+"4172","Lord Hardie","faulks",2.7819892011121
+"4173","Lord Hardie","appointment",2.61651848639541
+"4174","Lord Hardie","soon",2.51789779417069
+"4175","Lord Hardie","mental",2.44420276298685
+"4176","Lord Hardie","lord",2.35855980366448
+"4177","Lord Harris of Haringey","defaulting",8.28851855207134
+"4178","Lord Harris of Haringey","tax",6.75086497315386
+"4179","Lord Harris of Haringey","imprisoned",5.59956083124307
+"4180","Lord Harris of Haringey","council",5.50012609751765
+"4181","Lord Harris of Haringey","profile",4.09668510429549
+"4182","Lord Harris of Haringey","nspcc",3.94626999523619
+"4183","Lord Harris of Haringey","three",3.83936175686576
+"4184","Lord Harris of Haringey","payment",3.12303938994237
+"4185","Lord Harris of Haringey","instances",2.9660198676456
+"4186","Lord Harris of Haringey","projections",2.9627916852678
+"4187","Lord Harris of Haringey","population",2.74169664195257
+"4188","Lord Harris of Haringey","future",2.58482721225858
+"4189","Lord Hennessy of Nympsfield","adaptation",3.94626999523619
+"4190","Lord Hennessy of Nympsfield","drawn",3.41794916166247
+"4191","Lord Hennessy of Nympsfield","contingency",3.27960332856952
+"4192","Lord Hennessy of Nympsfield","event",2.86362749075499
+"4193","Lord Hennessy of Nympsfield","withdrawal",2.86362749075499
+"4194","Lord Hennessy of Nympsfield","parliament",2.67715168788365
+"4195","Lord Hennessy of Nympsfield","law",1.86680174879449
+"4196","Lord Hennessy of Nympsfield","plans",1.17379912398123
+"4197","Lord Hennessy of Nympsfield","will",0.900179395178779
+"4198","Lord Hennessy of Nympsfield","2010",0
+"4199","Lord Hennessy of Nympsfield","accommod",0
+"4200","Lord Hennessy of Nympsfield","cost",0
+"4201","Lord Hodgson of Astley Abbotts","funders",8.93608349195347
+"4202","Lord Hodgson of Astley Abbotts","litigation",5.36088674086983
+"4203","Lord Hodgson of Astley Abbotts","third",4.6971569832168
+"4204","Lord Hodgson of Astley Abbotts","statutory",4.58595362133072
+"4205","Lord Hodgson of Astley Abbotts","party",4.10682512576973
+"4206","Lord Hodgson of Astley Abbotts","rapid",3.87104686156941
+"4207","Lord Hodgson of Astley Abbotts","firms",3.81781461066932
+"4208","Lord Hodgson of Astley Abbotts","regulation",3.74719743007124
+"4209","Lord Hodgson of Astley Abbotts","introduce",3.47432908967482
+"4210","Lord Hodgson of Astley Abbotts","238)",3.43131630145811
+"4211","Lord Hodgson of Astley Abbotts","expansion",3.39316268687164
+"4212","Lord Hodgson of Astley Abbotts","field",2.70970249642714
+"4213","Lord Hoyle","three",3.59940877240346
+"4214","Lord Hoyle","occurred",3.16447422051701
+"4215","Lord Hoyle","assaults",2.65318930278093
+"4216","Lord Hoyle","deaths",2.52321877287561
+"4217","Lord Hoyle","last",1.98447881000685
+"4218","Lord Hoyle","officers",1.84033965476906
+"4219","Lord Hoyle","years",1.52285807678787
+"4220","Lord Hoyle","prison",1.46234899491025
+"4221","Lord Hoyle","2010",0
+"4222","Lord Hoyle","accommod",0
+"4223","Lord Hoyle","cost",0
+"4224","Lord Hoyle","flight",0
+"4225","Lord Hunt of Chesterton","trends",2.50249153962001
+"4226","Lord Hunt of Chesterton","weapons",2.45861202616093
+"4227","Lord Hunt of Chesterton","dangerous",2.40040534414891
+"4228","Lord Hunt of Chesterton","inmates",2.31848137149163
+"4229","Lord Hunt of Chesterton","violent",2.25005404930656
+"4230","Lord Hunt of Chesterton","remove",2.22554873537017
+"4231","Lord Hunt of Chesterton","incidents",1.64229098861976
+"4232","Lord Hunt of Chesterton","staff",1.18966878587893
+"4233","Lord Hunt of Chesterton","five",1.07383365913102
+"4234","Lord Hunt of Chesterton","last",0.701619211838426
+"4235","Lord Hunt of Chesterton","years",0.538411636440705
+"4236","Lord Hunt of Chesterton","prison",0.517018445381184
+"4237","Lord Hylton","parole",5.52128735785015
+"4238","Lord Hylton","unite",3.59344518056598
+"4239","Lord Hylton","reunion",3.56084520918548
+"4240","Lord Hylton","attitudes",3.43131630145811
+"4241","Lord Hylton","lifestyles",3.43131630145811
+"4242","Lord Hylton","board",3.13793755784454
+"4243","Lord Hylton","evidence",3.09438711254217
+"4244","Lord Hylton","consideration",3.05543550134056
+"4245","Lord Hylton","reinstate",3.03596229535056
+"4246","Lord Hylton","insists",3.02613653442003
+"4247","Lord Hylton","unwilling",3.02613653442003
+"4248","Lord Hylton","light",3.02583209182232
+"4249","Lord Inglewood","bakers",2.51789779417069
+"4250","Lord Inglewood","extradition",2.51789779417069
+"4251","Lord Inglewood","sir",2.06253023013261
+"4252","Lord Inglewood","scott",2.01094493905212
+"4253","Lord Inglewood","analysis",1.77121406175741
+"4254","Lord Inglewood","prepared",1.70010821907173
+"4255","Lord Inglewood","means",1.65649347691521
+"4256","Lord Inglewood","kingdoms",1.57509792661922
+"4257","Lord Inglewood","removing",1.51196263285752
+"4258","Lord Inglewood","intend",1.46719540122316
+"4259","Lord Inglewood","testing",1.44721516507234
+"4260","Lord Inglewood","considered",1.41104653095635
+"4261","Lord Jones of Cheltenham","tagging",4.93671752179437
+"4262","Lord Jones of Cheltenham","electronic",4.65912168047508
+"4263","Lord Jones of Cheltenham","gps",3.41794916166247
+"4264","Lord Jones of Cheltenham","mandation",3.12125570410566
+"4265","Lord Jones of Cheltenham","persistent",3.00614501296026
+"4266","Lord Jones of Cheltenham","priority",3.00614501296026
+"4267","Lord Jones of Cheltenham","integrated",2.91685822425804
+"4268","Lord Jones of Cheltenham","technology",2.71279008918916
+"4269","Lord Jones of Cheltenham","delays",2.69464082784836
+"4270","Lord Jones of Cheltenham","address",2.58378238148607
+"4271","Lord Jones of Cheltenham","extend",2.25717779218662
+"4272","Lord Jones of Cheltenham","plans",2.15045903058332
+"4273","Lord Jopling","365)",4.27960332856952
+"4274","Lord Jopling","newby",4.27960332856952
+"4275","Lord Jopling","now",2.71279008918916
+"4276","Lord Jopling","put",2.67715168788365
+"4277","Lord Jopling","lord",2.04152148934748
+"4278","Lord Jopling","written",2.00621034109779
+"4279","Lord Jopling","may",1.67930336192942
+"4280","Lord Jopling","answer",1.30664891614466
+"4281","Lord Jopling","will",0.900179395178779
+"4282","Lord Jopling","2010",0
+"4283","Lord Jopling","accommod",0
+"4284","Lord Jopling","cost",0
+"4285","Lord Judd","evaluate",3.92850578372976
+"4286","Lord Judd","respond",3.51886513677103
+"4287","Lord Judd","immediate",3.47960280697864
+"4288","Lord Judd","make",3.1681104354564
+"4289","Lord Judd","arrangements",3.11175924881476
+"4290","Lord Judd","recommendations",3.09052357263342
+"4291","Lord Judd","light",3.0699621600199
+"4292","Lord Judd","ichanging",3.02613653442003
+"4293","Lord Judd","lives/",3.02613653442003
+"4294","Lord Judd","action",2.94184425440126
+"4295","Lord Judd","iimproving",2.73724348610663
+"4296","Lord Judd","harris",2.47885283397922
+"4297","Lord Kennedy of Southwark","brixton",24.3813468238097
+"4298","Lord Kennedy of Southwark","hmp",20.2086127162435
+"4299","Lord Kennedy of Southwark","worship",8.94929915460943
+"4300","Lord Kennedy of Southwark","claims",7.34620343901486
+"4301","Lord Kennedy of Southwark","plan",7.2978338041373
+"4302","Lord Kennedy of Southwark","opportunities",7.10064524377605
+"4303","Lord Kennedy of Southwark","wandsworth",6.42394910520913
+"4304","Lord Kennedy of Southwark","freedom",6.08003571753592
+"4305","Lord Kennedy of Southwark","prison",6.00582656377423
+"4306","Lord Kennedy of Southwark","facilities",5.92558337053561
+"4307","Lord Kennedy of Southwark","magistracy",5.92006160568685
+"4308","Lord Kennedy of Southwark","industrial",5.85660828177442
+"4309","Lord Kinnock","oath",3.00771725513075
+"4310","Lord Kinnock","constitutional",2.58411820880339
+"4311","Lord Kinnock","contained",2.19019352891621
+"4312","Lord Kinnock","judiciary",2.16051916247603
+"4313","Lord Kinnock","amend",2.10725164286616
+"4314","Lord Kinnock","2005",2.06045775222909
+"4315","Lord Kinnock","chancellor",2.00897118944989
+"4316","Lord Kinnock","defend",1.72751534579565
+"4317","Lord Kinnock","lord",1.63685870590173
+"4318","Lord Kinnock","independence",1.56048760807113
+"4319","Lord Kinnock","reform",1.50191235710431
+"4320","Lord Kinnock","office",1.20478511034402
+"4321","Lord Knight of Weymouth","percentage",7.49307826941912
+"4322","Lord Knight of Weymouth","kingdom",7.44444563041726
+"4323","Lord Knight of Weymouth","united",5.99134130466804
+"4324","Lord Knight of Weymouth","custody",5.57485463578121
+"4325","Lord Knight of Weymouth","change",5.13897108445827
+"4326","Lord Knight of Weymouth","pentonville",4.16613934830755
+"4327","Lord Knight of Weymouth","prison",3.60759734720811
+"4328","Lord Knight of Weymouth","committed",3.31862407648584
+"4329","Lord Knight of Weymouth","kept",3.12889493147202
+"4330","Lord Knight of Weymouth","fulfilment",3.12889493147202
+"4331","Lord Knight of Weymouth","hmp",3.01825163239317
+"4332","Lord Knight of Weymouth","last",2.95445856608649
+"4333","Lord Laird","death",8.75056327391906
+"4334","Lord Laird","instigated",8.11983996731891
+"4335","Lord Laird","inquiries",8.09829943632682
+"4336","Lord Laird","define",7.98895157032486
+"4337","Lord Laird","1988",7.24339653875041
+"4338","Lord Laird","single",6.0167241521483
+"4339","Lord Laird","coroners",5.49133406743478
+"4340","Lord Laird","individual",4.86866317281327
+"4341","Lord Laird","someone",4.84726318464957
+"4342","Lord Laird","opposed",4.84726318464957
+"4343","Lord Laird","200304",4.53920480163004
+"4344","Lord Laird","sudden",4.27960332856952
+"4345","Lord Laming","jointreport",3.43131630145811
+"4346","Lord Laming","gate",2.62953257572083
+"4347","Lord Laming","inspection",2.36227133380841
+"4348","Lord Laming","resettlement",2.23948306883757
+"4349","Lord Laming","address",2.07163466432223
+"4350","Lord Laming","intend",1.99945029909348
+"4351","Lord Laming","concerns",1.98108604417081
+"4352","Lord Laming","raised",1.95508227330209
+"4353","Lord Laming","inspectorate",1.8043734224098
+"4354","Lord Laming","services",1.41432391552654
+"4355","Lord Laming","probation",1.34128555998561
+"4356","Lord Laming","months",1.08090979512305
+"4357","Lord Lamont of Lerwick","political",2.55071852282361
+"4358","Lord Lamont of Lerwick","guide",2.43298522388647
+"4359","Lord Lamont of Lerwick","supreme",2.34504906306343
+"4360","Lord Lamont of Lerwick","chancellor",1.82311164771461
+"4361","Lord Lamont of Lerwick","concerns",1.79780629071224
+"4362","Lord Lamont of Lerwick","enforcing",1.74503261600435
+"4363","Lord Lamont of Lerwick","judicial",1.73130909458525
+"4364","Lord Lamont of Lerwick","conduct",1.64262607127272
+"4365","Lord Lamont of Lerwick","activity",1.62729931706721
+"4366","Lord Lamont of Lerwick","close",1.56769463149354
+"4367","Lord Lamont of Lerwick","lord",1.48542507133199
+"4368","Lord Lamont of Lerwick","justices",1.35829778688838
+"4369","Lord Lester of Herne Hill","lord",23.2505254426628
+"4370","Lord Lester of Herne Hill","right",18.9440679955906
+"4371","Lord Lester of Herne Hill","human",18.3204618333439
+"4372","Lord Lester of Herne Hill","fees",16.8535510494701
+"4373","Lord Lester of Herne Hill","european",16.5499237033236
+"4374","Lord Lester of Herne Hill","1998",15.8151488593617
+"4375","Lord Lester of Herne Hill","act",15.0773345706447
+"4376","Lord Lester of Herne Hill","tribunal",13.8824514554309
+"4377","Lord Lester of Herne Hill","chancellor",13.782059460295
+"4378","Lord Lester of Herne Hill","defamation",13.7336480581511
+"4379","Lord Lester of Herne Hill","intend",12.6677086679137
+"4380","Lord Lester of Herne Hill","impact",12.4997955664683
+"4381","Lord Lloyd of Berwick","225",2.19841182391001
+"4382","Lord Lloyd of Berwick","likelihood",2.19841182391001
+"4383","Lord Lloyd of Berwick","still",1.65861579171479
+"4384","Lord Lloyd of Berwick","2007",1.58154526293005
+"4385","Lord Lloyd of Berwick","tariffs",1.5684742928832
+"4386","Lord Lloyd of Berwick","amended",1.46413600283427
+"4387","Lord Lloyd of Berwick","less",1.38277895470615
+"4388","Lord Lloyd of Berwick","risk",1.34148171881807
+"4389","Lord Lloyd of Berwick","harm",1.3204590362257
+"4390","Lord Lloyd of Berwick","2003",1.30570842592141
+"4391","Lord Lloyd of Berwick","reoffending",1.23104061946196
+"4392","Lord Lloyd of Berwick","two",1.22744456891189
+"4393","Lord MacKenzie of Culkein","suspects",2.84021979687721
+"4394","Lord MacKenzie of Culkein","union",2.36567939003947
+"4395","Lord MacKenzie of Culkein","consideration",2.33362741099141
+"4396","Lord MacKenzie of Culkein","scotland",2.31848137149163
+"4397","Lord MacKenzie of Culkein","remains",2.13981749225093
+"4398","Lord MacKenzie of Culkein","european",1.84156790874553
+"4399","Lord MacKenzie of Culkein","transfer",1.73012243883783
+"4400","Lord MacKenzie of Culkein","independent",1.68551925849796
+"4401","Lord MacKenzie of Culkein","given",1.6393683788356
+"4402","Lord MacKenzie of Culkein","member",1.50806781151124
+"4403","Lord MacKenzie of Culkein","criminals",1.29617497704349
+"4404","Lord MacKenzie of Culkein","convicted",1.1600788515361
+"4405","Lord Maginnis of Drumglass","bbc",4.9033267873554
+"4406","Lord Maginnis of Drumglass","broadcast",4.72249401077071
+"4407","Lord Maginnis of Drumglass","panorama",4.72249401077071
+"4408","Lord Maginnis of Drumglass","expert",4.08661635563775
+"4409","Lord Maginnis of Drumglass","compliant",3.71827925096883
+"4410","Lord Maginnis of Drumglass","note",3.62528254494361
+"4411","Lord Maginnis of Drumglass","sale",3.4772652310262
+"4412","Lord Maginnis of Drumglass","allegations",3.32412792473218
+"4413","Lord Maginnis of Drumglass","intend",3.25960101296311
+"4414","Lord Maginnis of Drumglass","sharia",3.19310155974459
+"4415","Lord Maginnis of Drumglass","regarding",3.18727010187302
+"4416","Lord Maginnis of Drumglass","rules",3.06362086510222
+"4417","Lord Marks of Henley-on-Thames","month",4.7025501981088
+"4418","Lord Marks of Henley-on-Thames","licences",3.67855407435598
+"4419","Lord Marks of Henley-on-Thames","women",3.57997651931585
+"4420","Lord Marks of Henley-on-Thames","watch",3.09165134229387
+"4421","Lord Marks of Henley-on-Thames","least",3.09165134229387
+"4422","Lord Marks of Henley-on-Thames","owe",3.02459750431282
+"4423","Lord Marks of Henley-on-Thames","place",2.97769177393061
+"4424","Lord Marks of Henley-on-Thames","shortage",2.96651282783612
+"4425","Lord Marks of Henley-on-Thames","last",2.82599940066193
+"4426","Lord Marks of Henley-on-Thames","broken",2.73165126531128
+"4427","Lord Marks of Henley-on-Thames","space",2.66500148325835
+"4428","Lord Marks of Henley-on-Thames","turnover",2.59011055998321
+"4429","Lord Marlesford","escape",5.45486106640198
+"4430","Lord Marlesford","uncaptured",4.27960332856952
+"4431","Lord Marlesford","freelance",4.27960332856952
+"4432","Lord Marlesford","virtue",4.27960332856952
+"4433","Lord Marlesford","recaptured",3.94626999523619
+"4434","Lord Marlesford","journalists",3.7512824949958
+"4435","Lord Marlesford","passport",3.41757006606683
+"4436","Lord Marlesford","occupation",3.34381835455032
+"4437","Lord Marlesford","large",3.08461582832913
+"4438","Lord Marlesford","custodial",3.05730560539953
+"4439","Lord Marlesford","circumstances",2.8154975209766
+"4440","Lord Marlesford","absconded",2.67747102833134
+"4441","Lord Mawson","journalists",2.65255729035792
+"4442","Lord Mawson","enacted",2.554732013629
+"4443","Lord Mawson","opposed",2.554732013629
+"4444","Lord Mawson","originate",1.83716143816139
+"4445","Lord Mawson","freedom",1.75515512910095
+"4446","Lord Mawson","requests",1.66345698178269
+"4447","Lord Mawson","purse",1.51542860301384
+"4448","Lord Mawson","scheme",1.45343079899702
+"4449","Lord Mawson","legislation",1.36319051664362
+"4450","Lord Mawson","members",1.23133221190609
+"4451","Lord Mawson","information",1.15131448443217
+"4452","Lord Mawson","estimate",1.10046674431824
+"4453","Lord McColl of Dulwich","53a",2.65255729035792
+"4454","Lord McColl of Dulwich","arrested",1.89303211276754
+"4455","Lord McColl of Dulwich","came",1.80757352550478
+"4456","Lord McColl of Dulwich","2003",1.65732985237203
+"4457","Lord McColl of Dulwich","imposed",1.64539717251449
+"4458","Lord McColl of Dulwich","penalty",1.5276471563495
+"4459","Lord McColl of Dulwich","force",1.45343079899702
+"4460","Lord McColl of Dulwich","charged",1.41263905589742
+"4461","Lord McColl of Dulwich","sexual",1.34574841232674
+"4462","Lord McColl of Dulwich","provision",1.3222876290808
+"4463","Lord McColl of Dulwich","section",1.24190445666875
+"4464","Lord McColl of Dulwich","act",0.968144902573035
+"4465","Lord Mendelsohn","businesses",5.96836319744033
+"4466","Lord Mendelsohn","claiming",5.69407544437001
+"4467","Lord Mendelsohn","management",4.98879533130191
+"4468","Lord Mendelsohn","fee",4.26517092082023
+"4469","Lord Mendelsohn","money",4.15910345372329
+"4470","Lord Mendelsohn","board",3.46842987137066
+"4471","Lord Mendelsohn","satisfaction",3.03596229535056
+"4472","Lord Mendelsohn","authorised",2.94626999523619
+"4473","Lord Mendelsohn","surveys",2.74728716075575
+"4474","Lord Mendelsohn","sized",2.68101913850003
+"4475","Lord Mendelsohn","details",2.63802026696727
+"4476","Lord Mendelsohn","medium",2.62953257572083
+"4477","Lord Moonie","444(1a)",3.74376043407845
+"4478","Lord Moonie","twelve",3.55877904927178
+"4479","Lord Moonie","1996",2.59147193149936
+"4480","Lord Moonie","education",1.95447685723703
+"4481","Lord Moonie","prosecutions",1.71693305681506
+"4482","Lord Moonie","section",1.66618967200276
+"4483","Lord Moonie","information",1.54465047040227
+"4484","Lord Moonie","act",1.29890268853393
+"4485","Lord Moonie","months",1.27894971725636
+"4486","Lord Moonie","last",0.768585338205803
+"4487","Lord Moonie","2010",0
+"4488","Lord Moonie","accommod",0
+"4489","Lord Morrow","polygraph",3.12889493147202
+"4490","Lord Morrow","pilot",2.31848137149163
+"4491","Lord Morrow","projects",2.26286952768758
+"4492","Lord Morrow","regions",2.16993689156612
+"4493","Lord Morrow","tests",2.13024304334035
+"4494","Lord Morrow","sex",2.00807242661388
+"4495","Lord Morrow","managed",1.61946499222125
+"4496","Lord Morrow","community",1.42546141145211
+"4497","Lord Morrow","use",1.38402864552212
+"4498","Lord Morrow","england",1.17604471449965
+"4499","Lord Morrow","five",1.07383365913102
+"4500","Lord Morrow","offenders",1.00179033693354
+"4501","Lord Murphy of Torfaen","barriers",5.03287359696938
+"4502","Lord Murphy of Torfaen","chaplaincy",4.84726318464957
+"4503","Lord Murphy of Torfaen","practise",3.97883593553688
+"4504","Lord Murphy of Torfaen","coates",3.70624520066165
+"4505","Lord Murphy of Torfaen","dame",3.70624520066165
+"4506","Lord Murphy of Torfaen","iunlocking",3.70624520066165
+"4507","Lord Murphy of Torfaen","prisons",3.70624520066165
+"4508","Lord Murphy of Torfaen","sally",3.70624520066165
+"4509","Lord Murphy of Torfaen","chaplaincy",3.47854462985022
+"4510","Lord Murphy of Torfaen","faith",3.36472586037556
+"4511","Lord Murphy of Torfaen","improve",2.87532361013451
+"4512","Lord Murphy of Torfaen","prison",2.75215719769134
+"4513","Lord Myners","probate",4.96507917905393
+"4514","Lord Myners","inducements",4.83317393779203
+"4515","Lord Myners","behind",4.53920480163004
+"4516","Lord Myners","improper",4.42492564732817
+"4517","Lord Myners","bribery",4.18611570642329
+"4518","Lord Myners","rationale",4.18565141103677
+"4519","Lord Myners","budget",3.89951712259443
+"4520","Lord Myners","announced",3.76817866081132
+"4521","Lord Myners","grant",3.66350689244314
+"4522","Lord Myners","intend",3.05421078129932
+"4523","Lord Myners","capacity",2.94922653294524
+"4524","Lord Myners","latter",2.94542501489603
+"4525","Lord Norton of Louth","session",6.21999387557833
+"4526","Lord Norton of Louth","paper",5.80027863209174
+"4527","Lord Norton of Louth","103",5.43767266409928
+"4528","Lord Norton of Louth","prisoners",5.43767266409928
+"4529","Lord Norton of Louth","committee",5.29476262888076
+"4530","Lord Norton of Louth","201314)",4.60753817711437
+"4531","Lord Norton of Louth","vote",4.371190057755
+"4532","Lord Norton of Louth","draft",4.10251148249833
+"4533","Lord Norton of Louth","joint",3.98169739729495
+"4534","Lord Norton of Louth","response",3.95840660424927
+"4535","Lord Norton of Louth","eligibility",3.6004364315173
+"4536","Lord Norton of Louth","6th",3.31496648398472
+"4537","Lord Ouseley","black",8.64530250804891
+"4538","Lord Ouseley","made",7.90378904615397
+"4539","Lord Ouseley","minority",7.65742002946119
+"4540","Lord Ouseley","ethnic",6.6282241320533
+"4541","Lord Ouseley","diverse",5.83423142963881
+"4542","Lord Ouseley","ogden",5.8211791263776
+"4543","Lord Ouseley","judiciary",5.38928165569673
+"4544","Lord Ouseley","impact",5.35209001637786
+"4545","Lord Ouseley","appointed",5.31750004073874
+"4546","Lord Ouseley","discount",5.00133945486995
+"4547","Lord Ouseley","hl948",4.84232232414625
+"4548","Lord Ouseley","hl949)",4.84232232414625
+"4549","Lord Paddick","serious",2.30406568859574
+"4550","Lord Paddick","expect",2.27917930305815
+"4551","Lord Paddick","force",2.18014619849554
+"4552","Lord Paddick","bring",2.14629028544491
+"4553","Lord Paddick","crime",1.90772689267857
+"4554","Lord Paddick","section",1.86285668500313
+"4555","Lord Paddick","act",1.45221735385955
+"4556","Lord Paddick","2015",1.3253647347837
+"4557","Lord Paddick","2010",0
+"4558","Lord Paddick","accommod",0
+"4559","Lord Paddick","cost",0
+"4560","Lord Paddick","flight",0
+"4561","Lord Patel","gathering",2.23732478865236
+"4562","Lord Patel","comprehensive",2.04834255214774
+"4563","Lord Patel","physical",1.67037807913852
+"4564","Lord Patel","misuse",1.6382652723279
+"4565","Lord Patel","centrally",1.59623705516206
+"4566","Lord Patel","relevant",1.57143416973413
+"4567","Lord Patel","problems",1.52771775067028
+"4568","Lord Patel","substance",1.47300614266989
+"4569","Lord Patel","outcomes",1.40725481865745
+"4570","Lord Patel","development",1.38245193322952
+"4571","Lord Patel","performance",1.31925267529624
+"4572","Lord Patel","monitor",1.27588468277875
+"4573","Lord Patel of Bradford","mental",3.39259116124004
+"4574","Lord Patel of Bradford","health",3.31909243619055
+"4575","Lord Patel of Bradford","format",2.89679381763326
+"4576","Lord Patel of Bradford","diagnosed",2.74045601321832
+"4577","Lord Patel of Bradford","physical",2.36227133380841
+"4578","Lord Patel of Bradford","misuse",2.31685696689096
+"4579","Lord Patel of Bradford","illness",2.27623243136231
+"4580","Lord Patel of Bradford","substance",2.08314526442263
+"4581","Lord Patel of Bradford","prior",2.03903132527525
+"4582","Lord Patel of Bradford","suicide",1.95508227330209
+"4583","Lord Patel of Bradford","collect",1.73218905718105
+"4584","Lord Patel of Bradford","assessments",1.73218905718105
+"4585","Lord Patten","suicide",4.07415519654107
+"4586","Lord Patten","faulks",3.48061253526857
+"4587","Lord Patten","hl2986",3.31496648398472
+"4588","Lord Patten","self",3.20351899473159
+"4589","Lord Patten","annum",3.05676759423755
+"4590","Lord Patten","lord",2.95084999414574
+"4591","Lord Patten","privacy",2.91685822425804
+"4592","Lord Patten","written",2.89981065796948
+"4593","Lord Patten","hl4088",2.87084518782474
+"4594","Lord Patten","died",2.86362749075499
+"4595","Lord Patten","natural",2.77174934321718
+"4596","Lord Patten","particular",2.50487494800326
+"4597","Lord Pearson of Rannoch","drawing",4.18565141103677
+"4598","Lord Pearson of Rannoch","lennon",4.05998820009529
+"4599","Lord Pearson of Rannoch","yaxley",4.05998820009529
+"4600","Lord Pearson of Rannoch","compliant",3.71827925096883
+"4601","Lord Pearson of Rannoch","note",3.62528254494361
+"4602","Lord Pearson of Rannoch","stephen",3.42753266806161
+"4603","Lord Pearson of Rannoch","winchester",3.32573006579733
+"4604","Lord Pearson of Rannoch","sharia",3.19310155974459
+"4605","Lord Pearson of Rannoch","guarantee",3.17222462467664
+"4606","Lord Pearson of Rannoch","society",2.93988413450734
+"4607","Lord Pearson of Rannoch","141)",2.74045601321832
+"4608","Lord Pearson of Rannoch","practice",2.64502412511753
+"4609","Lord Pendry","fault",5.24142222825589
+"4610","Lord Pendry","divorce",3.6870760901367
+"4611","Lord Pendry","based",3.18205695260184
+"4612","Lord Pendry","mentions",3.05676759423755
+"4613","Lord Pendry","system",2.28635586774091
+"4614","Lord Pendry","put",2.07371278048889
+"4615","Lord Pendry","name",2.06064118462997
+"4616","Lord Pendry","enable",1.95995742654
+"4617","Lord Pendry","intend",1.93165250462965
+"4618","Lord Pendry","parties",1.92267611225897
+"4619","Lord Pendry","review",1.8135226806377
+"4620","Lord Pendry","procedure",1.78981389034065
+"4621","Lord Ponsonby of Shulbrede","metropolitan",2.90573092600763
+"4622","Lord Ponsonby of Shulbrede","scrutiny",2.64753203626047
+"4623","Lord Ponsonby of Shulbrede","panels",2.28217092499607
+"4624","Lord Ponsonby of Shulbrede","across",2.21815631628716
+"4625","Lord Ponsonby of Shulbrede","disposal",2.16354619114918
+"4626","Lord Ponsonby of Shulbrede","greater",2.13113425676615
+"4627","Lord Ponsonby of Shulbrede","adult",1.81551389074173
+"4628","Lord Ponsonby of Shulbrede","london",1.79607457986063
+"4629","Lord Ponsonby of Shulbrede","introducing",1.62656293907626
+"4630","Lord Ponsonby of Shulbrede","progress",1.62257891973243
+"4631","Lord Ponsonby of Shulbrede","youth",1.4989444738656
+"4632","Lord Ponsonby of Shulbrede","police",1.42678822407936
+"4633","Lord Porter of Spalding","cinavas",2.47083013377443
+"4634","Lord Porter of Spalding","karl",2.47083013377443
+"4635","Lord Porter of Spalding","polling",2.27838004404456
+"4636","Lord Porter of Spalding","discourage",2.02397486356704
+"4637","Lord Porter of Spalding","count",2.02397486356704
+"4638","Lord Porter of Spalding","station",1.78090377883241
+"4639","Lord Porter of Spalding","elected",1.71894868808477
+"4640","Lord Porter of Spalding","attacks",1.68419754320827
+"4641","Lord Porter of Spalding","event",1.65331610264621
+"4642","Lord Porter of Spalding","guidelines",1.46086601291633
+"4643","Lord Porter of Spalding","guilty",1.34346116562623
+"4644","Lord Porter of Spalding","commissioner",1.34346116562623
+"4645","Lord Quirk","week",6.51797340923876
+"4646","Lord Quirk","hours",6.41504223297626
+"4647","Lord Quirk","education",5.32064652072995
+"4648","Lord Quirk","provide",5.04466471668603
+"4649","Lord Quirk","written",4.83911405009819
+"4650","Lord Quirk","institutions",4.79933848900037
+"4651","Lord Quirk","young",4.41224388121718
+"4652","Lord Quirk","hl2982",4.26348878340245
+"4653","Lord Quirk","contract",4.06142784911456
+"4654","Lord Quirk","per",3.79386580458442
+"4655","Lord Quirk","offender",3.60816008976423
+"4656","Lord Quirk","target",3.52301190043303
+"4657","Lord Ramsbotham","college",14.671885565302
+"4658","Lord Ramsbotham","secure",11.1824467355347
+"4659","Lord Ramsbotham","libraries",10.8151858064453
+"4660","Lord Ramsbotham","proposals",10.1943704144812
+"4661","Lord Ramsbotham","bidders",8.60419453782954
+"4662","Lord Ramsbotham","winning",8.35907582529717
+"4663","Lord Ramsbotham","manage",7.46395890904364
+"4664","Lord Ramsbotham","education",6.86439873875931
+"4665","Lord Ramsbotham","youth",6.79259287549779
+"4666","Lord Ramsbotham","contract",6.7789047644437
+"4667","Lord Ramsbotham","establishment",6.7766354606767
+"4668","Lord Ramsbotham","accordance",6.61129015194519
+"4669","Lord Roberts of Llandudno","verne",12.4619026999452
+"4670","Lord Roberts of Llandudno","past",6.69608124755645
+"4671","Lord Roberts of Llandudno","surgeries",6.63611067170138
+"4672","Lord Roberts of Llandudno","migrants",5.42573844568052
+"4673","Lord Roberts of Llandudno","immigration",4.7596442442995
+"4674","Lord Roberts of Llandudno","detained",4.65939557636895
+"4675","Lord Roberts of Llandudno","arson",4.59436399688715
+"4676","Lord Roberts of Llandudno","hmp",4.31802271574753
+"4677","Lord Roberts of Llandudno","249)",4.28127125797188
+"4678","Lord Roberts of Llandudno","site",4.23397705933202
+"4679","Lord Roberts of Llandudno","certain",4.18565141103677
+"4680","Lord Roberts of Llandudno","concerns",4.11204400156859
+"4681","Lord Rogan","westminster",6.05168214513729
+"4682","Lord Rogan","cyclists",5.70644518638869
+"4683","Lord Rogan","traffic",5.16492675920478
+"4684","Lord Rogan","road",4.68131157792383
+"4685","Lord Rogan","cities",4.60015885736804
+"4686","Lord Rogan","complement",4.53920480163004
+"4687","Lord Rogan","cautioned",4.43636205749986
+"4688","Lord Rogan","london",4.10543567269916
+"4689","Lord Rogan","standard",2.85809820335057
+"4690","Lord Rogan","staffing",2.85809820335057
+"4691","Lord Rogan","convicted",2.3717416947312
+"4692","Lord Rogan","mercy",2.18904295998707
+"4693","Lord Rooker","constitutional",3.05756989844826
+"4694","Lord Rooker","set",2.23176173334764
+"4695","Lord Rooker","governance",2.17710600243595
+"4696","Lord Rooker","implement",1.94998204028951
+"4697","Lord Rooker","reform",1.77708666637046
+"4698","Lord Rooker","changes",1.75322657673322
+"4699","Lord Rooker","sections",1.66618967200276
+"4700","Lord Rooker","act",1.29890268853393
+"4701","Lord Rooker","plan",1.11356362418732
+"4702","Lord Rooker","2010",1.07715654707529
+"4703","Lord Rooker","accommod",0
+"4704","Lord Rooker","cost",0
+"4705","Lord Scriven","literature",5.16379095224052
+"4706","Lord Scriven","homophobic",4.77915351997029
+"4707","Lord Scriven","chaplains",4.68737417225737
+"4708","Lord Scriven","identity",3.24255128325494
+"4709","Lord Scriven","shows",2.90573092600763
+"4710","Lord Scriven","hl7786",2.80165802822211
+"4711","Lord Scriven","routinely",2.79856870449039
+"4712","Lord Scriven","appropriate",2.64979210162876
+"4713","Lord Scriven","transgender",2.57357864873072
+"4714","Lord Scriven","put",2.53976909264296
+"4715","Lord Scriven","based",2.46481071682209
+"4716","Lord Scriven","distributed",2.42174508089634
+"4717","Lord Sharkey","manifesto",4.30871920636458
+"4718","Lord Sharkey","though",4.30871920636458
+"4719","Lord Sharkey","today",4.30871920636458
+"4720","Lord Sharkey","pledge",4.09582287937708
+"4721","Lord Sharkey","even",4.09582287937708
+"4722","Lord Sharkey","innocent",4.09582287937708
+"4723","Lord Sharkey","indecency",3.82760522795375
+"4724","Lord Sharkey","historically",3.82760522795375
+"4725","Lord Sharkey","pardon",3.65093477745763
+"4726","Lord Sharkey","deceased",3.51897787751719
+"4727","Lord Sharkey","gross",3.46365655308136
+"4728","Lord Sharkey","similarly",3.32589774937437
+"4729","Lord Shipley","complex",3.34381835455032
+"4730","Lord Shipley","begin",2.97730646336668
+"4731","Lord Shipley","sunderland",2.97730646336668
+"4732","Lord Shipley","expect",2.14883085430993
+"4733","Lord Shipley","programme",2.00197332384794
+"4734","Lord Shipley","reform",1.8732138217488
+"4735","Lord Shipley","new",1.75631812579254
+"4736","Lord Shipley","work",1.47788950752407
+"4737","Lord Shipley","court",0.9481521829499
+"4738","Lord Shipley","2010",0
+"4739","Lord Shipley","accommod",0
+"4740","Lord Shipley","cost",0
+"4741","Lord Snape","inconsiderate",3.31496648398472
+"4742","Lord Snape","lane",3.31496648398472
+"4743","Lord Snape","middle",3.31496648398472
+"4744","Lord Snape","motorway",3.31496648398472
+"4745","Lord Snape","discourage",2.71544722781206
+"4746","Lord Snape","motorists",2.71544722781206
+"4747","Lord Snape","network",2.59011055998321
+"4748","Lord Snape","behaviour",2.18087500200613
+"4749","Lord Snape","appropriate",2.16354619114918
+"4750","Lord Snape","action",1.69208260946014
+"4751","Lord Snape","announcement",1.66893838071657
+"4752","Lord Snape","police",1.42678822407936
+"4753","Lord Steel of Aikwood","taiwan",5.24142222825589
+"4754","Lord Steel of Aikwood","exchange",3.64644082156937
+"4755","Lord Steel of Aikwood","liberia",3.43131630145811
+"4756","Lord Steel of Aikwood","speakerphone",3.43131630145811
+"4757","Lord Steel of Aikwood","sign",3.23819253110551
+"4758","Lord Steel of Aikwood","charles",3.16405505954568
+"4759","Lord Steel of Aikwood","frankland",3.00771725513075
+"4760","Lord Steel of Aikwood","taylor",2.89679381763326
+"4761","Lord Steel of Aikwood","agreement",2.72256089412682
+"4762","Lord Steel of Aikwood","expect",2.6317695683041
+"4763","Lord Steel of Aikwood","via",2.54349367327473
+"4764","Lord Steel of Aikwood","phone",2.44233218676566
+"4765","Lord Stoddart of Swindon","extant",10.748800860333
+"4766","Lord Stoddart of Swindon","freedom",7.08745660195581
+"4767","Lord Stoddart of Swindon","speech",6.3548920289313
+"4768","Lord Stoddart of Swindon","conscience",5.33989570687327
+"4769","Lord Stoddart of Swindon","thought",5.33989570687327
+"4770","Lord Stoddart of Swindon","1534",5.24142222825589
+"4771","Lord Stoddart of Swindon","1558",5.24142222825589
+"4772","Lord Stoddart of Swindon","supremacy",5.24142222825589
+"4773","Lord Stoddart of Swindon","detrimental",4.74363998799565
+"4774","Lord Stoddart of Swindon","expression",4.5758974018423
+"4775","Lord Stoddart of Swindon","individual",4.50758547583955
+"4776","Lord Stoddart of Swindon","review",4.43298346831509
+"4777","Lord Storey","dyslexic",5.74169037564949
+"4778","Lord Storey","teams",5.53788720017397
+"4779","Lord Storey","gcses",5.24142222825589
+"4780","Lord Storey","cinderella",4.85261405031394
+"4781","Lord Storey","gaoled",4.85261405031394
+"4782","Lord Storey","youth",4.43207254332748
+"4783","Lord Storey","accreditation",4.32405681828926
+"4784","Lord Storey","neglect",3.97500772156452
+"4785","Lord Storey","students",3.55877904927178
+"4786","Lord Storey","field",3.42753266806161
+"4787","Lord Storey","transgender",3.0760148293351
+"4788","Lord Storey","statements",3.05756989844826
+"4789","Lord Taylor of Warwick","reach",2.88962832808875
+"4790","Lord Taylor of Warwick","senior",2.77174934321718
+"4791","Lord Taylor of Warwick","positions",2.73165126531128
+"4792","Lord Taylor of Warwick","minorities",2.58378238148607
+"4793","Lord Taylor of Warwick","unlawful",2.50249153962001
+"4794","Lord Taylor of Warwick","sending",2.45861202616093
+"4795","Lord Taylor of Warwick","comply",2.41891817793516
+"4796","Lord Taylor of Warwick","sector",2.40803338053112
+"4797","Lord Taylor of Warwick","ban",2.28974789753234
+"4798","Lord Taylor of Warwick","ethnic",2.23650898958786
+"4799","Lord Taylor of Warwick","books",2.1117302095541
+"4800","Lord Taylor of Warwick","rule",2.02980623689682
+"4801","Lord Tebbit","definition",6.6322220466705
+"4802","Lord Tebbit","homicide",5.95057946123444
+"4803","Lord Tebbit","marriage",5.75469680400393
+"4804","Lord Tebbit","previous",4.79763433863719
+"4805","Lord Tebbit","1984",3.32573006579733
+"4806","Lord Tebbit","ahmad",3.31496648398472
+"4807","Lord Tebbit","hl7756",3.31496648398472
+"4808","Lord Tebbit","wimbledon",3.31496648398472
+"4809","Lord Tebbit","convicted",3.06798913985673
+"4810","Lord Tebbit","killed",2.9660198676456
+"4811","Lord Tebbit","manner",2.71544722781206
+"4812","Lord Tebbit","kingdom",2.53976909264296
+"4813","Lord Temple-Morris","cash",3.47854462985022
+"4814","Lord Temple-Morris","real",3.41846706944372
+"4815","Lord Temple-Morris","spending",2.47696676016445
+"4816","Lord Temple-Morris","terms",2.37951526841418
+"4817","Lord Temple-Morris","aid",1.7068082426619
+"4818","Lord Temple-Morris","legal",1.4869800787047
+"4819","Lord Temple-Morris","last",0.859304531368921
+"4820","Lord Temple-Morris","years",0.659416890428306
+"4821","Lord Temple-Morris","2010",0
+"4822","Lord Temple-Morris","accommod",0
+"4823","Lord Temple-Morris","cost",0
+"4824","Lord Temple-Morris","flight",0
+"4825","Lord Touhig","children",11.8366733112776
+"4826","Lord Touhig","dependants",9.5519673266712
+"4827","Lord Touhig","remand",7.76143185087577
+"4828","Lord Touhig","individuals",7.09351970485922
+"4829","Lord Touhig","secure",6.12282002742928
+"4830","Lord Touhig","affected",6.11067585706883
+"4831","Lord Touhig","home",5.87642726679623
+"4832","Lord Touhig","vulnerable",5.73075667470488
+"4833","Lord Touhig","adults",5.64492405528252
+"4834","Lord Touhig","currently",5.58754846357033
+"4835","Lord Touhig","parent",5.32140239063243
+"4836","Lord Touhig","college",4.74506338993178
+"4837","Lord Trefgarne","service",7.45630339108153
+"4838","Lord Trefgarne","blackman",6.78632537374327
+"4839","Lord Trefgarne","alexander",6.53604834482776
+"4840","Lord Trefgarne","currently",6.10987828517142
+"4841","Lord Trefgarne","held",6.05319360244408
+"4842","Lord Trefgarne","sentenced",6.02882902782445
+"4843","Lord Trefgarne","england",5.85242262213566
+"4844","Lord Trefgarne","wales",5.8287365833572
+"4845","Lord Trefgarne","prison",5.67459053893392
+"4846","Lord Trefgarne","age",5.33122202647897
+"4847","Lord Trefgarne","andy",5.24142222825589
+"4848","Lord Trefgarne","coulson",5.24142222825589
+"4849","Lord Verjee","clink",3.20970249642714
+"4850","Lord Verjee","restaurants",3.20970249642714
+"4851","Lord Verjee","qualifications",2.34484459176782
+"4852","Lord Verjee","skills",2.16722124606656
+"4853","Lord Verjee","communication",2.06346187124685
+"4854","Lord Verjee","initiatives",1.97115341883042
+"4855","Lord Verjee","future",1.70970249642714
+"4856","Lord Verjee","programme",1.50147999288595
+"4857","Lord Verjee","increase",1.44049859716443
+"4858","Lord Verjee","members",1.30602503539834
+"4859","Lord Verjee","support",1.24057325978589
+"4860","Lord Verjee","provide",1.1931801988127
+"4861","Lord Vinson","false",2.42363159232479
+"4862","Lord Vinson","144)",2.35164628192127
+"4863","Lord Vinson","beyond",2.25717781328434
+"4864","Lord Vinson","claims",2.2480305552358
+"4865","Lord Vinson","falling",2.20002479457481
+"4866","Lord Vinson","aid",2.18700375008145
+"4867","Lord Vinson","detained",2.07195789134648
+"4868","Lord Vinson","overall",2.01949474580582
+"4869","Lord Vinson","unlawfully",1.98877861050493
+"4870","Lord Vinson","cost",1.97473867992441
+"4871","Lord Vinson","lawyers",1.90764872903825
+"4872","Lord Vinson","statutory",1.90764872903825
+"4873","Lord Wallace of Saltaire","citizens",2.45861202616093
+"4874","Lord Wallace of Saltaire","states",2.43829237745785
+"4875","Lord Wallace of Saltaire","union",2.36567939003947
+"4876","Lord Wallace of Saltaire","kingdom",2.31848137149163
+"4877","Lord Wallace of Saltaire","1950",2.23494994757275
+"4878","Lord Wallace of Saltaire","alderney",2.23494994757275
+"4879","Lord Wallace of Saltaire","anchorage",2.23494994757275
+"4880","Lord Wallace of Saltaire","breakwater",2.23494994757275
+"4881","Lord Wallace of Saltaire","ceded",2.23494994757275
+"4882","Lord Wallace of Saltaire","ibackground",2.23494994757275
+"4883","Lord Wallace of Saltaire","ion",2.23494994757275
+"4884","Lord Wallace of Saltaire","122)",2.06087229161705
+"4885","Lord Wallace of Tankerness","hirst",3.70624520066165
+"4886","Lord Wallace of Tankerness","europe",2.70759331252997
+"4887","Lord Wallace of Tankerness","committee",2.13024304334035
+"4888","Lord Wallace of Tankerness","ministers",2.01519174843934
+"4889","Lord Wallace of Tankerness","september",1.89717975254958
+"4890","Lord Wallace of Tankerness","council",1.82305507495929
+"4891","Lord Wallace of Tankerness","meeting",1.78008191699418
+"4892","Lord Wallace of Tankerness","decision",1.65721983375472
+"4893","Lord Wallace of Tankerness","response",1.59258662237649
+"4894","Lord Wallace of Tankerness","case",1.14116560411926
+"4895","Lord Wallace of Tankerness","plan",1.01653986030767
+"4896","Lord Wallace of Tankerness","made",0.823991858216293
+"4897","Lord Warner","butler",7.13907103398329
+"4898","Lord Warner","ellie",7.13907103398329
+"4899","Lord Warner","judicial",4.30459923493639
+"4900","Lord Warner","hogg",3.87104686156941
+"4901","Lord Warner","mrs",3.39316268687164
+"4902","Lord Warner","case",3.24645731342256
+"4903","Lord Warner","scope",3.02459750431282
+"4904","Lord Warner","charedim",2.80165802822211
+"4905","Lord Warner","family",2.67417480032078
+"4906","Lord Warner","learning",2.59024852532215
+"4907","Lord Warner","president",2.59024852532215
+"4908","Lord Warner","complaint",2.42157481515729
+"4909","Lord Watts","enterprise",6.06902323020932
+"4910","Lord Watts","undertaken",5.10753946847058
+"4911","Lord Watts","courses",5.05971162235217
+"4912","Lord Watts","hl5604",3.87104686156941
+"4913","Lord Watts","keen",2.72308615973505
+"4914","Lord Watts","elie",2.69307502496926
+"4915","Lord Watts","reoffending",2.50566128129862
+"4916","Lord Watts","rates",2.22417490665585
+"4917","Lord Watts","lord",1.84662566771267
+"4918","Lord Watts","written",1.81468553235063
+"4919","Lord Watts","march",1.66340247677821
+"4920","Lord Watts","prisoners",1.21694420053194
+"4921","Lord Wigley","offered",3.97847905684633
+"4922","Lord Wigley","course",3.6151167470008
+"4923","Lord Wigley","speaking",3.61293666190285
+"4924","Lord Wigley","completed",3.15510945232865
+"4925","Lord Wigley","berwyn",3.12645945569042
+"4926","Lord Wigley","imprisoned",3.12134878040416
+"4927","Lord Wigley","assembly",3.09165134229387
+"4928","Lord Wigley","toan",2.80165802822211
+"4929","Lord Wigley","welsh",2.77174934321718
+"4930","Lord Wigley","beyond",2.62953257572083
+"4931","Lord Wigley","protection",2.52555243635546
+"4932","Lord Wigley","preceding",2.36522224775013
+"4933","Lord Wills","negligence",5.80471371745065
+"4934","Lord Wills","gross",5.09675646421032
+"4935","Lord Wills","manslaughter",5.09675646421032
+"4936","Lord Wills","sellu",3.31496648398472
+"4937","Lord Wills","quashed",3.28349511107287
+"4938","Lord Wills","david",2.90573092600763
+"4939","Lord Wills","appeal",2.73713171546802
+"4940","Lord Wills","safe",2.33191167023605
+"4941","Lord Wills","conviction",2.15217377710666
+"4942","Lord Wills","offence",1.94239424074877
+"4943","Lord Wills","need",1.85035255851401
+"4944","Lord Wills","respect",1.8279819003314
+"4945","Lord, Jonathan","divorce",6.26956601229915
+"4946","Lord, Jonathan","blame",4.85261405031394
+"4947","Lord, Jonathan","modernise",3.71827925096883
+"4948","Lord, Jonathan","couples",3.65449501766502
+"4949","Lord, Jonathan","separating",3.34075615827703
+"4950","Lord, Jonathan","short",3.17229396360707
+"4951","Lord, Jonathan","across",3.03733562625761
+"4952","Lord, Jonathan","efficacy",3.00950229978049
+"4953","Lord, Jonathan","without",2.69805035632587
+"4954","Lord, Jonathan","three",2.64763556063055
+"4955","Lord, Jonathan","offensive",2.58411820880339
+"4956","Lord, Jonathan","juveniles",2.58411820880339
+"4957","Loughton, Tim","wardship",9.30782351509674
+"4958","Loughton, Tim","case",7.48129331783716
+"4959","Loughton, Tim","alienation",5.6323054520701
+"4960","Loughton, Tim","syndrome",5.6323054520701
+"4961","Loughton, Tim","flagged",5.62150983037432
+"4962","Loughton, Tim","involving",4.84809031139054
+"4963","Loughton, Tim","led",4.63371393378193
+"4964","Loughton, Tim","families",4.57471894229008
+"4965","Loughton, Tim","upcoming",4.27960332856952
+"4966","Loughton, Tim","deal",4.10706359133682
+"4967","Loughton, Tim","parental",4.00658013969087
+"4968","Loughton, Tim","eventuality",3.94626999523619
+"4969","Lucas, Caroline","plans",8.66488032285849
+"4970","Lucas, Caroline","2015",6.26204856966896
+"4971","Lucas, Caroline","fee",6.16487749975383
+"4972","Lucas, Caroline","thematic",5.26443451005614
+"4973","Lucas, Caroline","consultation",5.12205224469941
+"4974","Lucas, Caroline","publish",5.12035681323756
+"4975","Lucas, Caroline","recommendations",4.92331112279285
+"4976","Lucas, Caroline","tribunal",4.8657552928056
+"4977","Lucas, Caroline","hove",4.53920480163004
+"4978","Lucas, Caroline","chamber",4.41186705878695
+"4979","Lucas, Caroline","serious",4.34458792721413
+"4980","Lucas, Caroline","report",4.31596030556267
+"4981","Lucas, Ian","north",38.2380019983402
+"4982","Lucas, Ian","wrexham",28.2923921700948
+"4983","Lucas, Ian","wales",23.3268228374399
+"4984","Lucas, Ian","construct",17.9638362791339
+"4985","Lucas, Ian","court",14.7091266387904
+"4986","Lucas, Ian","magistrates",14.0377400315291
+"4987","Lucas, Ian","facilities",12.1876368192624
+"4988","Lucas, Ian","local",9.29352094200356
+"4989","Lucas, Ian","macur",8.83257189916018
+"4990","Lucas, Ian","custody",8.58071899625146
+"4991","Lucas, Ian","police",7.53966373245952
+"4992","Lucas, Ian","recorded",7.08547398648022
+"4993","Lumley, Karen","officer",6.06826642660645
+"4994","Lumley, Karen","prison",5.47871230379344
+"4995","Lumley, Karen","treatment",4.95573327347342
+"4996","Lumley, Karen","meaningful",4.83317393779203
+"4997","Lumley, Karen","improve",4.76793901885338
+"4998","Lumley, Karen","hewell",4.18565141103677
+"4999","Lumley, Karen","mental",4.12273629459309
+"5000","Lumley, Karen","well",4.09668510429549
+"5001","Lumley, Karen","lgbtq",4.05998820009529
+"5002","Lumley, Karen","health",4.03341935454156
+"5003","Lumley, Karen","number",3.66172394258429
+"5004","Lumley, Karen","made",3.51356670502744
+"5005","Lynch, Holly","halifax",7.11032505478187
+"5006","Lynch, Holly","molestation",6.04174181869633
+"5007","Lynch, Holly","attorney",5.62973046287047
+"5008","Lynch, Holly","calderdale",5.44243510359024
+"5009","Lynch, Holly","digitalisation",5.38338736478816
+"5010","Lynch, Holly","2016",4.79132832964138
+"5011","Lynch, Holly","power",4.59108144146618
+"5012","Lynch, Holly","appointed",4.45247971948066
+"5013","Lynch, Holly","18949",4.27960332856952
+"5014","Lynch, Holly","estate",4.12841829994204
+"5015","Lynch, Holly","updating",3.90662417136339
+"5016","Lynch, Holly","urgency",3.87104686156941
+"5017","Mackintosh, David","wrong",6.63253792323
+"5018","Mackintosh, David","reoffending",6.1712923396381
+"5019","Mackintosh, David","appropriate",6.12966496139698
+"5020","Mackintosh, David","burial",6.0919995693116
+"5021","Mackintosh, David","reduce",5.36386166405001
+"5022","Mackintosh, David","plot",4.83317393779203
+"5023","Mackintosh, David","nearing",4.53920480163004
+"5024","Mackintosh, David","oversight",4.47464957730471
+"5025","Mackintosh, David","educate",4.37034311323215
+"5026","Mackintosh, David","likelihood",4.18565141103677
+"5027","Mackintosh, David","reintegrate",3.83209802044349
+"5028","Mackintosh, David","exhumations",3.70624520066165
+"5029","Mactaggart, Fiona","sanitary",6.67658649660743
+"5030","Mactaggart, Fiona","product",5.73357118095204
+"5031","Mactaggart, Fiona","authorised",3.95283599364966
+"5032","Mactaggart, Fiona","female",3.79689745416674
+"5033","Mactaggart, Fiona","unidentified",3.43131630145811
+"5034","Mactaggart, Fiona","violence",3.28095915137594
+"5035","Mactaggart, Fiona","range",3.27960332856952
+"5036","Mactaggart, Fiona","brands",3.26802417241388
+"5037","Mactaggart, Fiona","domestic",3.26260121049122
+"5038","Mactaggart, Fiona","free",3.22296166142208
+"5039","Mactaggart, Fiona","others",2.68101913850003
+"5040","Mactaggart, Fiona","purchase",2.59024852532215
+"5041","Madders, Justin","fee",24.5784601033956
+"5042","Madders, Justin","employed",23.5685435672936
+"5043","Madders, Justin","tribunal",21.8449812704543
+"5044","Madders, Justin","review",11.1841558932826
+"5045","Madders, Justin","five",10.8755621237888
+"5046","Madders, Justin","last",10.7326753560367
+"5047","Madders, Justin","remission",9.91644312726242
+"5048","Madders, Justin","aid",9.82487358975567
+"5049","Madders, Justin","year",8.85779182255385
+"5050","Madders, Justin","legal",8.55948016806746
+"5051","Madders, Justin","departments",8.47800903981682
+"5052","Madders, Justin","claimant",8.46541542116256
+"5053","Mahmood, Shabana","imb",8.37130282207354
+"5054","Mahmood, Shabana","coroner",5.65218164097322
+"5055","Mahmood, Shabana","referrals",5.55406526647881
+"5056","Mahmood, Shabana","sat",5.38798804947879
+"5057","Mahmood, Shabana","2015",5.24826938352216
+"5058","Mahmood, Shabana","died",4.93483188860472
+"5059","Mahmood, Shabana","expert",4.92848939164633
+"5060","Mahmood, Shabana","annual",4.80437753329763
+"5061","Mahmood, Shabana","upper",4.74566956682366
+"5062","Mahmood, Shabana","panel",4.64444225880448
+"5063","Mahmood, Shabana","birmingham",4.54390379331315
+"5064","Mahmood, Shabana","pathologists",4.47464957730471
+"5065","Main, Anne","education",9.1034942525068
+"5066","Main, Anne","infraction",7.53761498480866
+"5067","Main, Anne","employment",6.44377441816141
+"5068","Main, Anne","training",6.31514813017014
+"5069","Main, Anne","national",5.44643927514773
+"5070","Main, Anne","citizens",5.40689714078524
+"5071","Main, Anne","systems",5.30431884796292
+"5072","Main, Anne","outcome",5.11489688129469
+"5073","Main, Anne","last",4.86472593468553
+"5074","Main, Anne","member",4.82455998327639
+"5075","Main, Anne","leave",4.233208319653
+"5076","Main, Anne","year",4.21468478998292
+"5077","Mak, Alan","british",2.62001925922161
+"5078","Mak, Alan","bill",2.48399137799887
+"5079","Mak, Alan","progress",2.37521232919745
+"5080","Mak, Alan","rights",1.96624125004087
+"5081","Mak, Alan","plans",1.33096310194277
+"5082","Mak, Alan","made",1.07885858922957
+"5083","Mak, Alan","will",1.02070749213754
+"5084","Mak, Alan","2010",0
+"5085","Mak, Alan","accommod",0
+"5086","Mak, Alan","cost",0
+"5087","Mak, Alan","flight",0
+"5088","Mak, Alan","hotel",0
+"5089","Malhotra, Seema","feltham",30.4607099103088
+"5090","Malhotra, Seema","institution",21.3134814446685
+"5091","Malhotra, Seema","young",19.5944250040304
+"5092","Malhotra, Seema","segregated",14.6343512482845
+"5093","Malhotra, Seema","children",14.1822271745518
+"5094","Malhotra, Seema","offender",13.161738204802
+"5095","Malhotra, Seema","month",11.8123321248429
+"5096","Malhotra, Seema","unit",9.30589401399384
+"5097","Malhotra, Seema","coroner",9.03124150630629
+"5098","Malhotra, Seema","london",8.93454100063754
+"5099","Malhotra, Seema","west",8.11134105412229
+"5100","Malhotra, Seema","held",6.7607441804178
+"5101","Malthouse, Kit","croydon",3.11386880460654
+"5102","Malthouse, Kit","abstinence",2.87133317957021
+"5103","Malthouse, Kit","nationwide",2.87133317957021
+"5104","Malthouse, Kit","method",2.38626192949754
+"5105","Malthouse, Kit","disposal",2.03229776967356
+"5106","Malthouse, Kit","alcohol",1.97384471962158
+"5107","Malthouse, Kit","piloted",1.94791397381381
+"5108","Malthouse, Kit","restriction",1.94791397381381
+"5109","Malthouse, Kit","implications",1.81447158050183
+"5110","Malthouse, Kit","without",1.73130909458525
+"5111","Malthouse, Kit","monitoring",1.63744219951844
+"5112","Malthouse, Kit","scheme",1.49556795378321
+"5113","Mann, John","ranby",7.29353922264272
+"5114","Mann, John","worksop",5.74169037564949
+"5115","Mann, John","courthouse",5.29447678014953
+"5116","Mann, John","graveyards",4.53920480163004
+"5117","Mann, John","headstones",4.53920480163004
+"5118","Mann, John","fundamental",4.29349905293811
+"5119","Mann, John","organisation",4.11147055855362
+"5120","Mann, John","cemeteries",4.05998820009529
+"5121","Mann, John","stake",4.05998820009529
+"5122","Mann, John","reasons",3.91567389558221
+"5123","Mann, John","suicides",3.65762401482577
+"5124","Mann, John","semitism",3.61293666190285
+"5125","Marris, Rob","soft",6.88085928205435
+"5126","Marris, Rob","tissue",6.88085928205435
+"5127","Marris, Rob","whiplash",5.48475265666544
+"5128","Marris, Rob","process",4.56103897199977
+"5129","Marris, Rob","injury",4.23138491938685
+"5130","Marris, Rob","reforming",4.23138491938685
+"5131","Marris, Rob","consultation",4.18151336186872
+"5132","Marris, Rob","response",4.15401071033198
+"5133","Marris, Rob","november",4.1472424846317
+"5134","Marris, Rob","departments",3.83304890772105
+"5135","Marris, Rob","claims",3.73642554623185
+"5136","Marris, Rob","publish",3.41815459639825
+"5137","Marsden, Gordon","enhanced",22.7583404073583
+"5138","Marsden, Gordon","redundancy",20.532220021785
+"5139","Marsden, Gordon","privatisation",19.1810919504704
+"5140","Marsden, Gordon","schemes",17.0025774113379
+"5141","Marsden, Gordon","following",15.0270559643361
+"5142","Marsden, Gordon","probation",12.5832176610391
+"5143","Marsden, Gordon","fund",11.1702363436045
+"5144","Marsden, Gordon","allocated",10.0677190882479
+"5145","Marsden, Gordon","companies",8.05177522356
+"5146","Marsden, Gordon","services",7.99923251010608
+"5147","Marsden, Gordon","june",7.71293953286974
+"5148","Marsden, Gordon","community",6.83226325447862
+"5149","Matheson, Christian","psychologists",4.47464957730471
+"5150","Matheson, Christian","psychiatrists",4.47464957730471
+"5151","Matheson, Christian","healthcare",3.97883593553688
+"5152","Matheson, Christian","sea",3.70624520066165
+"5153","Matheson, Christian","11221",2.94542501489603
+"5154","Matheson, Christian","static",2.94542501489603
+"5155","Matheson, Christian","blue",2.71600928102546
+"5156","Matheson, Christian","displaying",2.4865935471549
+"5157","Matheson, Christian","citizens",2.45861202616093
+"5158","Matheson, Christian","whilst",2.45861202616093
+"5159","Matheson, Christian","inquests",2.3826805336538
+"5160","Matheson, Christian","budget",2.36494085623794
+"5161","Mathias, Dr Tania","upper",4.57798157583753
+"5162","Mathias, Dr Tania","law",4.05735950759373
+"5163","Mathias, Dr Tania","asylum",3.75736747384003
+"5164","Mathias, Dr Tania","understood",3.74376043407845
+"5165","Mathias, Dr Tania","begin",3.64644082156937
+"5166","Mathias, Dr Tania","problems",3.61524003960915
+"5167","Mathias, Dr Tania","contempt",3.57272251098088
+"5168","Mathias, Dr Tania","easier",3.55877904927178
+"5169","Mathias, Dr Tania","expertise",3.42753266806161
+"5170","Mathias, Dr Tania","tier",3.34087235267073
+"5171","Mathias, Dr Tania","first",2.91531775090644
+"5172","Mathias, Dr Tania","mental",2.83844541098236
+"5173","Maynard, Paul","starts",11.8835456626733
+"5174","Maynard, Paul","matter",11.2026551792576
+"5175","Maynard, Paul","awarded",9.04782511371519
+"5176","Maynard, Paul","new",7.5300050840135
+"5177","Maynard, Paul","mental",7.06352360671434
+"5178","Maynard, Paul","health",6.91049603729136
+"5179","Maynard, Paul","2011",4.46115034327207
+"5180","Maynard, Paul","crematoriums",4.40004958914961
+"5181","Maynard, Paul","1902",4.05998820009529
+"5182","Maynard, Paul","2012",3.96071587008313
+"5183","Maynard, Paul","outset",3.74376043407845
+"5184","Maynard, Paul","exhaust",3.70624520066165
+"5185","McCabe, Steve","needs",9.10236852514333
+"5186","McCabe, Steve","tribunal",8.05074232009706
+"5187","McCabe, Steve","disabl",7.53853518756742
+"5188","McCabe, Steve","special",7.20534787473124
+"5189","McCabe, Steve","judge",6.60852442855996
+"5190","McCabe, Steve","led",6.2848005033832
+"5191","McCabe, Steve","three",6.21835013445409
+"5192","McCabe, Steve","parents",5.96315612101768
+"5193","McCabe, Steve","tier",5.89942777678192
+"5194","McCabe, Steve","educational",5.89579745493339
+"5195","McCabe, Steve","enforcement",5.8712638456461
+"5196","McCabe, Steve","grandchildren",5.50895598123469
+"5197","McCann, Michael","aid",9.60498412809068
+"5198","McCann, Michael","legal",8.36791134338038
+"5199","McCann, Michael","cases",7.86513574695406
+"5200","McCann, Michael","lawyers",7.52142484175351
+"5201","McCann, Michael","interest",7.17469104117449
+"5202","McCann, Michael","funded",5.80182921808908
+"5203","McCann, Michael","defence",5.69358496683649
+"5204","McCann, Michael","pensions",5.33115936404793
+"5205","McCann, Michael","last",4.83569634754208
+"5206","McCann, Michael","home",4.16822705820521
+"5207","McCann, Michael","received",3.95022203055584
+"5208","McCann, Michael","minstry",3.87104686156941
+"5209","McCarthy, Kerry","environmental",10.3521323540002
+"5210","McCarthy, Kerry","torture",5.27576424282376
+"5211","McCarthy, Kerry","governments",5.22434926858539
+"5212","McCarthy, Kerry","cost",4.87637738649287
+"5213","McCarthy, Kerry","protection",4.17452677038244
+"5214","McCarthy, Kerry","committee",4.02650983920213
+"5215","McCarthy, Kerry","visit",3.86529625685258
+"5216","McCarthy, Kerry","prevention",3.71934736388124
+"5217","McCarthy, Kerry","european",3.48086633931473
+"5218","McCarthy, Kerry","challenges",3.41846706944372
+"5219","McCarthy, Kerry","report",3.30750794579836
+"5220","McCarthy, Kerry","changes",3.2669448379456
+"5221","McCartney, Jason","nuisance",3.55877904927178
+"5222","McCartney, Jason","persistent",3.42753266806161
+"5223","McCartney, Jason","calls",2.35478770783629
+"5224","McCartney, Jason","regulator",2.14858295080525
+"5225","McCartney, Jason","closed",2.0440237224512
+"5226","McCartney, Jason","management",1.77403501465901
+"5227","McCartney, Jason","result",1.74745156000311
+"5228","McCartney, Jason","claims",1.56921484208927
+"5229","McCartney, Jason","companies",1.51097233307672
+"5230","McCartney, Jason","date",1.45628904348129
+"5231","McCartney, Jason","2010",0
+"5232","McCartney, Jason","accommod",0
+"5233","McCartney, Karl","insurance",12.1704178440975
+"5234","McCartney, Karl","drivers",8.3830696570887
+"5235","McCartney, Karl","injury",7.56265881031146
+"5236","McCartney, Karl","without",6.82839424634509
+"5237","McCartney, Karl","motor",6.79532590887786
+"5238","McCartney, Karl","claim",6.67802908849468
+"5239","McCartney, Karl","five",5.60988752781608
+"5240","McCartney, Karl","licence",5.42563619326193
+"5241","McCartney, Karl","fraudulent",5.40129285040031
+"5242","McCartney, Karl","premiums",5.38355115859473
+"5243","McCartney, Karl","evidence",5.18719790596387
+"5244","McCartney, Karl","convicted",5.18366998465001
+"5245","McCrea, Dr William","well",3.61293666190285
+"5246","McCrea, Dr William","association",2.5698423229212
+"5247","McCrea, Dr William","consult",1.8511359222821
+"5248","McCrea, Dr William","officers",1.50263103586465
+"5249","McCrea, Dr William","related",1.50263103586465
+"5250","McCrea, Dr William","work",1.47788950752407
+"5251","McCrea, Dr William","staff",1.37371118754739
+"5252","McCrea, Dr William","will",0.900179395178779
+"5253","McCrea, Dr William","prison",0.597001477233657
+"5254","McCrea, Dr William","2010",0
+"5255","McCrea, Dr William","accommod",0
+"5256","McCrea, Dr William","cost",0
+"5257","McDonald, Andy","importance",4.84726318464957
+"5258","McDonald, Andy","uphold",4.70329256384254
+"5259","McDonald, Andy","forecasts",4.42492564732817
+"5260","McDonald, Andy","constitutional",4.32405681828926
+"5261","McDonald, Andy","blundeston",3.56084520918548
+"5262","McDonald, Andy","bullwood",3.56084520918548
+"5263","McDonald, Andy","trends",3.53905747505455
+"5264","McDonald, Andy","brinsford",3.28349511107287
+"5265","McDonald, Andy","bullingdon",3.28349511107287
+"5266","McDonald, Andy","judicial",3.19237623336884
+"5267","McDonald, Andy","population",2.9613708350317
+"5268","McDonald, Andy","bristol",2.84390560599304
+"5269","McDonnell, John","rollout",11.236232621197
+"5270","McDonnell, John","tag",9.22703628857447
+"5271","McDonnell, John","criminal",9.20852976175059
+"5272","McDonnell, John","new",8.68321504779722
+"5273","McDonnell, John","noms",8.36626270962336
+"5274","McDonnell, John","compensation",8.09719798929343
+"5275","McDonnell, John","authority",7.96774533017639
+"5276","McDonnell, John","injuries",7.62398707603209
+"5277","McDonnell, John","race",7.25975568726028
+"5278","McDonnell, John","thameside",7.25975568726028
+"5279","McDonnell, John","england",7.06785967632753
+"5280","McDonnell, John","wales",7.03925449703972
+"5281","McGarry, Natalie","enquiry",3.16405505954568
+"5282","McGarry, Natalie","glasgow",3.00771725513075
+"5283","McGarry, Natalie","email",2.68101913850003
+"5284","McGarry, Natalie","behalf",2.58411820880339
+"5285","McGarry, Natalie","east",2.13296626751336
+"5286","McGarry, Natalie","respond",2.09501009189598
+"5287","McGarry, Natalie","constituent",1.73218905718105
+"5288","McGarry, Natalie","2017",1.65954621809528
+"5289","McGarry, Natalie","hon",1.65567104509136
+"5290","McGarry, Natalie","february",1.57272915904131
+"5291","McGarry, Natalie","march",1.47444870562504
+"5292","McGarry, Natalie","member",1.39619949171711
+"5293","McGinn, Conor","recovered",6.12966496139698
+"5294","McGinn, Conor","person",5.86251156857895
+"5295","McGinn, Conor","remains",5.42240925124275
+"5296","McGinn, Conor","merseyside",5.38201622419291
+"5297","McGinn, Conor","murder",5.32853788197449
+"5298","McGinn, Conor","small",5.02826823883978
+"5299","McGinn, Conor","limit",4.72159317679615
+"5300","McGinn, Conor","helens",4.70529168273102
+"5301","McGinn, Conor","claims",4.25621197675926
+"5302","McGinn, Conor","increase",3.58400930189957
+"5303","McGinn, Conor","1988",3.41846706944372
+"5304","McGinn, Conor","determine",3.41195200541721
+"5305","McGovern, Alison","foreign",8.80798190248118
+"5306","McGovern, Alison","national",6.19182315331422
+"5307","McGovern, Alison","country",4.16822705820521
+"5308","McGovern, Alison","england",4.02667284079658
+"5309","McGovern, Alison","wales",4.0103760120791
+"5310","McGovern, Alison","repatriated",3.05756989844826
+"5311","McGovern, Alison","known",3.02459750431282
+"5312","McGovern, Alison","origin",2.35010480806148
+"5313","McGovern, Alison","prison",2.33659065133906
+"5314","McGovern, Alison","category",2.16536053358349
+"5315","McGovern, Alison","purse",2.03316082283189
+"5316","McGovern, Alison","held",1.75372330014359
+"5317","McGovern, Jim","handling",4.19458552309246
+"5318","McGovern, Jim","share",3.54726218966247
+"5319","McGovern, Jim","governments",3.07889283536879
+"5320","McGovern, Jim","data",2.46722458634275
+"5321","McGovern, Jim","personal",2.01000780075487
+"5322","McGovern, Jim","2010",0
+"5323","McGovern, Jim","accommod",0
+"5324","McGovern, Jim","cost",0
+"5325","McGovern, Jim","flight",0
+"5326","McGovern, Jim","hotel",0
+"5327","McGovern, Jim","intern",0
+"5328","McGovern, Jim","made",0
+"5329","McInnes, Liz","causing",3.73050927196343
+"5330","McInnes, Liz","serious",3.36530333764683
+"5331","McInnes, Liz","drive",3.35604850415274
+"5332","McInnes, Liz","penalties",3.34690722976498
+"5333","McInnes, Liz","death",3.19164734287281
+"5334","McInnes, Liz","injury",2.90197037420746
+"5335","McInnes, Liz","consultation",2.86776743942596
+"5336","McInnes, Liz","response",2.8489055581525
+"5337","McInnes, Liz","publish",2.34424037571277
+"5338","McInnes, Liz","relating",2.32786599095927
+"5339","McInnes, Liz","offences",1.87293430771614
+"5340","McInnes, Liz","plans",1.81844178358886
+"5341","McIntosh, Anne","appeal",4.68577770587918
+"5342","McIntosh, Anne","rustling",4.53920480163004
+"5343","McIntosh, Anne","sheep",4.53920480163004
+"5344","McIntosh, Anne","farms",3.97883593553688
+"5345","McIntosh, Anne","adverse",3.7512824949958
+"5346","McIntosh, Anne","crime",3.61404969849206
+"5347","McIntosh, Anne","length",3.54990189424226
+"5348","McIntosh, Anne","independence",3.40688144604856
+"5349","McIntosh, Anne","resolution",3.34075615827703
+"5350","McIntosh, Anne","disputes",3.34075615827703
+"5351","McIntosh, Anne","promote",3.30769831157596
+"5352","McIntosh, Anne","payment",3.06995807202822
+"5353","McKechin, Ann","descriptions",3.00771725513075
+"5354","McKechin, Ann","describe",2.81075491518716
+"5355","McKechin, Ann","trade",2.36227133380841
+"5356","McKechin, Ann","firms",2.07163466432223
+"5357","McKechin, Ann","existing",2.07163466432223
+"5358","McKechin, Ann","regulating",1.81588402251021
+"5359","McKechin, Ann","hold",1.75644714779192
+"5360","McKechin, Ann","legislation",1.54571275570314
+"5361","McKechin, Ann","companies",1.27700469607686
+"5362","McKechin, Ann","effect",1.20598441603357
+"5363","McKechin, Ann","review",1.18722927979164
+"5364","McKechin, Ann","legal",1.12405128364568
+"5365","McKinnell, Catherine","trial",11.9010680804064
+"5366","McKinnell, Catherine","vacated",11.3621530017563
+"5367","McKinnell, Catherine","ineffective",10.3400246071104
+"5368","McKinnell, Catherine","cracked",9.70163538824751
+"5369","McKinnell, Catherine","bribery",7.62843913720129
+"5370","McKinnell, Catherine","crown",6.87310614789655
+"5371","McKinnell, Catherine","prosecution",6.57111755488714
+"5372","McKinnell, Catherine","2010",6.38550045779969
+"5373","McKinnell, Catherine","reasons",6.01050272001013
+"5374","McKinnell, Catherine","proportion",5.82293781976879
+"5375","McKinnell, Catherine","magistrates",5.59105990022349
+"5376","McKinnell, Catherine","court",5.21186507216045
+"5377","McLaughlin, Anne","punishment",6.16782129272557
+"5378","McLaughlin, Anne","review",5.72431925816392
+"5379","McLaughlin, Anne","aid",4.25007246402882
+"5380","McLaughlin, Anne","2012",4.23053193315677
+"5381","McLaughlin, Anne","legal",3.70268488814307
+"5382","McLaughlin, Anne","act",3.61612326045339
+"5383","McLaughlin, Anne","sentencing",3.07647509881416
+"5384","McLaughlin, Anne","offenders",3.05516078626717
+"5385","McLaughlin, Anne","scope",3.02459750431282
+"5386","McLaughlin, Anne","will",2.66572752769761
+"5387","McLaughlin, Anne","level",2.39765270230255
+"5388","McLaughlin, Anne","development",2.20563026934007
+"5389","McMahon, Jim","oldham",6.6263031112292
+"5390","McMahon, Jim","canadian",3.87104686156941
+"5391","McMahon, Jim","ratio",3.6870760901367
+"5392","McMahon, Jim","made",3.50048259782629
+"5393","McMahon, Jim","2500",3.47854462985022
+"5394","McMahon, Jim","officers",3.43412054739095
+"5395","McMahon, Jim","2006",3.39468579288825
+"5396","McMahon, Jim","ratification",3.39316268687164
+"5397","McMahon, Jim","breakdown",3.31611102333525
+"5398","McMahon, Jim","dilapidations",3.31496648398472
+"5399","McMahon, Jim","comprehensive",3.26802417241388
+"5400","McMahon, Jim","telephones",3.05543550134056
+"5401","McPartland, Stephen","amend",7.96185818644116
+"5402","McPartland, Stephen","forward",6.49240721255731
+"5403","McPartland, Stephen","bring",6.13009877282749
+"5404","McPartland, Stephen","legislative",5.84018800011122
+"5405","McPartland, Stephen","obscene",5.8211791263776
+"5406","McPartland, Stephen","1959",5.6064963140604
+"5407","McPartland, Stephen","possession",5.50407890621547
+"5408","McPartland, Stephen","proposals",4.84691488987669
+"5409","McPartland, Stephen","material",4.50097291154978
+"5410","McPartland, Stephen","act",4.14773149705975
+"5411","McPartland, Stephen","coroners",3.46324211469021
+"5412","McPartland, Stephen","additionally",3.33580627008542
+"5413","Mearns, Ian","unemployed",8.2131496654818
+"5414","Mearns, Ian","classed",7.60998953937443
+"5415","Mearns, Ian","week",7.38562209127165
+"5416","Mearns, Ian","hours",7.2689890948548
+"5417","Mearns, Ian","cells",7.25492941506077
+"5418","Mearns, Ian","per",7.1331210595858
+"5419","Mearns, Ian","information",6.06930650612685
+"5420","Mearns, Ian","spent",5.95723251517944
+"5421","Mearns, Ian","date",5.72211301894103
+"5422","Mearns, Ian","working",5.50899108889818
+"5423","Mearns, Ian","three",5.47754115969222
+"5424","Mearns, Ian","bought",5.29447678014953
+"5425","Menzies, Mark","1000",5.33249975824043
+"5426","Menzies, Mark","5000",5.24866832779457
+"5427","Menzies, Mark","illegitimate",4.83317393779203
+"5428","Menzies, Mark","claims",4.76260855621803
+"5429","Menzies, Mark","small",4.45837495836237
+"5430","Menzies, Mark","limit",4.18645779881063
+"5431","Menzies, Mark","adequately",3.94730576551841
+"5432","Menzies, Mark","preparatory",3.87104686156941
+"5433","Menzies, Mark","underway",3.87104686156941
+"5434","Menzies, Mark","handling",3.82911518397058
+"5435","Menzies, Mark","fraudulent",3.82911518397058
+"5436","Menzies, Mark","increasing",3.17780527273815
+"5437","Mercer, Johnny","threatening",2.49649536803054
+"5438","Mercer, Johnny","offensive",2.49649536803054
+"5439","Mercer, Johnny","bladed",2.35951705718439
+"5440","Mercer, Johnny","repeatedly",2.35951705718439
+"5441","Mercer, Johnny","weapon",2.19904944831774
+"5442","Mercer, Johnny","put",2.07371278048889
+"5443","Mercer, Johnny","article",2.01250952291925
+"5444","Mercer, Johnny","deal",1.98009758853622
+"5445","Mercer, Johnny","guidelines",1.95995742654
+"5446","Mercer, Johnny","possession",1.91391094884648
+"5447","Mercer, Johnny","place",1.27497144612389
+"5448","Mercer, Johnny","relation",1.16393299547964
+"5449","Metcalfe, Stephen","scientific",3.74376043407845
+"5450","Metcalfe, Stephen","digital",3.59704324855529
+"5451","Metcalfe, Stephen","fill",3.55877904927178
+"5452","Metcalfe, Stephen","vacant",3.24255128325494
+"5453","Metcalfe, Stephen","technology",3.0760148293351
+"5454","Metcalfe, Stephen","advertise",2.88980641474755
+"5455","Metcalfe, Stephen","vacancy",2.8559968586598
+"5456","Metcalfe, Stephen","adviser",2.69327453376365
+"5457","Metcalfe, Stephen","long",2.33356433561193
+"5458","Metcalfe, Stephen","increase",2.17782917259114
+"5459","Metcalfe, Stephen","chief",2.15554828044959
+"5460","Metcalfe, Stephen","system",2.11675421758744
+"5461","Miller, Maria","9301",8.39268498036147
+"5462","Miller, Maria","page",6.91614538957078
+"5463","Miller, Maria","session",6.71247313126287
+"5464","Miller, Maria","transgender",6.3016860706382
+"5465","Miller, Maria","committee",5.71398502855797
+"5466","Miller, Maria","equalities",5.57118177522706
+"5467","Miller, Maria","july",4.47828911736006
+"5468","Miller, Maria","first",4.45337125199025
+"5469","Miller, Maria","women",4.36648542073737
+"5470","Miller, Maria","response",4.27182060065392
+"5471","Miller, Maria","reference",3.86157073871563
+"5472","Miller, Maria","published",3.51509522707682
+"5473","Mitchell, Austin","mackeys",3.43131630145811
+"5474","Mitchell, Austin","abrogated",3.31496648398472
+"5475","Mitchell, Austin","clause",2.54036981474323
+"5476","Mitchell, Austin","suppliers",2.42174508089634
+"5477","Mitchell, Austin","now",2.17507094485323
+"5478","Mitchell, Austin","lost",2.16354619114918
+"5479","Mitchell, Austin","firm",2.07163466432223
+"5480","Mitchell, Austin","signed",2.04801278008781
+"5481","Mitchell, Austin","money",1.99945029909348
+"5482","Mitchell, Austin","outstanding",1.96355682253244
+"5483","Mitchell, Austin","income",1.82222582472368
+"5484","Mitchell, Austin","include",1.66006886031844
+"5485","Monaghan, Dr Paul","eventual",2.95970249642714
+"5486","Monaghan, Dr Paul","reintegration",2.70970249642714
+"5487","Monaghan, Dr Paul","alternatives",2.41722124606656
+"5488","Monaghan, Dr Paul","facilitating",2.41722124606656
+"5489","Monaghan, Dr Paul","incarceration",2.3792204727053
+"5490","Monaghan, Dr Paul","encourage",2.23297984752501
+"5491","Monaghan, Dr Paul","disorders",2.16722124606656
+"5492","Monaghan, Dr Paul","skilling",2.16722124606656
+"5493","Monaghan, Dr Paul","users",2.04873844898346
+"5494","Monaghan, Dr Paul","imprisonment",1.60735476239271
+"5495","Monaghan, Dr Paul","drug",1.52433574982685
+"5496","Monaghan, Dr Paul","rehabilitation",1.22115341883042
+"5497","Moon, Madeleine","bridgend",16.3930758103863
+"5498","Moon, Madeleine","law",8.72957105784144
+"5499","Moon, Madeleine","hearing",8.27507816228714
+"5500","Moon, Madeleine","will",8.1623146932447
+"5501","Moon, Madeleine","cardiff",7.75682294326784
+"5502","Moon, Madeleine","2005",7.11262311131667
+"5503","Moon, Madeleine","maternity",6.36841585886313
+"5504","Moon, Madeleine","pregnancy",6.24611615640563
+"5505","Moon, Madeleine","courts",5.98128382212697
+"5506","Moon, Madeleine","magistrates",5.45214858913092
+"5507","Moon, Madeleine","parc",5.17947314422942
+"5508","Moon, Madeleine","discrimination",4.94824343017818
+"5509","Morden, Jessica","newport",18.905995579256
+"5510","Morden, Jessica","wales",11.3822888546127
+"5511","Morden, Jessica","east",9.1017514938756
+"5512","Morden, Jessica","shared",8.75938970849228
+"5513","Morden, Jessica","average",7.72425288808088
+"5514","Morden, Jessica","case",7.67765575096437
+"5515","Morden, Jessica","legal",7.41258183120592
+"5516","Morden, Jessica","2009",7.36831172210901
+"5517","Morden, Jessica","unemployed",7.35457430163056
+"5518","Morden, Jessica","family",7.08075763253076
+"5519","Morden, Jessica","2013",6.85622162535118
+"5520","Morden, Jessica","classed",6.81446653007963
+"5521","Morrice, Graeme","reoffending",4.68766302096222
+"5522","Morrice, Graeme","reduce",4.07434530537872
+"5523","Morrice, Graeme","check",3.01048502121699
+"5524","Morrice, Graeme","trade",2.94626999523619
+"5525","Morrice, Graeme","membership",2.86362749075499
+"5526","Morrice, Graeme","union",2.73165126531128
+"5527","Morrice, Graeme","end",2.47084841033549
+"5528","Morrice, Graeme","employee",2.41794916166247
+"5529","Morrice, Graeme","dues",2.36130749451503
+"5530","Morrice, Graeme","system",1.86680174879449
+"5531","Morrice, Graeme","plans",1.17379912398123
+"5532","Morrice, Graeme","2010",0
+"5533","Morris, David","lunesdale",4.05998820009529
+"5534","Morris, David","morecambe",4.05998820009529
+"5535","Morris, David","ogden",3.24870593743824
+"5536","Morris, David","discount",2.79116667421482
+"5537","Morris, David","consumers",2.63802026696727
+"5538","Morris, David","money",2.36578149835588
+"5539","Morris, David","policies",2.1117302095541
+"5540","Morris, David","tables",2.068757051589
+"5541","Morris, David","constituency",2.04955373233904
+"5542","Morris, David","insurance",1.94894604562278
+"5543","Morris, David","rates",1.69874164476196
+"5544","Morris, David","changes",1.60046957415724
+"5545","Morris, Grahame","prison",9.39917035590114
+"5546","Morris, Grahame","service",9.03764896574425
+"5547","Morris, Grahame","bailiffs",8.95035035693186
+"5548","Morris, Grahame","introduction",8.71724492706321
+"5549","Morris, Grahame","per",8.53330339277971
+"5550","Morris, Grahame","unemployed",8.11864173115495
+"5551","Morris, Grahame","officer",7.9256345343947
+"5552","Morris, Grahame","staff",7.63783655512423
+"5553","Morris, Grahame","classed",7.52242211141948
+"5554","Morris, Grahame","week",7.30063643826469
+"5555","Morris, Grahame","hours",7.185345526677
+"5556","Morris, Grahame","cells",7.17144763028504
+"5557","Mowat, David","day",3.77598056672138
+"5558","Mowat, David","clara",3.56084520918548
+"5559","Mowat, David","tully",3.56084520918548
+"5560","Mowat, David","warrington",3.5056272969404
+"5561","Mowat, David","sat",3.41794916166247
+"5562","Mowat, David","unmarried",3.31496648398472
+"5563","Mowat, David","leigh",3.12889493147202
+"5564","Mowat, David","labour",2.84390560599304
+"5565","Mowat, David","infants",2.78222504611588
+"5566","Mowat, David","chamber",2.7512824949958
+"5567","Mowat, David","1989",2.49649536803054
+"5568","Mowat, David","lawyers",2.40040534414891
+"5569","Mulholland, Greg","drive",14.8104757305267
+"5570","Mulholland, Greg","insolvency",13.7086457799432
+"5571","Mulholland, Greg","litigation",11.7382829840465
+"5572","Mulholland, Greg","departments",10.4164587513704
+"5573","Mulholland, Greg","effect",9.45317753420509
+"5574","Mulholland, Greg","funding",9.29652878574693
+"5575","Mulholland, Greg","dangerous",7.84743109257409
+"5576","Mulholland, Greg","hostility",7.16133050014528
+"5577","Mulholland, Greg","implacable",7.16133050014528
+"5578","Mulholland, Greg","made",7.05864461668015
+"5579","Mulholland, Greg","offence",7.02415407153502
+"5580","Mulholland, Greg","alternative",6.71206491611329
+"5581","Munn, Meg","employee",12.0445076666685
+"5582","Munn, Meg","tribunal",11.6247295425227
+"5583","Munn, Meg","fee",10.2006786087823
+"5584","Munn, Meg","introduction",6.75292215189704
+"5585","Munn, Meg","characteristics",5.05277029823147
+"5586","Munn, Meg","month",4.91631021294626
+"5587","Munn, Meg","whistleblowers",4.53920480163004
+"5588","Munn, Meg","remission",4.48966651859793
+"5589","Munn, Meg","make",3.74699145430494
+"5590","Munn, Meg","afford",3.54665495033786
+"5591","Munn, Meg","unable",3.47854462985022
+"5592","Munn, Meg","collected",3.44107536457026
+"5593","Murray, Ian","employment",17.8524923447577
+"5594","Murray, Ian","tribunal",16.2274308083268
+"5595","Murray, Ian","fee",12.5677626746555
+"5596","Murray, Ian","remission",10.4214445996831
+"5597","Murray, Ian","scottish",9.31882638372423
+"5598","Murray, Ian","replaced",8.80928467842814
+"5599","Murray, Ian","statistics",7.88301661569417
+"5600","Murray, Ian","system",7.57361000605923
+"5601","Murray, Ian","repeal",7.15138065761472
+"5602","Murray, Ian","begin",5.85098540984494
+"5603","Murray, Ian","british",5.77039604563885
+"5604","Murray, Ian","independence",5.68731323607868
+"5605","Murrison, Dr Andrew","violent",2.5981386221167
+"5606","Murrison, Dr Andrew","2005",2.5698423229212
+"5607","Murrison, Dr Andrew","imprisoned",2.14313968319029
+"5608","Murrison, Dr Andrew","drug",2.0324476664358
+"5609","Murrison, Dr Andrew","non",1.82125685145388
+"5610","Murrison, Dr Andrew","offences",1.20897389705419
+"5611","Murrison, Dr Andrew","people",1.15968680846208
+"5612","Murrison, Dr Andrew","since",0.922449207717312
+"5613","Murrison, Dr Andrew","year",0.621704206467736
+"5614","Murrison, Dr Andrew","2010",0
+"5615","Murrison, Dr Andrew","accommod",0
+"5616","Murrison, Dr Andrew","cost",0
+"5617","Nandy, Lisa","business",2.72572939967665
+"5618","Nandy, Lisa","governments",2.4340785078348
+"5619","Nandy, Lisa","action",2.31697953590881
+"5620","Nandy, Lisa","involvement",2.18014619849554
+"5621","Nandy, Lisa","human",2.08465525902437
+"5622","Nandy, Lisa","rights",1.83925027434876
+"5623","Nandy, Lisa","review",1.5705567117715
+"5624","Nandy, Lisa","plan",1.24500198047693
+"5625","Nandy, Lisa","2010",0
+"5626","Nandy, Lisa","accommod",0
+"5627","Nandy, Lisa","cost",0
+"5628","Nandy, Lisa","flight",0
+"5629","Nash, Pamela","93w",3.02613653442003
+"5630","Nash, Pamela","payroll",2.91527851217387
+"5631","Nash, Pamela","recent",2.57269523725017
+"5632","Nash, Pamela","zero",2.41685502996241
+"5633","Nash, Pamela","engaged",2.35010480806148
+"5634","Nash, Pamela","associated",2.32450984241044
+"5635","Nash, Pamela","executive",2.1693601931869
+"5636","Nash, Pamela","bodies",1.9988262282057
+"5637","Nash, Pamela","agencies",1.79955395722818
+"5638","Nash, Pamela","two",1.55798988947631
+"5639","Nash, Pamela","conditions",1.51145140583671
+"5640","Nash, Pamela","column",1.42775472138718
+"5641","Newlands, Gavin","classic",3.28349511107287
+"5642","Newlands, Gavin","alpha",3.12125570410566
+"5643","Newlands, Gavin","retirement",3.01048502121699
+"5644","Newlands, Gavin","longer",2.94626999523619
+"5645","Newlands, Gavin","officers",2.75289563153701
+"5646","Newlands, Gavin","affected",2.38268209655663
+"5647","Newlands, Gavin","pensions",2.25717779218662
+"5648","Newlands, Gavin","potential",1.9242402650836
+"5649","Newlands, Gavin","scheme",1.71024738594059
+"5650","Newlands, Gavin","following",1.66224787192714
+"5651","Newlands, Gavin","transfer",1.66224787192714
+"5652","Newlands, Gavin","changes",1.53768142878608
+"5653","Nokes, Caroline","family",7.02050088263552
+"5654","Nokes, Caroline","abuse",6.17977116156683
+"5655","Nokes, Caroline","domestic",5.94124911463415
+"5656","Nokes, Caroline","psychological",5.29506407252094
+"5657","Nokes, Caroline","victims",5.10422744524709
+"5658","Nokes, Caroline","cross",4.26226851353229
+"5659","Nokes, Caroline","examine",4.2318559432788
+"5660","Nokes, Caroline","alleged",3.93978281757942
+"5661","Nokes, Caroline","court",3.88109932113783
+"5662","Nokes, Caroline","rooms",3.61293666190285
+"5663","Nokes, Caroline","litigants",3.48638067399356
+"5664","Nokes, Caroline","representing",3.40351707358568
+"5665","Norman, Jesse","sparsely",4.05998820009529
+"5666","Norman, Jesse","ability",2.64979210162876
+"5667","Norman, Jesse","cover",2.59147193149936
+"5668","Norman, Jesse","solicitors",2.37704676774681
+"5669","Norman, Jesse","populated",2.29386798520442
+"5670","Norman, Jesse","duty",2.03316082283189
+"5671","Norman, Jesse","areas",1.85357855701278
+"5672","Norman, Jesse","crime",1.70632280581349
+"5673","Norman, Jesse","provide",1.50926683490426
+"5674","Norman, Jesse","made",0.902637855891325
+"5675","Norman, Jesse","2010",0
+"5676","Norman, Jesse","accommod",0
+"5677","Nuttall, David","bury",27.723223065518
+"5678","Nuttall, David","magistrates",16.4768975062535
+"5679","Nuttall, David","compensation",16.2105276899349
+"5680","Nuttall, David","court",10.1453368987561
+"5681","Nuttall, David","services)",8.87737117195899
+"5682","Nuttall, David","salford",8.71955000367613
+"5683","Nuttall, David","claims",8.17734799304843
+"5684","Nuttall, David","journeys",8.13641521830018
+"5685","Nuttall, David","duration",7.75647837440558
+"5686","Nuttall, David","leaving",7.38216631291639
+"5687","Nuttall, David","decision",7.18695903168146
+"5688","Nuttall, David","consequences",6.94786960943628
+"5689","O'Brien, Stephen","quantify",2.87084518782474
+"5690","O'Brien, Stephen","willingness",2.87084518782474
+"5691","O'Brien, Stephen","adjusted",2.42363159232479
+"5692","O'Brien, Stephen","approach",2.35164628192127
+"5693","O'Brien, Stephen","fatality",2.29283000073471
+"5694","O'Brien, Stephen","tools",2.2431015435558
+"5695","O'Brien, Stephen","intervention",2.2431015435558
+"5696","O'Brien, Stephen","calculation",1.97641799682483
+"5697","O'Brien, Stephen","circumstances",1.88869315421575
+"5698","O'Brien, Stephen","quality",1.87368596379625
+"5699","O'Brien, Stephen","life",1.5840132220546
+"5700","O'Brien, Stephen","benefit",1.57228115030586
+"5701","Offord, Dr Matthew","estate",16.8386298036618
+"5702","Offord, Dr Matthew","cigarette",12.7714552716119
+"5703","Offord, Dr Matthew","smoke",12.7714552716119
+"5704","Offord, Dr Matthew","round",10.6111016694718
+"5705","Offord, Dr Matthew","autopsies",10.1276507179416
+"5706","Offord, Dr Matthew","made",9.99213962640243
+"5707","Offord, Dr Matthew","ban",9.87942856152379
+"5708","Offord, Dr Matthew","funded",9.68443380960138
+"5709","Offord, Dr Matthew","invasive",9.62723759385653
+"5710","Offord, Dr Matthew","minimal",9.62723759385653
+"5711","Offord, Dr Matthew","service",9.40146076836276
+"5712","Offord, Dr Matthew","probate",9.32012928286514
+"5713","Onn, Melanie","inhouse",8.13192140627296
+"5714","Onn, Melanie","ltd",6.64142873086581
+"5715","Onn, Melanie","commercial",5.9545420069392
+"5716","Onn, Melanie","communication",5.66945825875286
+"5717","Onn, Melanie","ongoing",3.71827925096883
+"5718","Onn, Melanie","tender",2.67053292650208
+"5719","Onn, Melanie","process",2.14163208208077
+"5720","Onn, Melanie","awarded",2.11033844850329
+"5721","Onn, Melanie","contracts",1.61481884961657
+"5722","Onn, Melanie","relation",1.59378089262189
+"5723","Onn, Melanie","five",1.23995630432835
+"5724","Onn, Melanie","last",0.810160081647056
+"5725","Onwurah, Chi","share",8.28418904342415
+"5726","Onwurah, Chi","training",7.10949661284798
+"5727","Onwurah, Chi","financial",5.95638302988321
+"5728","Onwurah, Chi","data",5.76189573621343
+"5729","Onwurah, Chi","three",5.60777131475705
+"5730","Onwurah, Chi","day",5.54559825715783
+"5731","Onwurah, Chi","commissioners",5.48841685201774
+"5732","Onwurah, Chi","digital",5.48047686139434
+"5733","Onwurah, Chi","office",5.38450275233179
+"5734","Onwurah, Chi","information",5.1950936982658
+"5735","Onwurah, Chi","aware",4.807305009891
+"5736","Onwurah, Chi","charles",4.47464957730471
+"5737","Osamor, Kate","honour",6.63066672493389
+"5738","Osamor, Kate","based",4.76825168016134
+"5739","Osamor, Kate","transnational",4.53920480163004
+"5740","Osamor, Kate","forfeitures",3.97883593553688
+"5741","Osamor, Kate","judicial",3.56918513378373
+"5742","Osamor, Kate","violence",3.54474711948047
+"5743","Osamor, Kate","lease",3.47854462985022
+"5744","Osamor, Kate","plans",3.00570066644878
+"5745","Osamor, Kate","reform",2.8098207326232
+"5746","Osamor, Kate","occurred",2.74051506458869
+"5747","Osamor, Kate","allegations",2.69738490107438
+"5748","Osamor, Kate","territorial",2.64753203626047
+"5749","Oswald, Kirsten ","397",3.43131630145811
+"5750","Oswald, Kirsten ","dishonest",3.43131630145811
+"5751","Oswald, Kirsten ","investors",3.02613653442003
+"5752","Oswald, Kirsten ","concealment",3.00771725513075
+"5753","Oswald, Kirsten ","financial",2.8167994370648
+"5754","Oswald, Kirsten ","entrusted",2.79043427402451
+"5755","Oswald, Kirsten ","markets",2.50674431074999
+"5756","Oswald, Kirsten ","material",2.44233218676566
+"5757","Oswald, Kirsten ","range",2.31902975323348
+"5758","Oswald, Kirsten ","exchequer",2.27897804629582
+"5759","Oswald, Kirsten ","2000",2.03903132527525
+"5760","Oswald, Kirsten ","2008",1.99015885026025
+"5761","Paisley, Ian","crash",4.84726318464957
+"5762","Paisley, Ian","known",4.4862030871116
+"5763","Paisley, Ian","cash",4.40004958914961
+"5764","Paisley, Ian","abuse",3.6600211835152
+"5765","Paisley, Ian","domestic",3.5187545052378
+"5766","Paisley, Ian","nspcc",3.41757006606683
+"5767","Paisley, Ian","fraud",3.30015833209255
+"5768","Paisley, Ian","rest",3.24870593743824
+"5769","Paisley, Ian","feasibl",3.12889493147202
+"5770","Paisley, Ian","regardless",3.12125570410566
+"5771","Paisley, Ian","insurance",3.01929423094153
+"5772","Paisley, Ian","victims",2.70756790725829
+"5773","Patel, Priti","purse",2.14313968319029
+"5774","Patel, Priti","funding",1.7823189631263
+"5775","Patel, Priti","support",1.65409767971452
+"5776","Patel, Priti","provided",1.59090693175026
+"5777","Patel, Priti","victims",1.47788950752407
+"5778","Patel, Priti","public",1.41794916166247
+"5779","Patel, Priti","services",1.16483802593091
+"5780","Patel, Priti","last",0.810160081647056
+"5781","Patel, Priti","years",0.621704206467736
+"5782","Patel, Priti","2010",0
+"5783","Patel, Priti","accommod",0
+"5784","Patel, Priti","cost",0
+"5785","Peacock, Stephanie","barnsley",3.05676759423755
+"5786","Peacock, Stephanie","entitlement",1.87293536701898
+"5787","Peacock, Stephanie","allowance",1.5885194715722
+"5788","Peacock, Stephanie","rate",1.51940071755902
+"5789","Peacock, Stephanie","success",1.51344055428188
+"5790","Peacock, Stephanie","independence",1.50757425575459
+"5791","Peacock, Stephanie","decisions",1.48226248077458
+"5792","Peacock, Stephanie","data",1.42445277907625
+"5793","Peacock, Stephanie","payment",1.35848277344775
+"5794","Peacock, Stephanie","appeals",1.31962600256212
+"5795","Peacock, Stephanie","support",1.28125855330693
+"5796","Peacock, Stephanie","recent",1.23650452588379
+"5797","Pearce, Teresa","belmarsh",16.5490400570941
+"5798","Pearce, Teresa","categorisation",11.911404080344
+"5799","Pearce, Teresa","prison",8.58261207302505
+"5800","Pearce, Teresa","unemployed",8.01579185134564
+"5801","Pearce, Teresa","classed",7.42712535665994
+"5802","Pearce, Teresa","hmp",7.36171494517828
+"5803","Pearce, Teresa","death",7.2316091023673
+"5804","Pearce, Teresa","week",7.20814934435518
+"5805","Pearce, Teresa","hours",7.09431897959201
+"5806","Pearce, Teresa","cells",7.08059714676104
+"5807","Pearce, Teresa","per",6.96171578418881
+"5808","Pearce, Teresa","data",6.69020198820973
+"5809","Pennycook, Matthew","universal",3.17222462467664
+"5810","Pennycook, Matthew","cycle",2.9660198676456
+"5811","Pennycook, Matthew","periodic",2.8559968586598
+"5812","Pennycook, Matthew","third",2.69327453376365
+"5813","Pennycook, Matthew","submit",2.53976909264296
+"5814","Pennycook, Matthew","national",1.50083368850539
+"5815","Pennycook, Matthew","dates",1.45628904348129
+"5816","Pennycook, Matthew","review",1.40474862801585
+"5817","Pennycook, Matthew","report",1.3596690855956
+"5818","Pennycook, Matthew","plans",1.11356362418732
+"5819","Pennycook, Matthew","2010",0
+"5820","Pennycook, Matthew","accommod",0
+"5821","Percy, Andrew","cellular",8.37130282207354
+"5822","Percy, Andrew","devices",8.37130282207354
+"5823","Percy, Andrew","goole",7.36384006130302
+"5824","Percy, Andrew","brigg",6.74183159337487
+"5825","Percy, Andrew","defibrillators",6.41940499285428
+"5826","Percy, Andrew","illegal",5.03430737635125
+"5827","Percy, Andrew","telephone",5.02826823883978
+"5828","Percy, Andrew","mobile",4.87580618959043
+"5829","Percy, Andrew","obtain",4.33444249213312
+"5830","Percy, Andrew","surrogacy",4.05998820009529
+"5831","Percy, Andrew","constituency",4.03139734706516
+"5832","Percy, Andrew","prison",3.95288956344129
+"5833","Perkins, Toby","jail",7.35703335685993
+"5834","Perkins, Toby","2005",6.82111307715037
+"5835","Perkins, Toby","organisations",6.63057804662788
+"5836","Perkins, Toby","community",6.52663455849311
+"5837","Perkins, Toby","rehabilitation",6.45614728051855
+"5838","Perkins, Toby","companies",6.31538338676162
+"5839","Perkins, Toby","sex",6.15456712825601
+"5840","Perkins, Toby","approved",5.55273903119893
+"5841","Perkins, Toby","phishing",4.05998820009529
+"5842","Perkins, Toby","related",3.98842221464287
+"5843","Perkins, Toby","applications",3.84684401234973
+"5844","Perkins, Toby","scams",3.74376043407845
+"5845","Phillips, Jess","victim",15.255578757027
+"5846","Phillips, Jess","code",13.2780049568784
+"5847","Phillips, Jess","trials",12.8779710838665
+"5848","Phillips, Jess","derbyshire",9.85767266215104
+"5849","Phillips, Jess","foston",9.85767266215104
+"5850","Phillips, Jess","convicted",8.70076508459977
+"5851","Phillips, Jess","since",8.35685600045161
+"5852","Phillips, Jess","practice",8.19298756678034
+"5853","Phillips, Jess","plans",7.83564440161273
+"5854","Phillips, Jess","hall",7.59340577831091
+"5855","Phillips, Jess","aged",7.5558864928237
+"5856","Phillips, Jess","people",7.38517704038211
+"5857","Phillips, Stephen","grantham",7.11032505478187
+"5858","Phillips, Stephen","freehold",6.15840517488079
+"5859","Phillips, Stephen","market",5.63320376644041
+"5860","Phillips, Stephen","used",4.07810412738959
+"5861","Phillips, Stephen","estimate",3.97132824006325
+"5862","Phillips, Stephen","magistrates",3.92944196991895
+"5863","Phillips, Stephen","buildings",3.85133987926054
+"5864","Phillips, Stephen","value",3.670167102332
+"5865","Phillips, Stephen","11183",3.43131630145811
+"5866","Phillips, Stephen","boston",3.20970249642714
+"5867","Phillips, Stephen","skegness",3.20970249642714
+"5868","Phillips, Stephen","23485",3.11386880460654
+"5869","Phillipson, Bridget","sunderland",34.7692699165493
+"5870","Phillipson, Bridget","court",32.0870612682348
+"5871","Phillipson, Bridget","programme",22.734070491637
+"5872","Phillipson, Bridget","reform",22.2217921405027
+"5873","Phillipson, Bridget","houghton",19.904212634687
+"5874","Phillipson, Bridget","answer",19.7418114249973
+"5875","Phillipson, Bridget","south",17.4659366519192
+"5876","Phillipson, Bridget","families",15.387934008876
+"5877","Phillipson, Bridget","plan",13.7991178857967
+"5878","Phillipson, Bridget","domestic",13.5742195735645
+"5879","Phillipson, Bridget","audit",13.4945345051337
+"5880","Phillipson, Bridget","hon",12.532580443716
+"5881","Poulter, Dr  ","increase",4.17442697215868
+"5882","Poulter, Dr  ","socio",3.82911518397058
+"5883","Poulter, Dr  ","magistrates",3.77192146148563
+"5884","Poulter, Dr  ","bono",3.74376043407845
+"5885","Poulter, Dr  ","diversity",3.57272251098088
+"5886","Poulter, Dr  ","background",3.53905747505455
+"5887","Poulter, Dr  ","economic",3.50721308287814
+"5888","Poulter, Dr  ","among",3.47700247201039
+"5889","Poulter, Dr  ","pro",3.32573006579733
+"5890","Poulter, Dr  ","attorney",2.71667557231756
+"5891","Poulter, Dr  ","social",2.70642350702279
+"5892","Poulter, Dr  ","holds",2.68301733631525
+"5893","Pound, Stephen","yet",3.15791038487567
+"5894","Pound, Stephen","commenced",2.85809820335057
+"5895","Pound, Stephen","serious",2.30406568859574
+"5896","Pound, Stephen","reasons",1.91066678394862
+"5897","Pound, Stephen","crime",1.90772689267857
+"5898","Pound, Stephen","section",1.86285668500313
+"5899","Pound, Stephen","act",1.45221735385955
+"5900","Pound, Stephen","2015",1.3253647347837
+"5901","Pound, Stephen","2010",0
+"5902","Pound, Stephen","accommod",0
+"5903","Pound, Stephen","cost",0
+"5904","Pound, Stephen","flight",0
+"5905","Powell, Lucy","reoffending",7.33594168086929
+"5906","Powell, Lucy","five",7.0040445224571
+"5907","Powell, Lucy","force",6.82362417964473
+"5908","Powell, Lucy","rate",6.51182086144694
+"5909","Powell, Lucy","area",6.48627689854289
+"5910","Powell, Lucy","police",6.11490386640934
+"5911","Powell, Lucy","sex",5.60022158633514
+"5912","Powell, Lucy","last",5.13387851078957
+"5913","Powell, Lucy","categorised",5.08073962948646
+"5914","Powell, Lucy","england",4.50815609865522
+"5915","Powell, Lucy","wales",4.48991060152243
+"5916","Powell, Lucy","job",4.19087809376928
+"5917","Prentis, Victoria","caseload",7.75118012196051
+"5918","Prentis, Victoria","carry",5.15274594718982
+"5919","Prentis, Victoria","probation",3.79372845989368
+"5920","Prentis, Victoria","national",3.58767872470901
+"5921","Prentis, Victoria","officers",3.40764688558734
+"5922","Prentis, Victoria","service",2.64160434367252
+"5923","Prentis, Victoria","area",2.21545012099043
+"5924","Prentis, Victoria","average",1.79584041953905
+"5925","Prentis, Victoria","2010",0
+"5926","Prentis, Victoria","accommod",0
+"5927","Prentis, Victoria","cost",0
+"5928","Prentis, Victoria","flight",0
+"5929","Prisk, Mark","1296",2.73724348610663
+"5930","Prisk, Mark","1297",2.73724348610663
+"5931","Prisk, Mark","sold",2.18612762920049
+"5932","Prisk, Mark","land",1.92551268930389
+"5933","Prisk, Mark","disposing",1.7864894704743
+"5934","Prisk, Mark","paragraphs",1.68100528376583
+"5935","Prisk, Mark","autumn",1.65259276391951
+"5936","Prisk, Mark","identify",1.55961612024068
+"5937","Prisk, Mark","capacity",1.54018332521237
+"5938","Prisk, Mark","spending",1.49366715666322
+"5939","Prisk, Mark","governments",1.46780456741021
+"5940","Prisk, Mark","progress",1.33980044751246
+"5941","Pritchard, Mark","judge",6.90464628026621
+"5942","Pritchard, Mark","circuit",6.28554479801711
+"5943","Pritchard, Mark","veto",6.28554479801711
+"5944","Pritchard, Mark","removal",5.81709926739656
+"5945","Pritchard, Mark","improve",5.01200973453228
+"5946","Pritchard, Mark","district",4.35092287689417
+"5947","Pritchard, Mark","will",4.0182321468855
+"5948","Pritchard, Mark","chancellors",3.99091614133482
+"5949","Pritchard, Mark","research",3.74348013489766
+"5950","Pritchard, Mark","power",3.71963262233453
+"5951","Pritchard, Mark","reoffending",3.68550049794132
+"5952","Pritchard, Mark","chief",3.619033728153
+"5953","Pugh, John","westminster",7.04323170660608
+"5954","Pugh, John","british",4.76144340038914
+"5955","Pugh, John","approximately",4.53920480163004
+"5956","Pugh, John","cleaning",3.97883593553688
+"5957","Pugh, John","nationals",3.26000069013947
+"5958","Pugh, John","payroll",3.22296166142208
+"5959","Pugh, John","another",2.62820455844056
+"5960","Pugh, John","suicide",2.43841600988385
+"5961","Pugh, John","cost",2.41295568213252
+"5962","Pugh, John","harmed",2.37029651038179
+"5963","Pugh, John","assertion",2.36776199714171
+"5964","Pugh, John","defender",2.28528799551152
+"5965","Pursglove, Tom","corby",9.9626188346255
+"5966","Pursglove, Tom","kettering",9.9626188346255
+"5967","Pursglove, Tom","magistrates",7.22853398590158
+"5968","Pursglove, Tom","wellingborough",6.3909082306143
+"5969","Pursglove, Tom","cost",4.70461414082225
+"5970","Pursglove, Tom","union",4.32160968831405
+"5971","Pursglove, Tom","northamptonshire",3.87104686156941
+"5972","Pursglove, Tom","leasehold",3.7512824949958
+"5973","Pursglove, Tom","northampton",3.42753266806161
+"5974","Pursglove, Tom","freehold",3.41794916166247
+"5975","Pursglove, Tom","courts",3.37572907972201
+"5976","Pursglove, Tom","sitting",3.34075615827703
+"5977","Quin, Jeremy","adur",7.90419475831916
+"5978","Quin, Jeremy","arun",7.90419475831916
+"5979","Quin, Jeremy","e07000223",7.90419475831916
+"5980","Quin, Jeremy","e07000224",7.90419475831916
+"5981","Quin, Jeremy","e07000225",7.90419475831916
+"5982","Quin, Jeremy","e07000226",7.90419475831916
+"5983","Quin, Jeremy","e07000227",7.90419475831916
+"5984","Quin, Jeremy","e07000228",7.90419475831916
+"5985","Quin, Jeremy","e07000229",7.90419475831916
+"5986","Quin, Jeremy","horsham",7.90419475831916
+"5987","Quin, Jeremy","mid",7.90419475831916
+"5988","Quin, Jeremy","crawley",7.66942891561876
+"5989","Quince, Will","improve",3.71202681900264
+"5990","Quince, Will","education",3.56837020943509
+"5991","Quince, Will","34465",3.56084520918548
+"5992","Quince, Will","web",3.56084520918548
+"5993","Quince, Will","honours",3.00614501296026
+"5994","Quince, Will","users",2.27287123933059
+"5995","Quince, Will","online",2.17409471862241
+"5996","Quince, Will","forms",2.14983689102042
+"5997","Quince, Will","completing",1.80248718886617
+"5998","Quince, Will","include",1.78320000420559
+"5999","Quince, Will","allow",1.70634363194117
+"6000","Quince, Will","april",1.6986485561086
+"6001","Qureshi, Yasmin","within",17.537863627217
+"6002","Qureshi, Yasmin","child",17.083347632812
+"6003","Qureshi, Yasmin","victims",12.0296773010742
+"6004","Qureshi, Yasmin","2012",8.06929008819133
+"6005","Qureshi, Yasmin","per",7.85986268543974
+"6006","Qureshi, Yasmin","prison",7.67853493840991
+"6007","Qureshi, Yasmin","2013",7.66314216191979
+"6008","Qureshi, Yasmin","last",7.57219877120728
+"6009","Qureshi, Yasmin","2015",7.40328348910551
+"6010","Qureshi, Yasmin","unemployed",7.28333303811424
+"6011","Qureshi, Yasmin","intermediaries",6.77081854745939
+"6012","Qureshi, Yasmin","classed",6.74845710711618
+"6013","Raab, Dominic","countries",7.39612490073182
+"6014","Raab, Dominic","field",6.69555684047549
+"6015","Raab, Dominic","affairs",5.35510930002753
+"6016","Raab, Dominic","citizens",4.63839045939512
+"6017","Raab, Dominic","back",4.63839045939512
+"6018","Raab, Dominic","outside",4.52857837206909
+"6019","Raab, Dominic","rate",4.42186304432877
+"6020","Raab, Dominic","agreements",4.11963107883832
+"6021","Raab, Dominic","home",3.93072125157178
+"6022","Raab, Dominic","reoffending",3.82746082915699
+"6023","Raab, Dominic","british",3.77520190798793
+"6024","Raab, Dominic","operation",3.72586568661105
+"6025","Reckless, Mark","eves",6.41940499285428
+"6026","Reckless, Mark","called",3.7232462814649
+"6027","Reckless, Mark","implementation",3.08319232186853
+"6028","Reckless, Mark","law",2.80020262319174
+"6029","Reckless, Mark","2010",0
+"6030","Reckless, Mark","accommod",0
+"6031","Reckless, Mark","cost",0
+"6032","Reckless, Mark","flight",0
+"6033","Reckless, Mark","hotel",0
+"6034","Reckless, Mark","intern",0
+"6035","Reckless, Mark","made",0
+"6036","Reckless, Mark","oversea",0
+"6037","Redwood, John","directives",5.16265094558885
+"6038","Redwood, John","negotiations",4.4862030871116
+"6039","Redwood, John","transposition",4.47464957730471
+"6040","Redwood, John","law",4.09679648114268
+"6041","Redwood, John","transposed",3.97883593553688
+"6042","Redwood, John","leading",3.95283599364966
+"6043","Redwood, John","cartridges",3.87104686156941
+"6044","Redwood, John","fasteners",3.87104686156941
+"6045","Redwood, John","printer",3.87104686156941
+"6046","Redwood, John","responsibilities",3.61529309021335
+"6047","Redwood, John","awaiting",3.34075615827703
+"6048","Redwood, John","departments",3.33595558530139
+"6049","Reed, Jamie","cumbria",16.2652214081402
+"6050","Reed, Jamie","copeland",12.8847716672138
+"6051","Reed, Jamie","escape",5.21082189466491
+"6052","Reed, Jamie","six",4.39374330507507
+"6053","Reed, Jamie","constituency",4.16244875455925
+"6054","Reed, Jamie","transparency",3.97883593553688
+"6055","Reed, Jamie","west",3.92460461584559
+"6056","Reed, Jamie","reassuring",3.87104686156941
+"6057","Reed, Jamie","police",3.61983992675931
+"6058","Reed, Jamie","amongst",3.41794916166247
+"6059","Reed, Jamie","omit",3.39316268687164
+"6060","Reed, Jamie","morale",3.34381835455032
+"6061","Reed, Steve","injunctions",6.80748498671001
+"6062","Reed, Steve","anti",5.36087180666306
+"6063","Reed, Steve","introduction",5.35051605723634
+"6064","Reed, Steve","behaviour",5.01365101488918
+"6065","Reed, Steve","act",4.82638907793364
+"6066","Reed, Steve","focus",4.25355453398948
+"6067","Reed, Steve","arising",4.04049769185166
+"6068","Reed, Steve","social",3.9350393430993
+"6069","Reed, Steve","2008",3.91283496251922
+"6070","Reed, Steve","annoyance",3.70624520066165
+"6071","Reed, Steve","surveys",3.59704324855529
+"6072","Reed, Steve","immigration",3.43389732355252
+"6073","Rees-Mogg, Jacob","ratify",3.71827925096883
+"6074","Rees-Mogg, Jacob","protocol",3.09406845518197
+"6075","Rees-Mogg, Jacob","sign",2.8043569942824
+"6076","Rees-Mogg, Jacob","convention",2.55410509904568
+"6077","Rees-Mogg, Jacob","european",2.25545085155543
+"6078","Rees-Mogg, Jacob","human",2.08465525902437
+"6079","Rees-Mogg, Jacob","rights",1.83925027434876
+"6080","Rees-Mogg, Jacob","plans",1.24500198047693
+"6081","Rees-Mogg, Jacob","2010",0
+"6082","Rees-Mogg, Jacob","accommod",0
+"6083","Rees-Mogg, Jacob","cost",0
+"6084","Rees-Mogg, Jacob","flight",0
+"6085","Rees, Christina","court",31.9938089680613
+"6086","Rees, Christina","claim",28.2202832179722
+"6087","Rees, Christina","injuries",23.1098691630221
+"6088","Rees, Christina","plan",20.2139659744719
+"6089","Rees, Christina","publish",19.8831684827947
+"6090","Rees, Christina","restorative",19.5855868745667
+"6091","Rees, Christina","justice",18.4053106348392
+"6092","Rees, Christina","time",18.3001957545072
+"6093","Rees, Christina","whiplash",18.1318784746906
+"6094","Rees, Christina","2015",17.2452661093465
+"6095","Rees, Christina","unrepresented",16.166661595285
+"6096","Rees, Christina","banning",15.7967578077291
+"6097","Reevell, Simon","jeffrey",4.85261405031394
+"6098","Reevell, Simon","advocacy",4.09668510429549
+"6099","Reevell, Simon","recommendations",2.60213937966508
+"6100","Reevell, Simon","future",2.58482721225858
+"6101","Reevell, Simon","implementation",2.33067432224227
+"6102","Reevell, Simon","criminal",1.69709141320269
+"6103","Reevell, Simon","report",1.62511539033139
+"6104","Reevell, Simon","2010",0
+"6105","Reevell, Simon","accommod",0
+"6106","Reevell, Simon","cost",0
+"6107","Reevell, Simon","flight",0
+"6108","Reevell, Simon","hotel",0
+"6109","Reeves, Ellie","racism",6.40087994200238
+"6110","Reeves, Ellie","homophobia",3.87104686156941
+"6111","Reeves, Ellie","islamophobia",3.87104686156941
+"6112","Reeves, Ellie","educate",3.5153549965841
+"6113","Reeves, Ellie","sponsors",3.26802417241388
+"6114","Reeves, Ellie","semitism",3.26802417241388
+"6115","Reeves, Ellie","clearance",2.89679381763326
+"6116","Reeves, Ellie","anti",2.72308615973505
+"6117","Reeves, Ellie","hate",2.68101913850003
+"6118","Reeves, Ellie","across",2.59024852532215
+"6119","Reeves, Ellie","discrimination",2.08314526442263
+"6120","Reeves, Ellie","programmes",1.81085300604662
+"6121","Reeves, Rachel","esa",4.53920480163004
+"6122","Reeves, Rachel","appeal",3.17291500605523
+"6123","Reeves, Rachel","lose",3.00771725513075
+"6124","Reeves, Rachel","pip",3.00771725513075
+"6125","Reeves, Rachel","waiting",2.821649149365
+"6126","Reeves, Rachel","expenses",2.58411820880339
+"6127","Reeves, Rachel","reassessment",2.58411820880339
+"6128","Reeves, Rachel","hearing",2.26717710875506
+"6129","Reeves, Rachel","eligible",2.09501009189598
+"6130","Reeves, Rachel","benefits",1.87923541276276
+"6131","Reeves, Rachel","average",1.67985489280887
+"6132","Reeves, Rachel","time",1.57664716888807
+"6133","Reid, Alan","indian",4.47464957730471
+"6134","Reid, Alan","serving",2.00015606292625
+"6135","Reid, Alan","nationals",1.79383936235451
+"6136","Reid, Alan","england",1.53980397852783
+"6137","Reid, Alan","wales",1.53357205388713
+"6138","Reid, Alan","sentence",1.32080217183626
+"6139","Reid, Alan","prison",0.676936046185048
+"6140","Reid, Alan","2010",0
+"6141","Reid, Alan","accommod",0
+"6142","Reid, Alan","cost",0
+"6143","Reid, Alan","flight",0
+"6144","Reid, Alan","hotel",0
+"6145","Reynolds, Emma","forfeited",3.41757006606683
+"6146","Reynolds, Emma","forfeiture",3.24870593743824
+"6147","Reynolds, Emma","leasehold",3.24870593743824
+"6148","Reynolds, Emma","residential",2.89583164068126
+"6149","Reynolds, Emma","leasehold",2.84021979687721
+"6150","Reynolds, Emma","presented",2.40040534414891
+"6151","Reynolds, Emma","county",2.2138164050252
+"6152","Reynolds, Emma","cases",1.63921110520083
+"6153","Reynolds, Emma","battery",1.49154985910157
+"6154","Reynolds, Emma","deception",1.49154985910157
+"6155","Reynolds, Emma","mistrial",1.49154985910157
+"6156","Reynolds, Emma","penetration",1.49154985910157
+"6157","Rimmer, Marie","data",16.602822814346
+"6158","Rimmer, Marie","commissioner",16.141155526145
+"6159","Rimmer, Marie","mediating",16.0502158918651
+"6160","Rimmer, Marie","information",14.6246190157184
+"6161","Rimmer, Marie","controller",13.3921112090766
+"6162","Rimmer, Marie","registration",12.6376300515765
+"6163","Rimmer, Marie","ico",11.850528564918
+"6164","Rimmer, Marie","obligations",11.5882632769978
+"6165","Rimmer, Marie","fee",9.81960393041922
+"6166","Rimmer, Marie","office",9.21841875886508
+"6167","Rimmer, Marie","provided",8.85366125596128
+"6168","Rimmer, Marie","notification",8.59874768245368
+"6169","Ritchie, Margaret","rights",11.9467289867489
+"6170","Ritchie, Margaret","human",11.312150683421
+"6171","Ritchie, Margaret","repeal",10.2154402504834
+"6172","Ritchie, Margaret","1998",8.55553790249591
+"6173","Ritchie, Margaret","discussed",6.72776743219094
+"6174","Ritchie, Margaret","northern",6.63802653681716
+"6175","Ritchie, Margaret","ireland",6.57050919294447
+"6176","Ritchie, Margaret","act",5.98200110007857
+"6177","Ritchie, Margaret","held",5.0201816527587
+"6178","Ritchie, Margaret","legislation",4.43747653080683
+"6179","Ritchie, Margaret","devolved",4.41251873543258
+"6180","Ritchie, Margaret","proposals",4.36545174443846
+"6181","Roberts, Liz Saville","wales",68.4828476003238
+"6182","Roberts, Liz Saville","community",65.3321539463364
+"6183","Roberts, Liz Saville","rehabilitation",58.2361824340361
+"6184","Roberts, Liz Saville","companies",56.9664543065986
+"6185","Roberts, Liz Saville","victim",43.0277026775463
+"6186","Roberts, Liz Saville","port",41.7369058494152
+"6187","Roberts, Liz Saville","talbot",41.7369058494152
+"6188","Roberts, Liz Saville","supervised",39.0031967272035
+"6189","Roberts, Liz Saville","england",31.326636631315
+"6190","Roberts, Liz Saville","probation",28.5195805570239
+"6191","Roberts, Liz Saville","new",24.4714072747466
+"6192","Roberts, Liz Saville","offender",24.1515116015313
+"6193","Robertson, John","disincentive",3.39316268687164
+"6194","Robertson, John","discrimination",2.35010480806148
+"6195","Robertson, John","sex",2.09736324608528
+"6196","Robertson, John","bringing",1.83036250545577
+"6197","Robertson, John","level",1.77078387586228
+"6198","Robertson, John","women",1.70026397235845
+"6199","Robertson, John","fees",1.57958692184775
+"6200","Robertson, John","claim",1.49618764642105
+"6201","Robertson, John","tribunal",1.2467211920649
+"6202","Robertson, John","acts",1.23845512058762
+"6203","Robertson, John","will",0.814242899404655
+"6204","Robertson, John","2010",0
+"6205","Robertson, Laurence","will",9.81901354611737
+"6206","Robertson, Laurence","fathers",9.28773534301111
+"6207","Robertson, Laurence","children",7.3731510868303
+"6208","Robertson, Laurence","mercy",6.51604297922696
+"6209","Robertson, Laurence","prerogative",6.51604297922696
+"6210","Robertson, Laurence","royal",6.01093934556724
+"6211","Robertson, Laurence","recent",5.55921453181597
+"6212","Robertson, Laurence","child",5.478775156382
+"6213","Robertson, Laurence","restricted",5.26312953052077
+"6214","Robertson, Laurence","contact",5.24351704994391
+"6215","Robertson, Laurence","adequacy",5.19172561434198
+"6216","Robertson, Laurence","made",4.96578699397831
+"6217","Robinson, Gavin","hyde",5.46601916160477
+"6218","Robinson, Gavin","maximum",5.24146099869667
+"6219","Robinson, Gavin","park",4.77873224966062
+"6220","Robinson, Gavin","increased",4.07434530537872
+"6221","Robinson, Gavin","recent",3.64823887265914
+"6222","Robinson, Gavin","attributable",3.41846706944372
+"6223","Robinson, Gavin","northern",3.13080918459068
+"6224","Robinson, Gavin","ireland",3.09896479241428
+"6225","Robinson, Gavin","30414",3.02613653442003
+"6226","Robinson, Gavin","outwith",3.02613653442003
+"6227","Robinson, Gavin","behaviour",2.9862860842447
+"6228","Robinson, Gavin","bombing",2.95970249642714
+"6229","Rosindell, Andrew","people",8.59509213217672
+"6230","Rosindell, Andrew","principles",8.05740415355521
+"6231","Rosindell, Andrew","leave",7.86665182756377
+"6232","Rosindell, Andrew","dependencies",7.01430401662148
+"6233","Rosindell, Andrew","prison",6.8785440907023
+"6234","Rosindell, Andrew","convicted",6.86012353056222
+"6235","Rosindell, Andrew","membership",6.67812333268912
+"6236","Rosindell, Andrew","january",6.47588597938596
+"6237","Rosindell, Andrew","since",6.35079744657254
+"6238","Rosindell, Andrew","television",6.26520343812711
+"6239","Rosindell, Andrew","consoles",6.1289729592364
+"6240","Rosindell, Andrew","30551",5.91940499285428
+"6241","Rotheram, Steve","altcourse",32.3383386421065
+"6242","Rotheram, Steve","prison",10.4015939271975
+"6243","Rotheram, Steve","liverpool",9.25359708454877
+"6244","Rotheram, Steve","g4s",9.06443893433821
+"6245","Rotheram, Steve","secretariat",9.0188253488288
+"6246","Rotheram, Steve","zone",8.58727486571043
+"6247","Rotheram, Steve","staff",8.55597678194744
+"6248","Rotheram, Steve","exclusion",7.50752716450826
+"6249","Rotheram, Steve","part",6.84452615210214
+"6250","Rotheram, Steve","strategic",6.36169236114788
+"6251","Rotheram, Steve","attempted",6.29811779018604
+"6252","Rotheram, Steve","safety",6.20541046910817
+"6253","Roy, Frank","motherwell",3.02613653442003
+"6254","Roy, Frank","wishaw",3.02613653442003
+"6255","Roy, Frank","submitted",1.89303211276754
+"6256","Roy, Frank","live",1.70273673269712
+"6257","Roy, Frank","disabl",1.68913305939254
+"6258","Roy, Frank","constituency",1.5276471563495
+"6259","Roy, Frank","allowance",1.45011324602714
+"6260","Roy, Frank","june",1.40388201018996
+"6261","Roy, Frank","independence",1.37622071165142
+"6262","Roy, Frank","decision",1.35311432810634
+"6263","Roy, Frank","applicants",1.32002817570349
+"6264","Roy, Frank","payment",1.24011943166586
+"6265","Ruane, Chris","per",9.34684788585726
+"6266","Ruane, Chris","hours",9.14533592873665
+"6267","Ruane, Chris","closure",8.47389655740111
+"6268","Ruane, Chris","unemployed",8.42507288859328
+"6269","Ruane, Chris","killed",8.40263723619825
+"6270","Ruane, Chris","classed",7.80634947152163
+"6271","Ruane, Chris","proportion",7.76969076123374
+"6272","Ruane, Chris","week",7.57619268866911
+"6273","Ruane, Chris","cells",7.44212776011804
+"6274","Ruane, Chris","spent",7.44067820513324
+"6275","Ruane, Chris","year",7.18411518243429
+"6276","Ruane, Chris","rhyl",6.90781549362413
+"6277","Ruffley, David","suffolk",22.2555336333675
+"6278","Ruffley, David","edmunds",17.0355785463568
+"6279","Ruffley, David","bury",14.7636008261731
+"6280","Ruffley, David","england",12.0780602510367
+"6281","Ruffley, David","wales",9.38653893938178
+"6282","Ruffley, David","east",7.93801714970858
+"6283","Ruffley, David","speeding",7.23881369156053
+"6284","Ruffley, David","constituency",6.69941078221865
+"6285","Ruffley, David","a14",5.91940499285428
+"6286","Ruffley, David","a143",5.91940499285428
+"6287","Ruffley, David","notices",5.72698538263046
+"6288","Ruffley, David","fixed",5.57045455654733
+"6289","Russell, Sir Bob","led",4.80863220182643
+"6290","Russell, Sir Bob","replacement",4.51435558437324
+"6291","Russell, Sir Bob","lighting",3.79348924101959
+"6292","Russell, Sir Bob","buildings",3.55704009794244
+"6293","Russell, Sir Bob","introduce",3.49441774270141
+"6294","Russell, Sir Bob","implement",3.42049477188119
+"6295","Russell, Sir Bob","programme",3.33148498672838
+"6296","Russell, Sir Bob","throughout",2.84390560599304
+"6297","Russell, Sir Bob","sites",2.09493838521941
+"6298","Russell, Sir Bob","guidance",1.86088796307582
+"6299","Russell, Sir Bob","operators",1.67282465366542
+"6300","Russell, Sir Bob","will",1.49798906143073
+"6301","Ryan, Joan","51526",3.28349511107287
+"6302","Ryan, Joan","ratification",3.12125570410566
+"6303","Ryan, Joan","istanbul",3.00614501296026
+"6304","Ryan, Joan","retirement",2.8559968586598
+"6305","Ryan, Joan","territorial",2.84390560599304
+"6306","Ryan, Joan","extending",2.57357864873072
+"6307","Ryan, Joan","jurisdiction",2.50487494800326
+"6308","Ryan, Joan","mandatory",2.45119119111302
+"6309","Ryan, Joan","extra",2.42718698913304
+"6310","Ryan, Joan","merits",2.26620980630634
+"6311","Ryan, Joan","convention",2.00360488304627
+"6312","Ryan, Joan","age",1.8254946009211
+"6313","Sandbach, Antoinette","qualifications",3.82911518397058
+"6314","Sandbach, Antoinette","civilian",3.61293666190285
+"6315","Sandbach, Antoinette","entry",3.60842906640044
+"6316","Sandbach, Antoinette","officers",3.34297069063371
+"6317","Sandbach, Antoinette","jewish",3.24870593743824
+"6318","Sandbach, Antoinette","christian",3.12889493147202
+"6319","Sandbach, Antoinette","checks",3.01048502121699
+"6320","Sandbach, Antoinette","improve",2.87532361013451
+"6321","Sandbach, Antoinette","education",2.76404767884895
+"6322","Sandbach, Antoinette","prison",2.64615595152731
+"6323","Sandbach, Antoinette","initial",2.62820455844056
+"6324","Sandbach, Antoinette","staff",2.56337997342631
+"6325","Sanders, Adrian","torbay",3.56084520918548
+"6326","Sanders, Adrian","invitation",2.53452789029924
+"6327","Sanders, Adrian","visit",1.96472659583339
+"6328","Sanders, Adrian","ministers",1.93613360544502
+"6329","Sanders, Adrian","constituency",1.79757753694861
+"6330","Sanders, Adrian","purse",1.78320000420559
+"6331","Sanders, Adrian","october",1.66926790481404
+"6332","Sanders, Adrian","issued",1.44484240207028
+"6333","Sanders, Adrian","cost",1.2089773209836
+"6334","Sanders, Adrian","public",1.17980501731736
+"6335","Sanders, Adrian","months",1.12171310581015
+"6336","Sanders, Adrian","2014",0.990701052935098
+"6337","Sawford, Andy","students",3.24870593743824
+"6338","Sawford, Andy","revenge",3.24870593743824
+"6339","Sawford, Andy","pornography",3.12889493147202
+"6340","Sawford, Andy","rejected",2.63950812614542
+"6341","Sawford, Andy","indeterminate",2.40431610091321
+"6342","Sawford, Andy","union",2.36567939003947
+"6343","Sawford, Andy","problem",2.33362741099141
+"6344","Sawford, Andy","matter",2.26286952768758
+"6345","Sawford, Andy","approval",2.242076693946
+"6346","Sawford, Andy","address",2.2376211802176
+"6347","Sawford, Andy","considered",1.99552114121798
+"6348","Sawford, Andy","representatives",1.90262388477968
+"6349","Scully, Paul","coercive",2.74045601321832
+"6350","Scully, Paul","understanding",2.4731947713059
+"6351","Scully, Paul","behaviour",2.25742009217267
+"6352","Scully, Paul","nature",2.22234351521451
+"6353","Scully, Paul","greater",2.20593352939347
+"6354","Scully, Paul","controlling",1.99945029909348
+"6355","Scully, Paul","london",1.85911381435817
+"6356","Scully, Paul","judges",1.69629558062002
+"6357","Scully, Paul","abuse",1.60178212894357
+"6358","Scully, Paul","domestic",1.53995777620509
+"6359","Scully, Paul","training",1.3181109012101
+"6360","Scully, Paul","provided",1.27556328703998
+"6361","Seabeck, Alison","prorogation",3.70624520066165
+"6362","Seabeck, Alison","substantive",3.12889493147202
+"6363","Seabeck, Alison","sufficient",3.0760148293351
+"6364","Seabeck, Alison","probation",2.89750797226184
+"6365","Seabeck, Alison","enforce",2.71943691980587
+"6366","Seabeck, Alison","rule",2.6576402076209
+"6367","Seabeck, Alison","powers",2.64798884998938
+"6368","Seabeck, Alison","commissioner",2.63850535059248
+"6369","Seabeck, Alison","advertised",2.63802026696727
+"6370","Seabeck, Alison","session",2.50249153962001
+"6371","Seabeck, Alison","grounds",2.28974789753234
+"6372","Seabeck, Alison","discrimination",2.25005404930656
+"6373","Selous, Andrew","anglican",7.53141717154227
+"6374","Selous, Andrew","vacancies",5.7454808238754
+"6375","Selous, Andrew","kent",3.97500772156452
+"6376","Selous, Andrew","surrey",3.87559006098025
+"6377","Selous, Andrew","chaplaincy",3.71872063128626
+"6378","Selous, Andrew","catholic",3.31496648398472
+"6379","Selous, Andrew","hindus",3.31496648398472
+"6380","Selous, Andrew","roman",3.31496648398472
+"6381","Selous, Andrew","sikh",3.31496648398472
+"6382","Selous, Andrew","church",3.05676759423755
+"6383","Selous, Andrew","unspent",3.05676759423755
+"6384","Selous, Andrew","box",2.90573092600763
+"6385","Shah, Naz","marriage",4.99424709733641
+"6386","Shah, Naz","feedback",2.79856870449039
+"6387","Shah, Naz","legalise",2.79043427402451
+"6388","Shah, Naz","humanist",2.41685502996241
+"6389","Shah, Naz","forced",2.33067432224227
+"6390","Shah, Naz","couples",2.27897804629582
+"6391","Shah, Naz","issued",1.96898829600609
+"6392","Shah, Naz","protection",1.96624125004087
+"6393","Shah, Naz","causing",1.86525463598171
+"6394","Shah, Naz","orders",1.85731646869165
+"6395","Shah, Naz","plans",1.73922221211239
+"6396","Shah, Naz","merits",1.68913305939254
+"6397","Shannon, Jim","five",14.3704038584322
+"6398","Shannon, Jim","last",12.5705486123273
+"6399","Shannon, Jim","will",11.4660182658436
+"6400","Shannon, Jim","reduce",10.8497631687713
+"6401","Shannon, Jim","people",10.5122402532203
+"6402","Shannon, Jim","insolvency",10.5009251744683
+"6403","Shannon, Jim","convicted",10.3081330459946
+"6404","Shannon, Jim","years",10.1637320462873
+"6405","Shannon, Jim","sentence",9.06213784206142
+"6406","Shannon, Jim","litigation",8.99161253933262
+"6407","Shannon, Jim","offence",8.30646453286183
+"6408","Shannon, Jim","islamist",8.15314304615893
+"6409","Shapps, Grant","television",4.41309896777581
+"6410","Shapps, Grant","proof",3.31496648398472
+"6411","Shapps, Grant","licence",3.24319386233088
+"6412","Shapps, Grant","data",3.08785525585447
+"6413","Shapps, Grant","prosecuted",3.03890140848352
+"6414","Shapps, Grant","rather",2.4572483380649
+"6415","Shapps, Grant","killing",2.42174508089634
+"6416","Shapps, Grant","accrued",2.38933314651331
+"6417","Shapps, Grant","unlawful",2.23829647828338
+"6418","Shapps, Grant","standard",2.08725981005346
+"6419","Shapps, Grant","five",2.08204870094487
+"6420","Shapps, Grant","offences",2.03002518963875
+"6421","Sharma, Virendra","reoffending",6.33312211045561
+"6422","Sharma, Virendra","wellness",6.25778986294404
+"6423","Sharma, Virendra","phone",5.93592983727004
+"6424","Sharma, Virendra","strategy",5.27604053393455
+"6425","Sharma, Virendra","mobile",5.09178603191395
+"6426","Sharma, Virendra","guidelines",4.93074196372238
+"6427","Sharma, Virendra","adviser",4.91722405232187
+"6428","Sharma, Virendra","special",4.36096200748773
+"6429","Sharma, Virendra","drive",4.22147159107588
+"6430","Sharma, Virendra","reduce",3.32668901136065
+"6431","Sharma, Virendra","responsibilities",3.18517324475299
+"6432","Sharma, Virendra","strengthening",3.17229396360707
+"6433","Sheerman, Barry","detached",13.0713882779452
+"6434","Sheerman, Barry","duty",11.3377295084845
+"6435","Sheerman, Barry","innumeracy",10.7814101273699
+"6436","Sheerman, Barry","staff",10.020766128644
+"6437","Sheerman, Barry","digital",9.55815952063709
+"6438","Sheerman, Barry","number",9.28754877661386
+"6439","Sheerman, Barry","prison",9.17453988258223
+"6440","Sheerman, Barry","help",8.55153780501047
+"6441","Sheerman, Barry","children",8.37267334952682
+"6442","Sheerman, Barry","law",7.46582624036399
+"6443","Sheerman, Barry","abuse",7.31841104767121
+"6444","Sheerman, Barry","domestic",7.03594065552442
+"6445","Shelbrooke, Alec","wishes",2.89583164068126
+"6446","Shelbrooke, Alec","deport",2.67135566824861
+"6447","Shelbrooke, Alec","perpetrated",2.33362741099141
+"6448","Shelbrooke, Alec","account",2.20240554917331
+"6449","Shelbrooke, Alec","considering",2.07700425544466
+"6450","Shelbrooke, Alec","foreign",1.94894604562278
+"6451","Shelbrooke, Alec","crime",1.55765248521593
+"6452","Shelbrooke, Alec","taken",1.42546141145211
+"6453","Shelbrooke, Alec","national",1.37006744376347
+"6454","Shelbrooke, Alec","victims",1.27988985750232
+"6455","Shelbrooke, Alec","offender",1.00179033693354
+"6456","Shelbrooke, Alec","prison",0.517018445381184
+"6457","Sherriff, Paula","champion",6.41940499285428
+"6458","Sherriff, Paula","diversity",4.37567357222911
+"6459","Sherriff, Paula","departmental",3.99041449529049
+"6460","Sherriff, Paula","board",3.11944857176072
+"6461","Sherriff, Paula","2010",0
+"6462","Sherriff, Paula","accommod",0
+"6463","Sherriff, Paula","cost",0
+"6464","Sherriff, Paula","flight",0
+"6465","Sherriff, Paula","hotel",0
+"6466","Sherriff, Paula","intern",0
+"6467","Sherriff, Paula","made",0
+"6468","Sherriff, Paula","oversea",0
+"6469","Shuker, Gavin","concerted",6.04174181869633
+"6470","Shuker, Gavin","indiscipline",6.04174181869633
+"6471","Shuker, Gavin","capabl",3.34381835455032
+"6472","Shuker, Gavin","service",3.15242183648347
+"6473","Shuker, Gavin","proven",2.91685822425804
+"6474","Shuker, Gavin","territorial",2.84390560599304
+"6475","Shuker, Gavin","calendar",2.68101913850003
+"6476","Shuker, Gavin","respond",2.61293666190285
+"6477","Shuker, Gavin","extra",2.42718698913304
+"6478","Shuker, Gavin","economic",2.38268209655663
+"6479","Shuker, Gavin","deal",2.31225582301834
+"6480","Shuker, Gavin","failure",2.25717779218662
+"6481","Siddiq, Tulip","favour",17.0444476732219
+"6482","Siddiq, Tulip","found",14.207529945992
+"6483","Siddiq, Tulip","proportion",13.9118575485529
+"6484","Siddiq, Tulip","impositions",13.3320159174088
+"6485","Siddiq, Tulip","cases",13.1426593288422
+"6486","Siddiq, Tulip","quarter",12.9109259032392
+"6487","Siddiq, Tulip","tier",12.2958729687447
+"6488","Siddiq, Tulip","2009",11.8218411143006
+"6489","Siddiq, Tulip","users",11.7521406622616
+"6490","Siddiq, Tulip","order",10.837171850876
+"6491","Siddiq, Tulip","first",10.7296457166393
+"6492","Siddiq, Tulip","court",10.6666039171621
+"6493","Simpson, David","influence",6.53701982398263
+"6494","Simpson, David","possession",5.09157890968382
+"6495","Simpson, David","illness",5.07681974253323
+"6496","Simpson, David","appropriate",4.99485540241553
+"6497","Simpson, David","five",4.91666755301223
+"6498","Simpson, David","prioritised",4.85261405031394
+"6499","Simpson, David","region",4.77205246287414
+"6500","Simpson, David","found",4.41628258771105
+"6501","Simpson, David","health",3.8529664221821
+"6502","Simpson, David","mental",3.78335128443341
+"6503","Simpson, David","attacks",3.30769831157596
+"6504","Simpson, David","last",3.21244206128494
+"6505","Slaughter, Andy","2010",116.793804563586
+"6506","Slaughter, Andy","since",115.339086048159
+"6507","Slaughter, Andy","2015",103.759581132917
+"6508","Slaughter, Andy","year",96.9405338637463
+"6509","Slaughter, Andy","prison",82.2691280398664
+"6510","Slaughter, Andy","last",81.1531358800392
+"6511","Slaughter, Andy","legal",78.1220719149812
+"6512","Slaughter, Andy","month",73.1413638313894
+"6513","Slaughter, Andy","public",71.1893224220339
+"6514","Slaughter, Andy","made",70.7519995633698
+"6515","Slaughter, Andy","may",69.0065889540303
+"6516","Slaughter, Andy","answer",68.4135976768571
+"6517","Smith, Andrew","speeding",5.57908301839485
+"6518","Smith, Andrew","overseas",5.51759593994307
+"6519","Smith, Andrew","whose",5.26121104427516
+"6520","Smith, Andrew","vehicle",5.17626973981025
+"6521","Smith, Andrew","registered",4.11963107883832
+"6522","Smith, Andrew","chamber",3.6912328104695
+"6523","Smith, Andrew","bullingdon",3.56953551699164
+"6524","Smith, Andrew","fines",3.5333867350251
+"6525","Smith, Andrew","asylum",3.31499100456447
+"6526","Smith, Andrew","capacity",3.23071579857372
+"6527","Smith, Andrew","motorists",3.17095919966703
+"6528","Smith, Andrew","charities",3.12645945569042
+"6529","Smith, Angela","treasury",7.7994349661849
+"6530","Smith, Angela","residence",6.25030178278566
+"6531","Smith, Angela","solicitor",5.95879293747035
+"6532","Smith, Angela","test",5.84979095525231
+"6533","Smith, Angela","external",5.6809462783286
+"6534","Smith, Angela","counsel",5.27112969848325
+"6535","Smith, Angela","aid",5.07340451410652
+"6536","Smith, Angela","welfare",5.00074201133963
+"6537","Smith, Angela","barrister",4.80184924395004
+"6538","Smith, Angela","animal",4.74566956682366
+"6539","Smith, Angela","legal",4.41997598507103
+"6540","Smith, Angela","2006",4.36933132444281
+"6541","Smith, Cat","transgender",13.3285319291122
+"6542","Smith, Cat","trans",12.0254682290345
+"6543","Smith, Cat","month",6.74692268193167
+"6544","Smith, Cat","care",6.24557067713451
+"6545","Smith, Cat","imposed",6.06551889718816
+"6546","Smith, Cat","received",6.02464055967182
+"6547","Smith, Cat","charges",5.20748973657084
+"6548","Smith, Cat","compensation",5.18587657674485
+"6549","Smith, Cat","privatisation",5.11714753458702
+"6550","Smith, Cat","fines",4.96989297803476
+"6551","Smith, Cat","prison",4.92028680912352
+"6552","Smith, Cat","advisor",4.47464957730471
+"6553","Smith, Chloe","norfolk",3.12125570410566
+"6554","Smith, Chloe","performance",1.93613360544502
+"6555","Smith, Chloe","probation",1.39191780670143
+"6556","Smith, Chloe","place",1.36953902481732
+"6557","Smith, Chloe","community",1.36953902481732
+"6558","Smith, Chloe","rehabilitation",1.35474808209269
+"6559","Smith, Chloe","companies",1.32521040167599
+"6560","Smith, Chloe","national",1.3163182221498
+"6561","Smith, Chloe","employment",1.18822915185961
+"6562","Smith, Chloe","england",1.12990721355036
+"6563","Smith, Chloe","service",0.96920382233173
+"6564","Smith, Chloe","offenders",0.962489022917663
+"6565","Smith, Henry","autism",4.42492564732817
+"6566","Smith, Henry","drone",3.8768432227893
+"6567","Smith, Henry","restrict",3.59177589611169
+"6568","Smith, Henry","crawley",3.32573006579733
+"6569","Smith, Henry","refurbishment",3.17222462467664
+"6570","Smith, Henry","adults",2.87057950920898
+"6571","Smith, Henry","maintenance",2.82452091497381
+"6572","Smith, Henry","reduce",2.5768422278022
+"6573","Smith, Henry","involved",2.51741598914827
+"6574","Smith, Henry","committed",2.50031865243931
+"6575","Smith, Henry","access",2.4877086190618
+"6576","Smith, Henry","crimes",2.41310485376795
+"6577","Smith, Jeff","cannabis",3.55877904927178
+"6578","Smith, Jeff","serving",1.67345062468017
+"6579","Smith, Jeff","related",1.42552096685713
+"6580","Smith, Jeff","five",1.17632583622875
+"6581","Smith, Jeff","offences",1.14693334391435
+"6582","Smith, Jeff","sentences",1.10506238013479
+"6583","Smith, Jeff","people",1.10017550615748
+"6584","Smith, Jeff","last",0.768585338205803
+"6585","Smith, Jeff","years",0.589800397003689
+"6586","Smith, Jeff","prison",0.566365330363054
+"6587","Smith, Jeff","2010",0
+"6588","Smith, Jeff","accommod",0
+"6589","Smith, Nick","sourced",9.11970314546194
+"6590","Smith, Nick","produced",8.2790960975187
+"6591","Smith, Nick","british",6.42527370259313
+"6592","Smith, Nick","vulnerable",6.10660369180133
+"6593","Smith, Nick","food",5.56739137798815
+"6594","Smith, Nick","procured",5.04048790476361
+"6595","Smith, Nick","dedicated",5.03287359696938
+"6596","Smith, Nick","held",4.97574459064043
+"6597","Smith, Nick","dairy",4.27960332856952
+"6598","Smith, Nick","annual",4.03301485795536
+"6599","Smith, Nick","budget",3.97047964914893
+"6600","Smith, Nick","proportion",3.65292415138542
+"6601","Smith, Royston","media",7.74405877987086
+"6602","Smith, Royston","platforms",6.36169236114788
+"6603","Smith, Royston","social",6.21990258870174
+"6604","Smith, Royston","translation",5.42936049310179
+"6605","Smith, Royston","quality",5.11714753458702
+"6606","Smith, Royston","place",4.63295721050567
+"6607","Smith, Royston","measures",4.31802088049153
+"6608","Smith, Royston","remanded",4.30139770331885
+"6609","Smith, Royston","prevent",4.12328564210578
+"6610","Smith, Royston","big",3.94626999523619
+"6611","Smith, Royston","frequency",3.94626999523619
+"6612","Smith, Royston","thebigword",3.87104686156941
+"6613","Smyth, Karin","opportunities",3.19310155974459
+"6614","Smyth, Karin","increase",2.03717265268936
+"6615","Smyth, Karin","community",1.74582655304259
+"6616","Smyth, Karin","released",1.74157594741658
+"6617","Smyth, Karin","employment",1.51470090798799
+"6618","Smyth, Karin","sentences",1.23549730067955
+"6619","Smyth, Karin","people",1.23003360947418
+"6620","Smyth, Karin","prison",0.633215689395457
+"6621","Smyth, Karin","2010",0
+"6622","Smyth, Karin","accommod",0
+"6623","Smyth, Karin","cost",0
+"6624","Smyth, Karin","flight",0
+"6625","Soames, Sir Nicholas","surrey",12.6684052510976
+"6626","Soames, Sir Nicholas","trust",12.6485956447038
+"6627","Soames, Sir Nicholas","probation",11.6308605494154
+"6628","Soames, Sir Nicholas","sussex",11.2902574427426
+"6629","Soames, Sir Nicholas","rehabilitation",8.82707600735509
+"6630","Soames, Sir Nicholas","reform",7.44702562262935
+"6631","Soames, Sir Nicholas","companies",7.15735907221158
+"6632","Soames, Sir Nicholas","unfilled",6.69555684047549
+"6633","Soames, Sir Nicholas","1689",6.41940499285428
+"6634","Soames, Sir Nicholas","bailiwick",6.36996164154389
+"6635","Soames, Sir Nicholas","external",6.3079044913487
+"6636","Soames, Sir Nicholas","commission",6.2865805754803
+"6637","Solloway, Amanda","gang",3.16405505954568
+"6638","Solloway, Amanda","discouraged",2.81075491518716
+"6639","Solloway, Amanda","culture",2.4731947713059
+"6640","Solloway, Amanda","becoming",2.41375789658761
+"6641","Solloway, Amanda","entering",2.22234351521451
+"6642","Solloway, Amanda","aware",2.08314526442263
+"6643","Solloway, Amanda","involved",1.64803561799487
+"6644","Solloway, Amanda","first",1.53711218049738
+"6645","Solloway, Amanda","system",1.49677126136131
+"6646","Solloway, Amanda","taken",1.31972082617252
+"6647","Solloway, Amanda","time",1.19183323262054
+"6648","Solloway, Amanda","offenders",0.927477629690987
+"6649","Spellar, John","agriculture",4.53920480163004
+"6650","Spellar, John","votes",3.88525076247425
+"6651","Spellar, John","handler",3.87104686156941
+"6652","Spellar, John","europe",3.82911518397058
+"6653","Spellar, John","50w",3.31496648398472
+"6654","Spellar, John","649",3.31496648398472
+"6655","Spellar, John","extension",3.09165134229387
+"6656","Spellar, John","purchasing",3.03733562625761
+"6657","Spellar, John","recognising",2.96651282783612
+"6658","Spellar, John","accident",2.91711571481941
+"6659","Spellar, John","packages",2.87734840200197
+"6660","Spellar, John","industry",2.85809820335057
+"6661","Starmer, Keir","victim",12.2971179497923
+"6662","Starmer, Keir","directive",11.530533880653
+"6663","Starmer, Keir","right",10.5708129825105
+"6664","Starmer, Keir","introduce",8.8713025344942
+"6665","Starmer, Keir","law",8.66950821662449
+"6666","Starmer, Keir","2012/29/eu",5.88929900323539
+"6667","Starmer, Keir","accordance",5.49781465751858
+"6668","Starmer, Keir","taken",5.30773536308659
+"6669","Starmer, Keir","article",4.84819267142326
+"6670","Starmer, Keir","minimum",4.84741193506405
+"6671","Starmer, Keir","transpose",4.59436399688715
+"6672","Starmer, Keir","publish",4.59317690186596
+"6673","Stephens, Chris","fee",4.37989523550573
+"6674","Stephens, Chris","tribunal",4.33848664708957
+"6675","Stephens, Chris","remission",4.23978925389475
+"6676","Stephens, Chris","regarding",3.58850087898264
+"6677","Stephens, Chris","disincentive",3.39316268687164
+"6678","Stephens, Chris","employment",3.20341153661836
+"6679","Stephens, Chris","applications",3.05004420591617
+"6680","Stephens, Chris","foregone",3.00771725513075
+"6681","Stephens, Chris","proportion",2.94675060994724
+"6682","Stephens, Chris","claim",2.82241624679594
+"6683","Stephens, Chris","successful",2.81624221213572
+"6684","Stephens, Chris","pursuing",2.79013999771611
+"6685","Stephenson, Andrew","education",13.6178920156604
+"6686","Stephenson, Andrew","prison",10.755459554708
+"6687","Stephenson, Andrew","workshop",9.33801076734931
+"6688","Stephenson, Andrew","made",9.30938300408858
+"6689","Stephenson, Andrew","coroner",8.3235857858805
+"6690","Stephenson, Andrew","recovery",8.00360916313189
+"6691","Stephenson, Andrew","lancashire",7.11990090070181
+"6692","Stephenson, Andrew","holloway",6.99525117594205
+"6693","Stephenson, Andrew","advisory",6.81177857984536
+"6694","Stephenson, Andrew","female",6.70273067706738
+"6695","Stephenson, Andrew","address",6.51582241438974
+"6696","Stephenson, Andrew","crash",6.3969191038859
+"6697","Stevens, Jo","prison",26.181620748379
+"6698","Stevens, Jo","protected",20.301284100146
+"6699","Stevens, Jo","training",20.153613939927
+"6700","Stevens, Jo","rehabilitation",19.5053374774076
+"6701","Stevens, Jo","public",17.3073267523879
+"6702","Stevens, Jo","recall",17.1626790940613
+"6703","Stevens, Jo","secure",17.0740898462372
+"6704","Stevens, Jo","community",16.6174410326421
+"6705","Stevens, Jo","medway",16.6101774974605
+"6706","Stevens, Jo","segregation",15.8512934804898
+"6707","Stevens, Jo","current",15.6747681204951
+"6708","Stevens, Jo","extremism",14.9872037982413
+"6709","Streeter, Gary","dartmoor",4.18565141103677
+"6710","Streeter, Gary","smuggled",3.97883593553688
+"6711","Streeter, Gary","efficacy",3.36472586037556
+"6712","Streeter, Gary","psychoactive",3.01117246978229
+"6713","Streeter, Gary","substances",2.75574215724209
+"6714","Streeter, Gary","measures",2.52379501140869
+"6715","Streeter, Gary","harmful",2.51407910387066
+"6716","Streeter, Gary","prevent",2.40997624193403
+"6717","Streeter, Gary","drugs",2.1557362910153
+"6718","Streeter, Gary","protect",1.83925027434876
+"6719","Streeter, Gary","used",1.69508198546227
+"6720","Streeter, Gary","effects",1.59536742492214
+"6721","Streeting, Wes","forthcoming",3.42753266806161
+"6722","Streeting, Wes","referendum",3.17222462467664
+"6723","Streeting, Wes","contingency",3.11130490204477
+"6724","Streeting, Wes","vote",3.00950229978049
+"6725","Streeting, Wes","prepare",2.74134213243143
+"6726","Streeting, Wes","membership",2.71667557231756
+"6727","Streeting, Wes","possibl",2.69327453376365
+"6728","Streeting, Wes","undertaking",2.57357864873072
+"6729","Streeting, Wes","leave",2.19206538294014
+"6730","Streeting, Wes","planning",1.11356362418732
+"6731","Streeting, Wes","2010",0
+"6732","Streeting, Wes","accommod",0
+"6733","Stringer, Graham","ownership",3.82911518397058
+"6734","Stringer, Graham","manchester",3.39468579288825
+"6735","Stringer, Graham","future",2.79193248547271
+"6736","Stringer, Graham","plans",1.43760445713995
+"6737","Stringer, Graham","will",1.10249009757759
+"6738","Stringer, Graham","prison",0.731174497455124
+"6739","Stringer, Graham","2010",0
+"6740","Stringer, Graham","accommod",0
+"6741","Stringer, Graham","cost",0
+"6742","Stringer, Graham","flight",0
+"6743","Stringer, Graham","hotel",0
+"6744","Stringer, Graham","intern",0
+"6745","Stuart, Graham","compensation",3.58461584948599
+"6746","Stuart, Graham","authority",3.52730737632742
+"6747","Stuart, Graham","injuries",3.37512617885311
+"6748","Stuart, Graham","application",3.3635730101558
+"6749","Stuart, Graham","criminal",2.69671879039491
+"6750","Stuart, Graham","initial",2.10725164286616
+"6751","Stuart, Graham","awards",1.69203502380758
+"6752","Stuart, Graham","length",1.62599667865118
+"6753","Stuart, Graham","decision",1.53428743183184
+"6754","Stuart, Graham","issued",1.39228497618285
+"6755","Stuart, Graham","average",1.26985093858496
+"6756","Stuart, Graham","five",1.23995630432835
+"6757","Stunell, Sir Andrew","visitors",6.87745667908711
+"6758","Stunell, Sir Andrew","official",3.67483806381206
+"6759","Stunell, Sir Andrew","deployment",3.41794916166247
+"6760","Stunell, Sir Andrew","counselling",3.02459750431282
+"6761","Stunell, Sir Andrew","chaplains",2.96651282783612
+"6762","Stunell, Sir Andrew","contribution",2.75317680220667
+"6763","Stunell, Sir Andrew","will",2.73512978672097
+"6764","Stunell, Sir Andrew","recruitment",2.43841600988385
+"6765","Stunell, Sir Andrew","governors",2.36349013868059
+"6766","Stunell, Sir Andrew","developing",2.20563026934007
+"6767","Stunell, Sir Andrew","vulnerable",2.1522996174682
+"6768","Stunell, Sir Andrew","improve",2.14313968319029
+"6769","Sturdy, Julian","guardianship",5.56739137798815
+"6770","Sturdy, Julian","affairs",5.14565823334464
+"6771","Sturdy, Julian","missing",4.79843744157075
+"6772","Sturdy, Julian","property",4.70821177002257
+"6773","Sturdy, Julian","proposals",4.44907271117904
+"6774","Sturdy, Julian","3000",3.94626999523619
+"6775","Sturdy, Julian","legislation",3.43297393038594
+"6776","Sturdy, Julian","5000",3.17229396360707
+"6777","Sturdy, Julian","rather",3.17229396360707
+"6778","Sturdy, Julian","pregnancy",3.11130490204477
+"6779","Sturdy, Julian","trends",2.74134213243143
+"6780","Sturdy, Julian","small",2.69464082784836
+"6781","Sutcliffe, Gerry","ex160",4.85261405031394
+"6782","Sutcliffe, Gerry","simplify",4.47464957730471
+"6783","Sutcliffe, Gerry","front",3.24870593743824
+"6784","Sutcliffe, Gerry","remission",2.99798373223083
+"6785","Sutcliffe, Gerry","form",2.92973383856673
+"6786","Sutcliffe, Gerry","documents",2.52629631481241
+"6787","Sutcliffe, Gerry","availability",2.47997415396931
+"6788","Sutcliffe, Gerry","house",2.16993689156612
+"6789","Sutcliffe, Gerry","assist",2.13981749225093
+"6790","Sutcliffe, Gerry","application",2.11675421758744
+"6791","Sutcliffe, Gerry","fee",1.98011699800062
+"6792","Sutcliffe, Gerry","completion",1.876088147768
+"6793","Swire, Sir Hugo","plates",4.18565141103677
+"6794","Swire, Sir Hugo","displayed",3.83209802044349
+"6795","Swire, Sir Hugo","improperly",3.83209802044349
+"6796","Swire, Sir Hugo","vehicle",2.96255763274197
+"6797","Swire, Sir Hugo","prosecutions",1.91958951392749
+"6798","Swire, Sir Hugo","number",1.47554590747955
+"6799","Swire, Sir Hugo","last",0.859304531368921
+"6800","Swire, Sir Hugo","years",0.659416890428306
+"6801","Swire, Sir Hugo","2010",0
+"6802","Swire, Sir Hugo","accommod",0
+"6803","Swire, Sir Hugo","cost",0
+"6804","Swire, Sir Hugo","flight",0
+"6805","Tami, Mark","extension",7.41678101198807
+"6806","Tami, Mark","reserved",6.16040447077757
+"6807","Tami, Mark","decision",5.9677949558126
+"6808","Tami, Mark","notice",5.46350736959667
+"6809","Tami, Mark","activities",4.85311414024887
+"6810","Tami, Mark","write",4.4560029784993
+"6811","Tami, Mark","may",3.64400542519123
+"6812","Tami, Mark","reference",3.60722538260977
+"6813","Tami, Mark","legal",3.04213684760207
+"6814","Tami, Mark","2013",2.98834815789981
+"6815","Tami, Mark","overturned",2.88980641474755
+"6816","Tami, Mark","stage",2.71667557231756
+"6817","Teather, Sarah","verne",8.37350002264447
+"6818","Teather, Sarah","immigration",3.63306047468209
+"6819","Teather, Sarah","stateless",3.56084520918548
+"6820","Teather, Sarah","hmp",3.50487735948833
+"6821","Teather, Sarah","772w",3.43131630145811
+"6822","Teather, Sarah","1954",3.28349511107287
+"6823","Teather, Sarah","compatibility",2.63950812614542
+"6824","Teather, Sarah","detained",2.60715650608644
+"6825","Teather, Sarah","ability",2.41891817793516
+"6826","Teather, Sarah","stop",2.3871558688598
+"6827","Teather, Sarah","legal",2.38059729442218
+"6828","Teather, Sarah","made",2.37852585264146
+"6829","The Countess of Mar","munchausens",3.43131630145811
+"6830","The Countess of Mar","proxy",3.43131630145811
+"6831","The Countess of Mar","unfounded",3.16405505954568
+"6832","The Countess of Mar","syndrome",2.81075491518716
+"6833","The Countess of Mar","health",1.65954621809528
+"6834","The Countess of Mar","education",1.6518344316623
+"6835","The Countess of Mar","local",1.62244295332602
+"6836","The Countess of Mar","authorities",1.56963214264527
+"6837","The Countess of Mar","total",1.5045088414504
+"6838","The Countess of Mar","prosecuting",1.45107327805128
+"6839","The Countess of Mar","average",1.26985093858496
+"6840","The Countess of Mar","cost",1.16499969694922
+"6841","The Earl of Clancarty","destroyed",3.70624520066165
+"6842","The Earl of Clancarty","graham",3.70624520066165
+"6843","The Earl of Clancarty","ovenden",3.70624520066165
+"6844","The Earl of Clancarty","paintings",3.56084520918548
+"6845","The Earl of Clancarty","forfeited",3.41757006606683
+"6846","The Earl of Clancarty","artwork",3.28349511107287
+"6847","The Earl of Clancarty","legislation",3.27362252747594
+"6848","The Earl of Clancarty","metropolitan",3.24870593743824
+"6849","The Earl of Clancarty","art",3.12889493147202
+"6850","The Earl of Clancarty","photographs",3.12125570410566
+"6851","The Earl of Clancarty","destruction",3.12125570410566
+"6852","The Earl of Clancarty","order",2.78144656833094
+"6853","The Earl of Dundee","reoffending",3.21989349534064
+"6854","The Earl of Dundee","dissuade",3.02613653442003
+"6855","The Earl of Dundee","rates",2.85817016365811
+"6856","The Earl of Dundee","head",2.50786376591274
+"6857","The Earl of Dundee","partial",2.47885283397922
+"6858","The Earl of Dundee","communities",2.39837016312701
+"6859","The Earl of Dundee","schools",2.36443663355857
+"6860","The Earl of Dundee","comparative",2.25786376591274
+"6861","The Earl of Dundee","custodial",2.22750077601814
+"6862","The Earl of Dundee","states",2.11162314073245
+"6863","The Earl of Dundee","either",2.07881200741289
+"6864","The Earl of Dundee","statistics",2.00786376591274
+"6865","The Earl of Sandwich","asylum",4.63670821892889
+"6866","The Earl of Sandwich","expert",3.95244751998732
+"6867","The Earl of Sandwich","deportation",3.60733004614331
+"6868","The Earl of Sandwich","chamber",3.47815150915792
+"6869","The Earl of Sandwich","members",3.2677882303788
+"6870","The Earl of Sandwich","immigration",2.75384562729727
+"6871","The Earl of Sandwich","situation",2.47885283397922
+"6872","The Earl of Sandwich","reduce",2.42809059836898
+"6873","The Earl of Sandwich","deployment",2.41685502996241
+"6874","The Earl of Sandwich","involvement",2.40377687632267
+"6875","The Earl of Sandwich","non",2.3024197907595
+"6876","The Earl of Sandwich","complex",2.04766219030028
+"6877","The Lord Bishop of Coventry","ali",3.56084520918548
+"6878","The Lord Bishop of Coventry","crucifixion",3.56084520918548
+"6879","The Lord Bishop of Coventry","mohammed",3.56084520918548
+"6880","The Lord Bishop of Coventry","nimr",3.56084520918548
+"6881","The Lord Bishop of Coventry","arabia",2.53452789029924
+"6882","The Lord Bishop of Coventry","commercial",2.40431610091321
+"6883","The Lord Bishop of Coventry","relationship",2.38268209655663
+"6884","The Lord Bishop of Coventry","saudi",2.36215802803281
+"6885","The Lord Bishop of Coventry","light",1.8967446205098
+"6886","The Lord Bishop of Coventry","death",1.71418960118974
+"6887","The Lord Bishop of Coventry","review",1.23204604931185
+"6888","The Lord Bishop of Coventry","sentencing",0.96920382233173
+"6889","The Lord Bishop of Derby","trafficking",2.19019352891621
+"6890","The Lord Bishop of Derby","fraud",1.97222182692514
+"6891","The Lord Bishop of Derby","benefit",1.87923541276276
+"6892","The Lord Bishop of Derby","organised",1.76659448258886
+"6893","The Lord Bishop of Derby","human",1.57585125276612
+"6894","The Lord Bishop of Derby","successful",1.56655980393289
+"6895","The Lord Bishop of Derby","incidents",1.5204660069395
+"6896","The Lord Bishop of Derby","resulted",1.47686612086861
+"6897","The Lord Bishop of Derby","prosecution",1.45107327805128
+"6898","The Lord Bishop of Derby","crime",1.44210597927357
+"6899","The Lord Bishop of Derby","recent",1.27990378092502
+"6900","The Lord Bishop of Derby","date",1.23078888121273
+"6901","The Lord Bishop of Rochester","radicalisation",5.71646351495421
+"6902","The Lord Bishop of Rochester","chaplains",5.01804652702503
+"6903","The Lord Bishop of Rochester","extremism",4.555508963001
+"6904","The Lord Bishop of Rochester","including",3.27916932833866
+"6905","The Lord Bishop of Rochester","christian",3.26802417241388
+"6906","The Lord Bishop of Rochester","faith",2.86944785508927
+"6907","The Lord Bishop of Rochester","beginning",2.82452091497381
+"6908","The Lord Bishop of Rochester","whilst",2.69327453376365
+"6909","The Lord Bishop of Rochester","vetting",2.67707694136014
+"6910","The Lord Bishop of Rochester","muslim",2.54671332961504
+"6911","The Lord Bishop of Rochester","counter",2.46856252730307
+"6912","The Lord Bishop of Rochester","islamist",2.34658941421983
+"6913","The Lord Bishop of St Albans","support",3.82717470064801
+"6914","The Lord Bishop of St Albans","suicide",3.61300941542385
+"6915","The Lord Bishop of St Albans","self",3.57192543056136
+"6916","The Lord Bishop of St Albans","risk",3.56799136867883
+"6917","The Lord Bishop of St Albans","deaths",3.45934423635821
+"6918","The Lord Bishop of St Albans","increases",3.22504722945452
+"6919","The Lord Bishop of St Albans","motabl",3.20970249642714
+"6920","The Lord Bishop of St Albans","hl6247",3.02613653442003
+"6921","The Lord Bishop of St Albans","succeeded",2.81346187124685
+"6922","The Lord Bishop of St Albans","istanbul",2.62879755453387
+"6923","The Lord Bishop of St Albans","inflicted",2.54671332961504
+"6924","The Lord Bishop of St Albans","territorial",2.48692330879865
+"6925","The Marquess of Lothian","bad",3.02613653442003
+"6926","The Marquess of Lothian","comments",3.02613653442003
+"6927","The Marquess of Lothian","rapporteur",3.02613653442003
+"6928","The Marquess of Lothian","rest",2.65255729035792
+"6929","The Marquess of Lothian","example",2.554732013629
+"6930","The Marquess of Lothian","world",2.47885283397922
+"6931","The Marquess of Lothian","torture",2.27897804629582
+"6932","The Marquess of Lothian","replace",1.91823226800131
+"6933","The Marquess of Lothian","moves",1.8695713295216
+"6934","The Marquess of Lothian","special",1.78035528433472
+"6935","The Marquess of Lothian","1998",1.6958668731429
+"6936","The Marquess of Lothian","set",1.66345698178269
+"6937","Thewliss, Alison","milk",6.70346293050559
+"6938","Thewliss, Alison","breast",6.37224092051863
+"6939","Thewliss, Alison","expressing",5.17439898163942
+"6940","Thewliss, Alison","lactating",4.05998820009529
+"6941","Thewliss, Alison","breastfeeding",3.20970249642714
+"6942","Thewliss, Alison","visitors",3.05756989844826
+"6943","Thewliss, Alison","citizens",3.01117246978229
+"6944","Thewliss, Alison","mothers",2.9263235172381
+"6945","Thewliss, Alison","lodged",2.9263235172381
+"6946","Thewliss, Alison","glasgow",2.81346187124685
+"6947","Thewliss, Alison","facilities",2.4788493700111
+"6948","Thewliss, Alison","leaving",2.45080360368913
+"6949","Thomas-Symonds, Nick","vacated",3.97500772156452
+"6950","Thomas-Symonds, Nick","ineffective",3.87559006098025
+"6951","Thomas-Symonds, Nick","cracked",3.65449501766502
+"6952","Thomas-Symonds, Nick","cases",3.57572580160226
+"6953","Thomas-Symonds, Nick","human",3.55559995662789
+"6954","Thomas-Symonds, Nick","cited",3.17095919966703
+"6955","Thomas-Symonds, Nick","rights",3.13703580838727
+"6956","Thomas-Symonds, Nick","effect",3.06605342854049
+"6957","Thomas-Symonds, Nick","resolved",3.02459750431282
+"6958","Thomas-Symonds, Nick","alternative",2.91527851217387
+"6959","Thomas-Symonds, Nick","europe",2.82798898275925
+"6960","Thomas-Symonds, Nick","contested",2.69307502496926
+"6961","Thomas, Gareth","will",7.84957711744167
+"6962","Thomas, Gareth","union",6.24292957792796
+"6963","Thomas, Gareth","credit",6.04254952538791
+"6964","Thomas, Gareth","prosecuted",5.16377084458424
+"6965","Thomas, Gareth","transposed",4.59436399688715
+"6966","Thomas, Gareth","london",4.02665682836877
+"6967","Thomas, Gareth","deductions",3.83209802044349
+"6968","Thomas, Gareth","yet",3.64644082156937
+"6969","Thomas, Gareth","months",3.63817962021546
+"6970","Thomas, Gareth","promote",3.57272251098088
+"6971","Thomas, Gareth","mayor",3.56953551699164
+"6972","Thomas, Gareth","agreed",3.47700247201039
+"6973","Thornberry, Emily","368",12.991288768233
+"6974","Thornberry, Emily","rights",12.1317782846306
+"6975","Thornberry, Emily","non",11.3342281609533
+"6976","Thornberry, Emily","pentonville",10.3403774957088
+"6977","Thornberry, Emily","wage",10.114893115831
+"6978","Thornberry, Emily","2015",10.075995599154
+"6979","Thornberry, Emily","minimum",10.0492440023749
+"6980","Thornberry, Emily","revolution",9.89314135568893
+"6981","Thornberry, Emily","repeal",9.67811650564699
+"6982","Thornberry, Emily","legislation",8.56943973447615
+"6983","Thornberry, Emily","human",8.21836263561466
+"6984","Thornberry, Emily","1998",8.10552365424642
+"6985","Timms, Stephen","tier",9.1756114003592
+"6986","Timms, Stephen","hearing",8.92733611538998
+"6987","Timms, Stephen","adjourned",8.57877336977572
+"6988","Timms, Stephen","first",8.00683772593185
+"6989","Timms, Stephen","law",7.19196364036157
+"6990","Timms, Stephen","appeal",7.11521354618209
+"6991","Timms, Stephen","respond",6.98167077527111
+"6992","Timms, Stephen","estimate",6.72732044624579
+"6993","Timms, Stephen","representative",6.11007336441587
+"6994","Timms, Stephen","home",6.01014042066946
+"6995","Timms, Stephen","send",5.94166317958107
+"6996","Timms, Stephen","office",5.85163797557906
+"6997","Tomlinson, Justin","support",15.0579587441574
+"6998","Tomlinson, Justin","within",13.9763500897881
+"6999","Tomlinson, Justin","victim",13.5297007923246
+"7000","Tomlinson, Justin","crime",6.7605456415463
+"7001","Tomlinson, Justin","recent",6.22892860715124
+"7002","Tomlinson, Justin","commission",6.07840669528129
+"7003","Tomlinson, Justin","provide",6.00806783294007
+"7004","Tomlinson, Justin","made",5.99013530305588
+"7005","Tomlinson, Justin","network",5.68536835599736
+"7006","Tomlinson, Justin","progress",5.31429086825326
+"7007","Tomlinson, Justin","streetgames",5.24142222825589
+"7008","Tomlinson, Justin","engineering",4.53920480163004
+"7009","Trickett, Jon","pass",16.3503524393025
+"7010","Trickett, Jon","contract",13.843253309002
+"7011","Trickett, Jon","servants",12.4690402661485
+"7012","Trickett, Jon","procured",12.0098723436295
+"7013","Trickett, Jon","premises",11.6125116225638
+"7014","Trickett, Jon","bodies",10.9146975199246
+"7015","Trickett, Jon","attorney",9.98561611285756
+"7016","Trickett, Jon","2010",9.68719766370602
+"7017","Trickett, Jon","since",9.35220099895434
+"7018","Trickett, Jon","security",9.04273032779694
+"7019","Trickett, Jon","indefinite",8.67936120509307
+"7020","Trickett, Jon","civil",8.6496439294823
+"7021","Turley, Anna","online",7.39779751503184
+"7022","Turley, Anna","welfare",5.412941528364
+"7023","Turley, Anna","media",5.30085629741086
+"7024","Turley, Anna","commence",5.21595466381659
+"7025","Turley, Anna","animal",5.13684405632266
+"7026","Turley, Anna","2006",4.72948512913235
+"7027","Turley, Anna","social",4.25756192505961
+"7028","Turley, Anna","abuse",3.9260125358616
+"7029","Turley, Anna","act",3.8887139083575
+"7030","Turley, Anna","malicious",3.87104686156941
+"7031","Turley, Anna","legislation",3.78858494303099
+"7032","Turley, Anna","2015",3.62930511800737
+"7033","Turner, Andrew","religion",4.0166773568643
+"7034","Turner, Andrew","depending",3.57272251098088
+"7035","Turner, Andrew","different",3.57272251098088
+"7036","Turner, Andrew","subject",2.84991150142526
+"7037","Turner, Andrew","aldershot",2.80165802822211
+"7038","Turner, Andrew","isle",2.80165802822211
+"7039","Turner, Andrew","wight",2.80165802822211
+"7040","Turner, Andrew","conditions",2.61791062808059
+"7041","Turner, Andrew","authority",2.07642814964642
+"7042","Turner, Andrew","offence",2.07376966082346
+"7043","Turner, Andrew","sexual",2.01862261849011
+"7044","Turner, Andrew","people",1.9892268355055
+"7045","Turner, Karl","son",17.8278871594182
+"7046","Turner, Karl","loss",17.2949337480344
+"7047","Turner, Karl","ashes",16.3273376497335
+"7048","Turner, Karl","hull",16.0167179407157
+"7049","Turner, Karl","1994",12.6794452265239
+"7050","Turner, Karl","2015",10.7761543007114
+"7051","Turner, Karl","legal",9.04269602805528
+"7052","Turner, Karl","procurement",8.88134321058757
+"7053","Turner, Karl","duty",8.85675605548649
+"7054","Turner, Karl","connor",8.58017357177562
+"7055","Turner, Karl","emma",8.58017357177562
+"7056","Turner, Karl","whitley",8.58017357177562
+"7057","Twigg, Derek","update",3.8768432227893
+"7058","Twigg, Derek","lgc",3.87104686156941
+"7059","Twigg, Derek","toxicological",3.87104686156941
+"7060","Twigg, Derek","statistics",3.59177589611169
+"7061","Twigg, Derek","timeliness",3.56953551699164
+"7062","Twigg, Derek","safety",3.33017271293153
+"7063","Twigg, Derek","forensics",3.26802417241388
+"7064","Twigg, Derek","ratio",2.72308615973505
+"7065","Twigg, Derek","analysis",2.72308615973505
+"7066","Twigg, Derek","england",2.45667728639025
+"7067","Twigg, Derek","wales",2.44673457424716
+"7068","Twigg, Derek","equivalent",2.37730047072246
+"7069","Tyrie, Andrew","chichester",26.9524841364723
+"7070","Tyrie, Andrew","combined",14.9560243569225
+"7071","Tyrie, Andrew","freehold",11.8634270501866
+"7072","Tyrie, Andrew","centre",8.79995603768841
+"7073","Tyrie, Andrew","court",7.98863380493911
+"7074","Tyrie, Andrew","value",5.22763308323018
+"7075","Tyrie, Andrew","moved",4.93372102756568
+"7076","Tyrie, Andrew","county",4.86855081777375
+"7077","Tyrie, Andrew","property",4.68131157792383
+"7078","Tyrie, Andrew","eastbourne",4.27960332856952
+"7079","Tyrie, Andrew","provision",4.2550399565069
+"7080","Tyrie, Andrew","crown",4.2519629996253
+"7081","Umunna, Chuka","departmental",15.9407460231858
+"7082","Umunna, Chuka","agencies",15.1363046278939
+"7083","Umunna, Chuka","bodies",13.2413425099742
+"7084","Umunna, Chuka","non",9.3359698331194
+"7085","Umunna, Chuka","public",8.17549206018931
+"7086","Umunna, Chuka","suppliers",7.95732737618556
+"7087","Umunna, Chuka","cherry",6.69555684047549
+"7088","Umunna, Chuka","groce",6.69555684047549
+"7089","Umunna, Chuka","subcontractors",5.75140952316262
+"7090","Umunna, Chuka","proportion",5.46070861508601
+"7091","Umunna, Chuka","inquest",5.09872440435961
+"7092","Umunna, Chuka","paid",4.53342379605787
+"7093","Vaz, Keith","transfer",64.2851440170769
+"7094","Vaz, Keith","exchanged",42.5853100946785
+"7095","Vaz, Keith","countries",34.8370406979621
+"7096","Vaz, Keith","agreements",34.1534963387822
+"7097","Vaz, Keith","prison",24.766349697457
+"7098","Vaz, Keith","effect",21.5139786203695
+"7099","Vaz, Keith","number",21.1565015209288
+"7100","Vaz, Keith","proportion",20.9001205752651
+"7101","Vaz, Keith","five",19.7275840012257
+"7102","Vaz, Keith","offenders",19.4503995422098
+"7103","Vaz, Keith","last",17.4970174617217
+"7104","Vaz, Keith","judges",16.3572484352584
+"7105","Vaz, Valerie","unemployed",8.06513130487968
+"7106","Vaz, Valerie","classed",7.47284140233856
+"7107","Vaz, Valerie","week",7.25251753108429
+"7108","Vaz, Valerie","hours",7.13798650840771
+"7109","Vaz, Valerie","cells",7.12418021383597
+"7110","Vaz, Valerie","per",7.00456710303806
+"7111","Vaz, Valerie","data",6.73138206327308
+"7112","Vaz, Valerie","hmp",5.88937195614262
+"7113","Vaz, Valerie","spent",5.84987056190487
+"7114","Vaz, Valerie","date",5.61898841720591
+"7115","Vaz, Valerie","working",5.40970739594692
+"7116","Vaz, Valerie","three",5.37882426110752
+"7117","Vickers, Martin","sufficient",2.57357864873072
+"7118","Vickers, Martin","next",2.25735088271388
+"7119","Vickers, Martin","given",1.79583808229787
+"7120","Vickers, Martin","places",1.56151473981095
+"7121","Vickers, Martin","custodial",1.45026624670716
+"7122","Vickers, Martin","sentences",1.10506238013479
+"7123","Vickers, Martin","offenders",1.0974063308584
+"7124","Vickers, Martin","will",0.853985157455321
+"7125","Vickers, Martin","years",0.589800397003689
+"7126","Vickers, Martin","prison",0.566365330363054
+"7127","Vickers, Martin","2010",0
+"7128","Vickers, Martin","accommod",0
+"7129","Villiers, Theresa","london",3.64765669719935
+"7130","Villiers, Theresa","fair",3.24255128325494
+"7131","Villiers, Theresa","system",3.1711049514487
+"7132","Villiers, Theresa","barnet",3.02613653442003
+"7133","Villiers, Theresa","hmi",3.02613653442003
+"7134","Villiers, Theresa","childhood",2.70970249642714
+"7135","Villiers, Theresa","december",2.70180896028649
+"7136","Villiers, Theresa","probation",2.63165666241223
+"7137","Villiers, Theresa","trends",2.50249153962001
+"7138","Villiers, Theresa","treatment",2.41261440011355
+"7139","Villiers, Theresa","become",2.25786376591274
+"7140","Villiers, Theresa","2016",2.18084289490945
+"7141","Viscount Astor","rspca",10.2598688432598
+"7142","Viscount Astor","reimbursing",6.54158959229096
+"7143","Viscount Astor","2012",4.68795225719261
+"7144","Viscount Astor","budget",4.16065374528253
+"7145","Viscount Astor","2013",4.03048587315492
+"7146","Viscount Astor","2014",3.48472983069961
+"7147","Viscount Astor","aid",3.00279733786114
+"7148","Viscount Astor","spent",2.98216726763883
+"7149","Viscount Astor","met",2.71136028825718
+"7150","Viscount Astor","legal",2.61605241302523
+"7151","Viscount Astor","ministers",2.46809575877173
+"7152","Viscount Astor","representatives",2.33022884507106
+"7153","Walker, Charles","sharia",10.1033573152375
+"7154","Walker, Charles","society",9.30214693161886
+"7155","Walker, Charles","rules",7.86598642781526
+"7156","Walker, Charles","succession",6.55720835846802
+"7157","Walker, Charles","law",6.26509182801266
+"7158","Walker, Charles","laundering",5.98171411485419
+"7159","Walker, Charles","guidance",5.96657910067988
+"7160","Walker, Charles","inclusion",5.91958112436281
+"7161","Walker, Charles","compatibility",4.93060960389795
+"7162","Walker, Charles","money",4.25513445210519
+"7163","Walker, Charles","equalities",3.7276398607036
+"7164","Walker, Charles","attention",3.56953551699164
+"7165","Walley, Joan","digitise",3.43131630145811
+"7166","Walley, Joan","manor",3.43131630145811
+"7167","Walley, Joan","frame",3.00771725513075
+"7168","Walley, Joan","newcastle",2.89679381763326
+"7169","Walley, Joan","archive",2.68101913850003
+"7170","Walley, Joan","staffordshire",2.54349367327473
+"7171","Walley, Joan","rolls",2.33889590623465
+"7172","Walley, Joan","copy",2.03903132527525
+"7173","Walley, Joan","north",1.709367221186
+"7174","Walley, Joan","records",1.59513409411094
+"7175","Walley, Joan","national",1.26843597748022
+"7176","Walley, Joan","time",1.19183323262054
+"7177","Ward, David","drivers",9.2938997176545
+"7178","Ward, David","uninsured",9.01170953250626
+"7179","Ward, David","claim",8.92910550154048
+"7180","Ward, David","car",8.54340763381967
+"7181","Ward, David","statute",8.34564649188295
+"7182","Ward, David","fraud",7.40236136678438
+"7183","Ward, David","region",7.38830136162761
+"7184","Ward, David","insurance",6.77237414724434
+"7185","Ward, David","humber",6.48510256650988
+"7186","Ward, David","instances",6.28213089098085
+"7187","Ward, David","management",5.93430146885097
+"7188","Ward, David","limitations",5.62925894983594
+"7189","Warman, Matt","find",3.41940499285428
+"7190","Warman, Matt","improve",2.6247993356631
+"7191","Warman, Matt","release",2.4629603247393
+"7192","Warman, Matt","provision",2.29026935578773
+"7193","Warman, Matt","employment",2.14211056701546
+"7194","Warman, Matt","work",1.81003759482355
+"7195","Warman, Matt","offenders",1.73515176210043
+"7196","Warman, Matt","plans",1.43760445713995
+"7197","Warman, Matt","will",1.10249009757759
+"7198","Warman, Matt","prisons",0.731174497455124
+"7199","Warman, Matt","2010",0
+"7200","Warman, Matt","accommod",0
+"7201","Watson, Tom","violence",7.72677466271013
+"7202","Watson, Tom","domestic",7.68354106364868
+"7203","Watson, Tom","66948",7.13907103398329
+"7204","Watson, Tom","bromwich",7.13907103398329
+"7205","Watson, Tom","eligibility",6.97081628148642
+"7206","Watson, Tom","2017",6.50278399097555
+"7207","Watson, Tom","aid",6.43751583988426
+"7208","Watson, Tom","evidence",6.15325107539313
+"7209","Watson, Tom","legal",5.60839675541105
+"7210","Watson, Tom","gps",5.15731104318073
+"7211","Watson, Tom","victims",4.98775281321178
+"7212","Watson, Tom","enrolled",4.85261405031394
+"7213","Weatherley, Mike","harbour",12.7606636019684
+"7214","Weatherley, Mike","safe",10.240707460918
+"7215","Weatherley, Mike","online",6.98451163633266
+"7216","Weatherley, Mike","provisions",6.36113221044424
+"7217","Weatherley, Mike","monetary",4.81211219256605
+"7218","Weatherley, Mike","received",4.33058712185299
+"7219","Weatherley, Mike","items",4.23465591893919
+"7220","Weatherley, Mike","holders",4.09668510429549
+"7221","Weatherley, Mike","providers",3.60783780039429
+"7222","Weatherley, Mike","internet",3.59704324855529
+"7223","Weatherley, Mike","traditional",3.56084520918548
+"7224","Weatherley, Mike","forward",3.29862860721943
+"7225","Weir, Mike","crackdown",9.97380702437266
+"7226","Weir, Mike","sussex",9.8493455520903
+"7227","Weir, Mike","safer",8.22180277021112
+"7228","Weir, Mike","partnership",7.92463953076419
+"7229","Weir, Mike","roads",6.50101868580577
+"7230","Weir, Mike","operation",6.50070891903314
+"7231","Weir, Mike","contribution",4.29904882460818
+"7232","Weir, Mike","metrics",3.56953551699164
+"7233","Weir, Mike","protocols",2.52629631481241
+"7234","Weir, Mike","inception",2.3523939457652
+"7235","Weir, Mike","promotion",2.2595881164911
+"7236","Weir, Mike","performance",2.10479913521751
+"7237","West, Catherine","scrubs",12.2070945287981
+"7238","West, Catherine","wormwood",12.2070945287981
+"7239","West, Catherine","pentonville",11.5725831853828
+"7240","West, Catherine","cleaners",9.89190772637122
+"7241","West, Catherine","pay",9.56083618831451
+"7242","West, Catherine","drug",8.84314779847726
+"7243","West, Catherine","dealing",8.56610428196111
+"7244","West, Catherine","general",8.52745086291119
+"7245","West, Catherine","hmp",8.38401339227334
+"7246","West, Catherine","structure",8.27390395519961
+"7247","West, Catherine","importance",7.74405700228283
+"7248","West, Catherine","guardian",7.71833665860476
+"7249","Whately, Helen","problems",3.05543550134056
+"7250","Whately, Helen","measures",2.69805035632587
+"7251","Whately, Helen","mental",2.39892421590637
+"7252","Whately, Helen","health",2.34695276901532
+"7253","Whately, Helen","support",1.87557047345725
+"7254","Whately, Helen","place",1.8663670909194
+"7255","Whately, Helen","staff",1.55764207520468
+"7256","Whately, Helen","2010",0
+"7257","Whately, Helen","accommod",0
+"7258","Whately, Helen","cost",0
+"7259","Whately, Helen","flight",0
+"7260","Whately, Helen","hotel",0
+"7261","Wheeler, Heather","female",2.4416632109614
+"7262","Wheeler, Heather","increase",2.35232435883189
+"7263","Wheeler, Heather","rehabilitation",1.99413518252648
+"7264","Wheeler, Heather","effectiveness",1.84217162447031
+"7265","Wheeler, Heather","plans",1.43760445713995
+"7266","Wheeler, Heather","prisoners",0.731174497455124
+"7267","Wheeler, Heather","2010",0
+"7268","Wheeler, Heather","accommod",0
+"7269","Wheeler, Heather","cost",0
+"7270","Wheeler, Heather","flight",0
+"7271","Wheeler, Heather","hotel",0
+"7272","Wheeler, Heather","intern",0
+"7273","Whittaker, Craig","provision",8.29357567637649
+"7274","Whittaker, Craig","todmorden",7.24241900527432
+"7275","Whittaker, Craig","rural",6.46918815093665
+"7276","Whittaker, Craig","account",5.88415081662117
+"7277","Whittaker, Craig","istanbul",5.41940499285428
+"7278","Whittaker, Craig","ratify",5.2584409454106
+"7279","Whittaker, Craig","life",5.25330673820084
+"7280","Whittaker, Craig","estate",4.68197761868413
+"7281","Whittaker, Craig","calder",4.53920480163004
+"7282","Whittaker, Craig","valley",4.53920480163004
+"7283","Whittaker, Craig","consultation",4.28307267225085
+"7284","Whittaker, Craig","court",4.20512517839038
+"7285","Williams, Craig","testify",5.74169037564949
+"7286","Williams, Craig","improve",3.71202681900264
+"7287","Williams, Craig","education",3.56837020943509
+"7288","Williams, Craig","vulnerable",3.19237623336884
+"7289","Williams, Craig","witnesses",2.89068607010282
+"7290","Williams, Craig","protect",2.32648802161266
+"7291","Williams, Craig","court",1.27207964045448
+"7292","Williams, Craig","prisons",1.03403689076237
+"7293","Williams, Craig","2010",0
+"7294","Williams, Craig","accommod",0
+"7295","Williams, Craig","cost",0
+"7296","Williams, Craig","flight",0
+"7297","Williams, Hywel","capabl",7.33818857698644
+"7298","Williams, Hywel","berwyn",7.14522620730583
+"7299","Williams, Hywel","wales",5.54394806596623
+"7300","Williams, Hywel","spiritual",3.87104686156941
+"7301","Williams, Hywel","bilingual",3.7512824949958
+"7302","Williams, Hywel","appeal",3.73870699093184
+"7303","Williams, Hywel","speak",3.26802417241388
+"7304","Williams, Hywel","work",3.24330772555368
+"7305","Williams, Hywel","capacity",2.94922653294524
+"7306","Williams, Hywel","briefing",2.79043427402451
+"7307","Williams, Hywel","full",2.78280086404243
+"7308","Williams, Hywel","lawyer",2.77174934321718
+"7309","Williams, Mark","solicitor",5.31523815837803
+"7310","Williams, Mark","drivers",4.55587291895569
+"7311","Williams, Mark","ceredigion",4.53920480163004
+"7312","Williams, Mark","roads",4.40964252447971
+"7313","Williams, Mark","cause",4.01614005624283
+"7314","Williams, Mark","bilingually",3.97883593553688
+"7315","Williams, Mark","serious",3.62297170450877
+"7316","Williams, Mark","drivers",3.61300826391667
+"7317","Williams, Mark","penalties",3.60316707721605
+"7318","Williams, Mark","death",3.43601953637984
+"7319","Williams, Mark","aid",3.41361648532381
+"7320","Williams, Mark","provide",3.37482323903188
+"7321","Williamson, Gavin","assault",14.1690732938439
+"7322","Williamson, Gavin","fly",13.2538428839362
+"7323","Williamson, Gavin","tippers",10.4313172483732
+"7324","Williamson, Gavin","incidents",10.0807803338097
+"7325","Williamson, Gavin","2011",9.34923464182301
+"7326","Williamson, Gavin","staff",8.98492122695361
+"7327","Williamson, Gavin","2012",8.30047390688019
+"7328","Williamson, Gavin","staffordshire",7.326911496638
+"7329","Williamson, Gavin","2013",7.13636594119374
+"7330","Williamson, Gavin","2009",6.10916276470361
+"7331","Williamson, Gavin","south",6.10667149560633
+"7332","Williamson, Gavin","wolverhampton",5.54292080508183
+"7333","Wilson, Corri","ayr",3.11386880460654
+"7334","Wilson, Corri","carrick",3.11386880460654
+"7335","Wilson, Corri","cumnock",3.11386880460654
+"7336","Wilson, Corri","allowance",2.94226746596752
+"7337","Wilson, Corri","successful",2.80320574234587
+"7338","Wilson, Corri","independence",2.79234014100363
+"7339","Wilson, Corri","decision",2.7454574849441
+"7340","Wilson, Corri","payment",2.51619179929642
+"7341","Wilson, Corri","cancer",2.47885283397922
+"7342","Wilson, Corri","appealed",2.44422100205073
+"7343","Wilson, Corri","support",2.3731565299332
+"7344","Wilson, Corri","personal",2.14944690860728
+"7345","Wilson, Rob","strong",4.83317393779203
+"7346","Wilson, Rob","connection",3.88525076247425
+"7347","Wilson, Rob","targeted",3.27882779967284
+"7348","Wilson, Rob","aid",1.97085239671184
+"7349","Wilson, Rob","legal",1.71701669743954
+"7350","Wilson, Rob","people",1.42032047108441
+"7351","Wilson, Rob","2010",0
+"7352","Wilson, Rob","accommod",0
+"7353","Wilson, Rob","cost",0
+"7354","Wilson, Rob","flight",0
+"7355","Wilson, Rob","hotel",0
+"7356","Wilson, Rob","intern",0
+"7357","Winnick, David","radicalised",4.13844640596946
+"7358","Winnick, David","extremism",3.99447578516243
+"7359","Winnick, David","religious",3.77738630843149
+"7360","Winnick, David","walsall",3.11386880460654
+"7361","Winnick, David","2004",2.242076693946
+"7362","Winnick, David","minimum",2.22752484989065
+"7363","Winnick, David","august",2.06564727275094
+"7364","Winnick, David","murder",2.02027944619746
+"7365","Winnick, David","life",1.96472659583339
+"7366","Winnick, David","imposed",1.93613360544502
+"7367","Winnick, David","respond",1.90119067942487
+"7368","Winnick, David","executive",1.74503261600435
+"7369","Wollaston, Dr Sarah","parent",9.632271274841
+"7370","Wollaston, Dr Sarah","abuse",7.71652088385092
+"7371","Wollaston, Dr Sarah","child",7.47455340108675
+"7372","Wollaston, Dr Sarah","sexual",7.35113168843502
+"7373","Wollaston, Dr Sarah","mortem",6.51604297922696
+"7374","Wollaston, Dr Sarah","children",6.4064837782365
+"7375","Wollaston, Dr Sarah","convicted",5.17406888890783
+"7376","Wollaston, Dr Sarah","1939",4.53920480163004
+"7377","Wollaston, Dr Sarah","coroners",4.44708265325225
+"7378","Wollaston, Dr Sarah","post",4.3449550289938
+"7379","Wollaston, Dr Sarah","pathologists",3.74376043407845
+"7380","Wollaston, Dr Sarah","cancer",3.71827925096883
+"7381","Woodcock, John","requested",8.65044053771961
+"7382","Woodcock, John","2010",8.09742213011162
+"7383","Woodcock, John","freedom",6.97767925174797
+"7384","Woodcock, John","since",6.57857259738121
+"7385","Woodcock, John","appointed",6.41385863419241
+"7386","Woodcock, John","occasions",6.1467026525951
+"7387","Woodcock, John","iphones",5.74169037564949
+"7388","Woodcock, John","exception",5.46308078285457
+"7389","Woodcock, John","spent",4.94161691536941
+"7390","Woodcock, John","senior",4.70664020100349
+"7391","Woodcock, John","information",4.57709011417941
+"7392","Woodcock, John","post",4.45919424436491
+"7393","Wragg, William","engagement",3.48576874441235
+"7394","Wragg, William","privacy",3.32573006579733
+"7395","Wragg, William","historic",3.32573006579733
+"7396","Wragg, William","recent",3.04024668052987
+"7397","Wragg, William","national",3.01300638959893
+"7398","Wragg, William","improve",2.87532361013451
+"7399","Wragg, William","circulated",2.80165802822211
+"7400","Wragg, William","safeguards",2.71667557231756
+"7401","Wragg, William","place",2.63906228215993
+"7402","Wragg, William","leaflets",2.58344013798612
+"7403","Wragg, William","remove",2.5698423229212
+"7404","Wragg, William","estimate",2.42655602030613
+"7405","Wright, Iain","hartlepool",15.6960138894882
+"7406","Wright, Iain","magistrates",7.87953585034295
+"7407","Wright, Iain","teesside",6.25642319256898
+"7408","Wright, Iain","court",5.75117078183104
+"7409","Wright, Iain","closure",5.34192301869429
+"7410","Wright, Iain","heard",5.12410929315054
+"7411","Wright, Iain","transactions",4.85261405031394
+"7412","Wright, Iain","uber",4.85261405031394
+"7413","Wright, Iain","presumption",4.05998820009529
+"7414","Wright, Iain","proposed",3.82152845056742
+"7415","Wright, Iain","estimate",3.71722541472756
+"7416","Wright, Iain","five",3.38318271131521
+"7417","Zeichner, Daniel","littlehey",8.04059085210012
+"7418","Zeichner, Daniel","sentence",7.36034965642197
+"7419","Zeichner, Daniel","will",7.06052501018373
+"7420","Zeichner, Daniel","review",7.05967952223704
+"7421","Zeichner, Daniel","implement",6.99884874433548
+"7422","Zeichner, Daniel","reintegrating",6.99347892192874
+"7423","Zeichner, Daniel","system",6.97644488505358
+"7424","Zeichner, Daniel","release",6.41983379232287
+"7425","Zeichner, Daniel","made",6.40663237011096
+"7426","Zeichner, Daniel","manage",6.11828545976423
+"7427","Zeichner, Daniel","imprisonment",5.99810697554106
+"7428","Zeichner, Daniel","driver",5.88223866771203

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ To access the deployed tool go to https://mojproducts.shinyapps.io/pqtool/
     ```
     Rscript DataCreator.R -i  my_input_file.csv -o my_destination_dir -k 1000
     ```
+    ```
+    for example, from the PQTool directory
+    Rscript data_generators/DataCreator.R -i  Data/archived_pqs.csv -o Data -k 1000
+    ```
   
 ### From an R console
 1. With defaults

--- a/data_generators/.Rhistory
+++ b/data_generators/.Rhistory
@@ -1,4 +1,3 @@
-hier <- cosDists %>% as.dist() %>% hclust(method = "single")
 clusterNum <- cutree(hier,h=similarityThreshold)
 #number of clusters with more than one occupant
 clustSizes <- sapply(seq(max(clusterNum)),function(x)length(which(clusterNum==x)))
@@ -509,4 +508,5 @@ runApp('~/Documents/PQTool')
 runApp('~/Documents/PQTool')
 runApp('~/Documents/PQTool')
 names(termsAndSumsN) <- gsub("probabl", "probability", names(termsAndSumsN))
+shiny::runApp('~/Documents/PQTool')
 shiny::runApp('~/Documents/PQTool')

--- a/global.R
+++ b/global.R
@@ -31,6 +31,8 @@ tables_data <- data[ , !(names(data) %in% drops)]
 
 topic_data <- read.csv("./Data/topDozenWordsPerTopic.csv")
 
+member_data <- read.csv("./Data/topDozenWordsPerMember.csv")
+
 merged_clusters <- ddply(
   data,
   .(Date, Answer_Date, Topic),
@@ -81,14 +83,3 @@ queryVec <- function(query){
   return(which(vocab %in% query))
 }
 
-plotWordcloud <- function(analysisObject){
-  words <- analysisObject$Questions$Question_Text %>%
-    iconv(to = "utf-8", sub = "byte") %>%
-    gsub("[^[:alnum:\\s]]", "", .) %>%
-    removePunctuation() %>%
-    removeWords(c("Justice")) %>%
-    tolower() %>%
-    # JUSTICE_STOP_WORDS assigned in .Rprofile
-    removeWords(c(stopwords(), JUSTICE_STOP_WORDS))
-  wordcloud(words, max.words = 50)
-}

--- a/server.R
+++ b/server.R
@@ -230,7 +230,6 @@ function(input, output, session) {
   }
   
   wordcloud_df <- function(){
-    
     df <- subset(topic_data,
                  (topic_data$topic == input$topic_choice))
   }
@@ -253,7 +252,7 @@ function(input, output, session) {
   
   output$wordcloud <- renderPlot(
     wordcloud(words = wordcloud_df()$word, freq = wordcloud_df()$freq,
-              scale = c(4, 1), random.order = TRUE, ordered.colors = TRUE,
+              scale = c(4, 1), random.order = TRUE,
               min.freq = 0.1)
   )
   
@@ -350,12 +349,16 @@ function(input, output, session) {
     df[cols]
   }
   
-  output$member_wordcloud <- renderPlot({
-    wordcloud_input <- reactive({
-      getElement(allMPs, input$person_choice)
-    })
-    plotWordcloud(wordcloud_input())
-  })
+  member_wordcloud_df <- function(){
+    df <- subset(member_data,
+                 (member_data$member == input$person_choice))
+  }
+  
+  output$member_wordcloud <- renderPlot(
+    wordcloud(words = member_wordcloud_df()$word, freq = member_wordcloud_df()$freq,
+              scale = c(4, 1), random.order = TRUE,
+              min.freq = 0.1)
+  )
   
   addPopover(session, "member_wordcloud", "Wordcloud",
              content = paste0("This wordcloud shows the words that are most important in the questions asked by this member.<br> The bigger the word, the more important it is."),


### PR DESCRIPTION
Added a top dozen words per member csv file that is created by DataCreator, and used it in the word cloud on the MP page, so that we are consistent in our treatment of topics and MPs.