### PR TITLE
Safeguard against losing questions during update

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,6 +1,10 @@
 #### -- Packrat Autoloader (version 0.4.8-1) -- ####
 SHINY_ROOT <- getwd()
 ARCHIVE_FILEPATH  <- file.path(SHINY_ROOT, 'Data', 'archived_pqs.csv')
+API_ENDPOINT      <- "http://lda.data.parliament.uk/answeredquestions.json"
+MOJ_ONLY          <- "AnsweringBody=Ministry+of+Justice"
+MIN_DOWNLOAD      <- "_pageSize=1"
+MAX_DOWNLOAD      <- "_pageSize=1000"
 JUSTICE_STOP_WORDS <- c(
   "a", "b", "c", "d", "i", "ii", "iii", "iv",
   "secretary", "state", "ministry", "majesty","majestys",

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -169,6 +169,11 @@ Source: CRAN
 Version: 1.2
 Hash: 1290583b9d16fb60322126a8698fb729
 
+Package: compare
+Source: CRAN
+Version: 0.2-6
+Hash: b9aea3450a31bce297fb0a45321002ab
+
 Package: crayon
 Source: CRAN
 Version: 1.3.2

--- a/tests/testthat/test-api-client.R
+++ b/tests/testthat/test-api-client.R
@@ -70,13 +70,15 @@ test_that("fetch_questions() calls the API with the correct params", {
   )
 
   with_mock(
-    `file.exists`      = function(filepath)            { TRUE         },
-    `write_csv`        = function(questions, filepath) { NULL         },
-    `last_answer_date` = function()                    { '2017-03-23' },
-    `number_to_fetch`  = function()                    { 1000         },
-    `update_archive`   = function(questions)           { NULL         },
-    `party`            = function(member)              { 'party'      },
-    `jsonlite::fromJSON` = function(actual_API_call) {
+    `file.exists`          = function(filepath)            { TRUE         },
+    `write_csv`            = function(questions, filepath) { NULL         },
+    `last_answer_date`     = function()                    { '2017-03-23' },
+    `number_in_archive`    = function()                    { 1000         },
+    `number_to_fetch`      = function()                    { 1000         },
+    `number_held_remotely` = function()                    { 2000         },
+    `update_archive`       = function(questions)           { NULL         },
+    `party`                = function(member)              { 'party'      },
+    `jsonlite::fromJSON`   = function(actual_API_call) {
       expect_equal(actual_API_call, expected_API_call)
       dummy_pqs_api_response
     },
@@ -119,13 +121,14 @@ test_that("fetch_questions() calls the API with the correct params", {
   )
 
   with_mock(
-    `file.exists`     = function(filepath)            { FALSE   },
-    `number_to_fetch` = function()                    { 1000    },
-    `file.create`     = function(filepath)            { NULL    },
-    `write_csv`       = function(questions, filepath) { NULL    },
-    `update_archive`  = function(questions)           { NULL    },
-    `party`           = function(member)              { 'party' },
-    `jsonlite::fromJSON` = function(actual_API_call) {
+    `file.exists`          = function(filepath)            { FALSE   },
+    `number_to_fetch`      = function()                    { 1000    },
+    `number_held_remotely` = function()                    { 1000    },
+    `file.create`          = function(filepath)            { NULL    },
+    `write_csv`            = function(questions, filepath) { NULL    },
+    `update_archive`       = function(questions)           { NULL    },
+    `party`                = function(member)              { 'party' },
+    `jsonlite::fromJSON`   = function(actual_API_call) {
       expect_equal(actual_API_call, expected_API_call)
       dummy_pqs_api_response
     },
@@ -137,10 +140,11 @@ test_that("fetch_questions() calls the API with the correct params", {
 test_that("fetch_questions creates an archive file if one does not already exist", {
 
   with_mock(
-    `file.exists`     = function(filepath) { FALSE   },
-    `number_to_fetch` = function()         { 1000    },
-    `party`           = function(memeber)  { 'party' },
-    `jsonlite::fromJSON` = function(actual_API_call) {
+    `file.exists`          = function(filepath) { FALSE   },
+    `number_to_fetch`      = function()         { 1000    },
+    `number_held_remotely` = function()         { 1000    },
+    `party`                = function(memeber)  { 'party' },
+    `jsonlite::fromJSON`   = function(actual_API_call) {
       dummy_pqs_api_response
     },
     `write_csv`      = function(questions, filepath) { NULL },
@@ -160,11 +164,12 @@ test_that("fetch_questions creates an archive file if one does not already exist
 test_that("fetch_questions() downloads new questions and calls the update_archive function", {
 
   with_mock(
-    `file.exists`       = function(filepath) { FALSE   },
-    `number_to_fetch`   = function()         { 3000    },
-    `file.create`       = function(filepath) { NULL    },
-    `party`             = function(member)   { 'party' },
-    `jsonlite::fromJSON` = function(actual_API_call) {
+    `file.exists`          = function(filepath) { FALSE   },
+    `number_to_fetch`      = function()         { 3000    },
+    `number_held_remotely` = function()         { 3000    },
+    `file.create`          = function(filepath) { NULL    },
+    `party`                = function(member)   { 'party' },
+    `jsonlite::fromJSON`   = function(actual_API_call) {
       dummy_pqs_api_response
     },
 


### PR DESCRIPTION
If you interrupt the update process, or it is interrupted by API timeout, for example, then re-run `fetch_questions()` you will end up with some questions missing for some, as yet inexplicable, reason. In this scenario if, after interrupting the update, you run `number_to_fetch()` you will see that the number returned is not high enough.  The subsequent download is based on this number.

`number_to_fetch()` queries our archive and gets the date of the last question answered then uses this to filter for new questions when querying the API.  This is likely to be where the problem lies.

This is a quick fix to make sure that when this bug occurs, we know about it.  Here, we compare:  `number_to_fetch()` + the total already held in our archive with the total held remotely.  If the former is lower than the latter, we're going to 'lose' questions.  We could also throw a warning if the former is greater than the latter, because this would imply duplication but we *should* be OK handling that.