### PR TITLE
Make date input wider so it renders properly on DOM1

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -52,7 +52,7 @@ navbarPage("PQ Text Analysis",
                              )
                       ),
                       
-                      column(2,
+                      column(3,
                              conditionalPanel(
                                condition = searchTextEntered,
                                introBox(
@@ -77,7 +77,7 @@ navbarPage("PQ Text Analysis",
                              )
                       ),
                       column(2,
-                             offset = 4,
+                             offset = 3,
                              actionButton(
                                "tutorial_button",
                                "Click here for a quick tour",


### PR DESCRIPTION
Date input renders fine on macbooks and big screens, but not on DOM1. Given that the majority of users will access the tool via DOM1 this needs fixed.