### PR TITLE
Added links to TheyWorkForYou pages, corrected some MP names

### DIFF
--- a/Data/topDozenWordsPerMember.csv
+++ b/Data/topDozenWordsPerMember.csv
@@ -227,3558 +227,3558 @@
 "226","Bailey, Adrian","boards",1.46773421738291
 "227","Bailey, Adrian","programme",1.39949685331059
 "228","Bailey, Adrian","managing",1.31970583861406
-"229","Bailey, Rebecca Long","1287",3.74933095786226
-"230","Bailey, Rebecca Long","budget",3.55070657190092
-"231","Bailey, Rebecca Long","expertise",3.43310319184542
-"232","Bailey, Rebecca Long","small",3.06209355073595
-"233","Bailey, Rebecca Long","minor",2.93639188796211
-"234","Bailey, Rebecca Long","limit",2.8757419427
-"235","Bailey, Rebecca Long","funded",2.81922999954547
-"236","Bailey, Rebecca Long","1293",2.74099913247552
-"237","Bailey, Rebecca Long","whiplash",2.7371112523786
-"238","Bailey, Rebecca Long","nuisance",2.73373133054671
-"239","Bailey, Rebecca Long","reference",2.63976260714791
-"240","Bailey, Rebecca Long","located",2.61566627500507
-"241","Baker, Norman","comrcio",2.42963604985466
-"242","Baker, Norman","diligence",2.42963604985466
-"243","Baker, Norman","internacional",2.42963604985466
-"244","Baker, Norman","killarney",2.42963604985466
-"245","Baker, Norman","lda",2.42963604985466
-"246","Baker, Norman","lewes",2.42963604985466
-"247","Baker, Norman","quora",2.42963604985466
-"248","Baker, Norman","whitbread",2.42963604985466
-"249","Baker, Norman","offshore",2.24065381335005
-"250","Baker, Norman","plc",2.24065381335005
-"251","Baker, Norman","fact",1.94112405518782
-"252","Baker, Norman","recently",1.89909583802198
-"253","Baker, Steve","obstacle",4.1918794459622
-"254","Baker, Steve","preparation",3.04356366118304
-"255","Baker, Steve","delays",2.86949933839398
-"256","Baker, Steve","restricted",2.82787718429044
-"257","Baker, Steve","dates",2.63407640607955
-"258","Baker, Steve","books",2.59255877883951
-"259","Baker, Steve","asylum)",2.45485747743195
-"260","Baker, Steve","tier",2.20283267172732
-"261","Baker, Steve","immigr",2.17816581124606
-"262","Baker, Steve","hearings",2.13782734425893
-"263","Baker, Steve","access",1.9567403329279
-"264","Baker, Steve","first",1.9229875624584
-"265","Barclay, Stephen","network rail",6.02398445487787
-"266","Barclay, Stephen","532",4.98893495426658
-"267","Barclay, Stephen","task",4.80523252962503
-"268","Barclay, Stephen","tackling",4.80523252962503
-"269","Barclay, Stephen","publish",4.58155879969684
-"270","Barclay, Stephen","lay",4.52360581122418
-"271","Barclay, Stephen","prime",4.44788395995126
-"272","Barclay, Stephen","radicalisation",4.10370205381423
-"273","Barclay, Stephen","2000",4.08689105599983
-"274","Barclay, Stephen","drive",4.04558544020847
-"275","Barclay, Stephen","freedom",3.98916015497135
-"276","Barclay, Stephen","extremism",3.96121138322711
-"277","Bardell, Hannah","july",2.05101380989086
-"278","Bardell, Hannah","claims",1.75419324822195
-"279","Bardell, Hannah","estimate",1.65339824303596
-"280","Bardell, Hannah","employment",1.51553132933529
-"281","Bardell, Hannah","number",1.47926745223442
-"282","Bardell, Hannah","2013",1.46691649229498
-"283","Bardell, Hannah","tribunal",1.4620586486878
-"284","Bardell, Hannah","made",1.01189529216649
-"285","Bardell, Hannah","convict",0
-"286","Bardell, Hannah","five",0
-"287","Bardell, Hannah","person",0
-"288","Bardell, Hannah","rape",0
-"289","Baroness Afshar","tax",4.53310433109601
-"290","Baroness Afshar","council",3.69515628330937
-"291","Baroness Afshar","rough",3.43602425333506
-"292","Baroness Afshar","groups",3.2533896810499
-"293","Baroness Afshar","non",3.18325117713378
-"294","Baroness Afshar","begging",3.16876301142263
-"295","Baroness Afshar","sleeping",3.16876301142263
-"296","Baroness Afshar","payment",3.07584073248771
-"297","Baroness Afshar","sum",2.68572709037698
-"298","Baroness Afshar","breakdown",2.51145226262694
-"299","Baroness Afshar","committals",2.51145226262694
-"300","Baroness Afshar","specific",2.48215439173454
-"301","Baroness Altmann","county",5.72892131281441
-"302","Baroness Altmann","action",4.89341456969299
-"303","Baroness Altmann","lodge",4.79576848015894
-"304","Baroness Altmann","defence",4.31026736023359
-"305","Baroness Altmann","discovered",3.43602425333506
-"306","Baroness Altmann","penalise",3.43602425333506
-"307","Baroness Altmann","individual",3.34363258668647
-"308","Baroness Altmann","sue",2.96410638215638
-"309","Baroness Altmann","monies",2.81786575697609
-"310","Baroness Altmann","knowing",2.79458629730814
-"311","Baroness Altmann","correct",2.56786575697609
-"312","Baroness Altmann","notification",2.54820162515169
-"313","Baroness Armstrong of Hill Top","chairs",3.22883350906107
-"314","Baroness Armstrong of Hill Top","departmental",2.66614817783265
-"315","Baroness Armstrong of Hill Top","list",2.316511644339
-"316","Baroness Armstrong of Hill Top","appointed",2.27067713642236
-"317","Baroness Armstrong of Hill Top","bodies",2.20920227937655
-"318","Baroness Armstrong of Hill Top","non",1.81851536411445
-"319","Baroness Armstrong of Hill Top","persons",1.49234905385142
-"320","Baroness Armstrong of Hill Top","public",1.41513357710606
-"321","Baroness Armstrong of Hill Top","will",0.89885139728238
-"322","Baroness Armstrong of Hill Top","convict",0
-"323","Baroness Armstrong of Hill Top","five",0
-"324","Baroness Armstrong of Hill Top","rape",0
-"325","Baroness Corston","holloway",14.8285410817851
-"326","Baroness Corston","site",12.8288041368427
-"327","Baroness Corston","carillion",12.4565318785247
-"328","Baroness Corston","women",11.5155471239816
-"329","Baroness Corston","prison",10.7556469660525
-"330","Baroness Corston","rehabilitation",10.4445335441449
-"331","Baroness Corston","programme",9.46066461988412
-"332","Baroness Corston","contract",9.27414725025645
-"333","Baroness Corston","irish",8.95848424862502
-"334","Baroness Corston","republic",8.47578602212964
-"335","Baroness Corston","market",8.25022680605374
-"336","Baroness Corston","community",7.76448943570648
-"337","Baroness Coussins","interpretation",25.9064140061415
-"338","Baroness Coussins","thebigword",9.82000637533273
-"339","Baroness Coussins","translating",7.21685144856835
-"340","Baroness Coussins","court",6.95026856464688
-"341","Baroness Coussins","provision",5.75473981511824
-"342","Baroness Coussins","contract",5.71986682127364
-"343","Baroness Coussins","services",4.39043822264554
-"344","Baroness Coussins","cancellation",4.32492039014931
-"345","Baroness Coussins","current",4.27176491212878
-"346","Baroness Coussins","quality",4.24581812860593
-"347","Baroness Coussins","directive",4.23827106545622
-"348","Baroness Coussins","language",3.81201666310858
-"349","Baroness Deech","nuptial",4.4813076267001
-"350","Baroness Deech","plan",4.36897444397305
-"351","Baroness Deech","binding",4.26021258338486
-"352","Baroness Deech","divorce",3.42022720303473
-"353","Baroness Deech","pre",3.06209355073595
-"354","Baroness Deech","post",2.53488617054572
-"355","Baroness Deech","agreements",2.50499992588602
-"356","Baroness Deech","review",2.44332354494223
-"357","Baroness Deech","britainajourney",2.23801641999213
-"358","Baroness Deech","equalthat",2.23801641999213
-"359","Baroness Deech","theconclusion",2.23801641999213
-"360","Baroness Deech","legislation",2.17250239952996
-"361","Baroness Doocey","section",7.82142165883526
-"362","Baroness Doocey","past",7.578919879091
-"363","Baroness Doocey","coroners",6.25981105085803
-"364","Baroness Doocey","act",6.10678125143013
-"365","Baroness Doocey","2009",5.85182036896875
-"366","Baroness Doocey","modern",5.65946662226605
-"367","Baroness Doocey","slavery",5.50333522145866
-"368","Baroness Doocey","guidance",3.95714676462488
-"369","Baroness Doocey","commission",3.65527403965854
-"370","Baroness Doocey","victim",3.45129399522619
-"371","Baroness Doocey","prosecutions",3.32124643019985
-"372","Baroness Doocey","embedded",3.2883807836292
-"373","Baroness Drake","lower",3.83630669925203
-"374","Baroness Drake","level",2.39549516757162
-"375","Baroness Drake","access",2.25944911590024
-"376","Baroness Drake","fees",2.14596231804009
-"377","Baroness Drake","employment",1.74998484191408
-"378","Baroness Drake","tribunals",1.68823990878185
-"379","Baroness Drake","convict",0
-"380","Baroness Drake","five",0
-"381","Baroness Drake","person",0
-"382","Baroness Drake","rape",0
-"383","Baroness Drake","year",0
-"384","Baroness Drake","offenc",0
-"385","Baroness Gale","53a",3.0124252070077
-"386","Baroness Gale","2003",1.88394336463971
-"387","Baroness Gale","imposed",1.86382176623512
-"388","Baroness Gale","penalty",1.736897009058
-"389","Baroness Gale","sexual",1.51978119303064
-"390","Baroness Gale","prosecutions",1.45351977788345
-"391","Baroness Gale","section",1.41087121425122
-"392","Baroness Gale","act",1.1015749124891
-"393","Baroness Gale","wales",1.08044214622602
-"394","Baroness Gale","convictions",1.07533509847354
-"395","Baroness Gale","case",1.05636173340212
-"396","Baroness Gale","offences",0.970161872294391
-"397","Baroness Golding","thames",2.42018272653674
-"398","Baroness Golding","drawn",2.09665361085237
-"399","Baroness Golding","leeds",1.97724864039993
-"400","Baroness Golding","liverpool",1.89252946562044
-"401","Baroness Golding","formal",1.89252946562044
-"402","Baroness Golding","1999",1.78995701313116
-"403","Baroness Golding","conclusions",1.70093865408485
-"404","Baroness Golding","announcement",1.70093865408485
-"405","Baroness Golding","kingston",1.6648336320889
-"406","Baroness Golding","pilot",1.64300965747714
-"407","Baroness Golding","basis",1.57729636028212
-"408","Baroness Golding","upon",1.46642789744679
-"409","Baroness Gould of Potternewton","genital",2.44704013864261
-"410","Baroness Gould of Potternewton","mutilation",2.44704013864261
-"411","Baroness Gould of Potternewton","abroad",2.41846584846456
-"412","Baroness Gould of Potternewton","sufficient",2.17977889673018
-"413","Baroness Gould of Potternewton","kingdom",2.15120460655214
-"414","Baroness Gould of Potternewton","practice",2.00415825097043
-"415","Baroness Gould of Potternewton","consider",1.91251765481776
-"416","Baroness Gould of Potternewton","carried",1.82059197438716
-"417","Baroness Gould of Potternewton","united",1.7322232976726
-"418","Baroness Gould of Potternewton","female",1.5965605243227
-"419","Baroness Gould of Potternewton","legislation",1.53619117885168
-"420","Baroness Gould of Potternewton","current",1.46729183002864
-"421","Baroness Hamwee","timetabling",3.71133036988416
-"422","Baroness Hamwee","guardianship",2.67644083747113
-"423","Baroness Hamwee","affairs",2.50757670884253
-"424","Baroness Hamwee","decide",2.38776570287631
-"425","Baroness Hamwee","missing",2.32356654071415
-"426","Baroness Hamwee","property",2.28117708317411
-"427","Baroness Hamwee","legislation",1.65927611555321
-"428","Baroness Hamwee","consultation",1.59767179159901
-"429","Baroness Hamwee","response",1.58233986939804
-"430","Baroness Hamwee","proposed",1.382850987175
-"431","Baroness Hamwee","persons",1.292412191949
-"432","Baroness Hamwee","will",0.77842814427368
-"433","Baroness Hayter of Kentish Town","intend",7.68836556647595
-"434","Baroness Hayter of Kentish Town","withdraw",7.53622466752175
-"435","Baroness Hayter of Kentish Town","continued",7.11490175301801
-"436","Baroness Hayter of Kentish Town","choice",6.99748917747002
-"437","Baroness Hayter of Kentish Town","bank",6.91767985244346
-"438","Baroness Hayter of Kentish Town","participation",6.87258900498037
-"439","Baroness Hayter of Kentish Town","brussels",6.79814219616455
-"440","Baroness Hayter of Kentish Town","hague",6.53997015295838
-"441","Baroness Hayter of Kentish Town","signatory",6.53997015295838
-"442","Baroness Hayter of Kentish Town","ombudsman",6.04182856213677
-"443","Baroness Hayter of Kentish Town","will",5.75683163277542
-"444","Baroness Hayter of Kentish Town","become",5.64629281153565
-"445","Baroness Healy of Primrose Hill","immediate",2.07634261619918
-"446","Baroness Healy of Primrose Hill","remanded",1.90517311907292
-"447","Baroness Healy of Primrose Hill","subsequently",1.87041297747788
-"448","Baroness Healy of Primrose Hill","crown",1.52246814793449
-"449","Baroness Healy of Primrose Hill","women",1.51183088109155
-"450","Baroness Healy of Primrose Hill","magistrates",1.23421797132583
-"451","Baroness Healy of Primrose Hill","custodial",1.22663261584402
-"452","Baroness Healy of Primrose Hill","receive",1.17187381445793
-"453","Baroness Healy of Primrose Hill","england",1.08648714188543
-"454","Baroness Healy of Primrose Hill","wales",1.08044214622602
-"455","Baroness Healy of Primrose Hill","convicted",1.07533509847354
-"456","Baroness Healy of Primrose Hill","proportion",1.05636173340212
-"457","Baroness Hodgson of Abinger","identification",4.0655587238791
-"458","Baroness Hodgson of Abinger","gathered",3.74933095786226
-"459","Baroness Hodgson of Abinger","gypsies",2.72224609610137
-"460","Baroness Hodgson of Abinger","enable",2.38261729153062
-"461","Baroness Hodgson of Abinger","can",2.3603582316201
-"462","Baroness Hodgson of Abinger","travellers",2.27178033009015
-"463","Baroness Hodgson of Abinger","youth",1.83106512470491
-"464","Baroness Hodgson of Abinger","system",1.77057117926664
-"465","Baroness Hodgson of Abinger","justice",1.76759904999392
-"466","Baroness Hodgson of Abinger","data",1.75016175949694
-"467","Baroness Hodgson of Abinger","convict",0
-"468","Baroness Hodgson of Abinger","five",0
-"469","Baroness Howe of Idlicote","visiting",12.2624653844511
-"470","Baroness Howe of Idlicote","barnardos",11.8092733361489
-"471","Baroness Howe of Idlicote","locked",10.5267904683264
-"472","Baroness Howe of Idlicote","experiences",9.65416474903672
-"473","Baroness Howe of Idlicote","fathers",9.04328542677841
-"474","Baroness Howe of Idlicote","parent",8.62158067625167
-"475","Baroness Howe of Idlicote","incentive",7.77147348379736
-"476","Baroness Howe of Idlicote","privileges",7.77147348379736
-"477","Baroness Howe of Idlicote","children",7.5272510068545
-"478","Baroness Howe of Idlicote","earned",6.49739728023495
-"479","Baroness Howe of Idlicote","scheme",5.07968713666443
-"480","Baroness Howe of Idlicote","report",4.93709434552974
-"481","Baroness Hussein-Ece","pursue",2.24866008047404
-"482","Baroness Hussein-Ece","sex",1.67972611422613
-"483","Baroness Hussein-Ece","violence",1.40962467057739
-"484","Baroness Hussein-Ece","child",1.40436284294811
-"485","Baroness Hussein-Ece","domestic",1.39917897119383
-"486","Baroness Hussein-Ece","given",1.37917895962982
-"487","Baroness Hussein-Ece","access",1.34231279435367
-"488","Baroness Hussein-Ece","prosecuted",1.31904770519308
-"489","Baroness Hussein-Ece","family",1.24549958361764
-"490","Baroness Hussein-Ece","aid",1.16841695963381
-"491","Baroness Hussein-Ece","legal",1.01908364267726
-"492","Baroness Hussein-Ece","convicted",0.975850700855631
-"493","Baroness Jones of Moulsecoomb","crash",2.36906627436083
-"494","Baroness Jones of Moulsecoomb","laid",2.36906627436083
-"495","Baroness Jones of Moulsecoomb","treated",2.19288698659778
-"496","Baroness Jones of Moulsecoomb","traffic",1.91354453719715
-"497","Baroness Jones of Moulsecoomb","qualify",1.80498121111431
-"498","Baroness Jones of Moulsecoomb","extend",1.7797820163586
-"499","Baroness Jones of Moulsecoomb","code",1.73473074144029
-"500","Baroness Jones of Moulsecoomb","road",1.73473074144029
-"501","Baroness Jones of Moulsecoomb","practice",1.63638835955545
-"502","Baroness Jones of Moulsecoomb","regard",1.59339139449136
-"503","Baroness Jones of Moulsecoomb","include",1.38886356842976
-"504","Baroness Jones of Moulsecoomb","charge",1.31169365828426
-"505","Baroness Kennedy of Cradley","holloway",7.832596889295
-"506","Baroness Kennedy of Cradley","hmp",5.17474934942291
-"507","Baroness Kennedy of Cradley","presently",3.72656987909899
-"508","Baroness Kennedy of Cradley","economic",3.42469510436916
-"509","Baroness Kennedy of Cradley","corporate",3.32233905826068
-"510","Baroness Kennedy of Cradley","liability",3.16413841980111
-"511","Baroness Kennedy of Cradley","assaults",2.64601479405024
-"512","Baroness Kennedy of Cradley","call",2.62695853427377
-"513","Baroness Kennedy of Cradley","held",2.59921946369702
-"514","Baroness Kennedy of Cradley","evidence",2.17646965574086
-"515","Baroness Kennedy of Cradley","response",1.93796263984368
-"516","Baroness Kennedy of Cradley","crime",1.90523557471049
-"517","Baroness Kennedy of The Shaws","unaccompanied",10.4850148932327
-"518","Baroness Kennedy of The Shaws","migrant",10.1741003237417
-"519","Baroness Kennedy of The Shaws","appeared",7.77370276837618
-"520","Baroness Kennedy of The Shaws","deradicalisation",4.92430098544712
-"521","Baroness Kennedy of The Shaws","children",4.69028170103063
-"522","Baroness Kennedy of The Shaws","undergone",4.64386075887713
-"523","Baroness Kennedy of The Shaws","2014",4.3528902404315
-"524","Baroness Kennedy of The Shaws","proceedings",4.02611872964542
-"525","Baroness Kennedy of The Shaws","programme",2.84656078331018
-"526","Baroness Kennedy of The Shaws","healthy",2.72005056373129
-"527","Baroness Kennedy of The Shaws","either",2.63508283207643
-"528","Baroness Kennedy of The Shaws","currently",2.63204190948855
-"529","Baroness King of Bow","explanatory",3.03028855770365
-"530","Baroness King of Bow","pupils",2.79458629730814
-"531","Baroness King of Bow","admission",2.79458629730814
-"532","Baroness King of Bow","academy",2.79458629730814
-"533","Baroness King of Bow","sen",2.65670931364155
-"534","Baroness King of Bow","went",2.3685886568422
-"535","Baroness King of Bow","schools",2.3685886568422
-"536","Baroness King of Bow","memorandum",2.28313006957944
-"537","Baroness King of Bow","instances",2.21489270550712
-"538","Baroness King of Bow","goods",1.92238429128494
-"539","Baroness King of Bow","compliance",1.88525145619363
-"540","Baroness King of Bow","copy",1.80240862399988
-"541","Baroness Kinnock of Holyhead","eritrean",7.17198619315161
-"542","Baroness Kinnock of Holyhead","asylum",4.45485122606036
-"543","Baroness Kinnock of Holyhead","appeals",3.08593514978754
-"544","Baroness Kinnock of Holyhead","nationals",2.8751867939638
-"545","Baroness Kinnock of Holyhead","lodged",2.67644083747113
-"546","Baroness Kinnock of Holyhead","2013",2.50978229810019
-"547","Baroness Kinnock of Holyhead","outside",2.40549051337143
-"548","Baroness Kinnock of Holyhead","initial",2.2679546969101
-"549","Baroness Kinnock of Holyhead","2015",2.2639600220934
-"550","Baroness Kinnock of Holyhead","2014",2.16573453457835
-"551","Baroness Kinnock of Holyhead","pay",2.05512425612285
-"552","Baroness Kinnock of Holyhead","refusals",1.98583828345695
-"553","Baroness Lawrence of Clarendon","historical",2.96511597206594
-"554","Baroness Lawrence of Clarendon","face",2.84530496609973
-"555","Baroness Lawrence of Clarendon","continue",2.40549051337143
-"556","Baroness Lawrence of Clarendon","problems",2.32356654071415
-"557","Baroness Lawrence of Clarendon","met",2.20749071839583
-"558","Baroness Lawrence of Clarendon","discuss",2.02752005996842
-"559","Baroness Lawrence of Clarendon","commissioner",2.01315759583639
-"560","Baroness Lawrence of Clarendon","financial",1.61903391940739
-"561","Baroness Lawrence of Clarendon","crime",1.55561833261298
-"562","Baroness Lawrence of Clarendon","families",1.48244102236422
-"563","Baroness Lawrence of Clarendon","victims",1.280089689943
-"564","Baroness Lawrence of Clarendon","legal",1.21295214947974
-"565","Baroness Lister of Burtersett","pursuing",4.6425415406108
-"566","Baroness Lister of Burtersett","upper",4.53118197942137
-"567","Baroness Lister of Burtersett","chamber)",4.14180702582731
-"568","Baroness Lister of Burtersett","representation",3.98060651743871
-"569","Baroness Lister of Burtersett","appeals",3.96942824049451
-"570","Baroness Lister of Burtersett","asylum",3.68769560347356
-"571","Baroness Lister of Burtersett","hl2645",3.56573088174181
-"572","Baroness Lister of Burtersett","litigants",3.51908706169429
-"573","Baroness Lister of Burtersett","200203",3.31951479760817
-"574","Baroness Lister of Burtersett","forcible",3.31951479760817
-"575","Baroness Lister of Burtersett","meters",3.31951479760817
-"576","Baroness Lister of Burtersett","prepayment",3.31951479760817
-"577","Baroness Ludford","rental",10.6797352150481
-"578","Baroness Ludford","buildings",10.3271882946916
-"579","Baroness Ludford","raised",9.87824869103113
-"580","Baroness Ludford","disposed",9.14366566627923
-"581","Baroness Ludford","money",8.16568323286223
-"582","Baroness Ludford","sale",8.10871807481138
-"583","Baroness Ludford","estate",7.79932991909789
-"584","Baroness Ludford","may",6.83874630057567
-"585","Baroness Ludford","third",6.28511776787567
-"586","Baroness Ludford","amp",5.67019187359006
-"587","Baroness Ludford","parties",5.4968437030573
-"588","Baroness Ludford","2010",4.62088948203288
-"589","Baroness Masham of Ilton","training",6.69170822148218
-"590","Baroness Masham of Ilton","officer",6.09576342693685
-"591","Baroness Masham of Ilton","role",4.82579733469774
-"592","Baroness Masham of Ilton","suggestion",3.42265523528935
-"593","Baroness Masham of Ilton","fulfil",3.27333545844424
-"594","Baroness Masham of Ilton","vocational",3.13398010069454
-"595","Baroness Masham of Ilton","degree",3.04104746457308
-"596","Baroness Masham of Ilton","league",3.04104746457308
-"597","Baroness Masham of Ilton","howard",3.04104746457308
-"598","Baroness Masham of Ilton","penal",3.04104746457308
-"599","Baroness Masham of Ilton","receive",2.70863175929399
-"600","Baroness Masham of Ilton","england",2.51127172761062
-"601","Baroness Meacher","havemade",3.71133036988416
-"602","Baroness Meacher","law",3.46522367369785
-"603","Baroness Meacher","terminal",2.84483247791272
-"604","Baroness Meacher","die",2.79899796999608
-"605","Baroness Meacher","illness",2.77762119085617
-"606","Baroness Meacher","burials",2.64310543618979
-"607","Baroness Meacher","possible",2.46369719538345
-"608","Baroness Meacher","assisted",2.45485747743195
-"609","Baroness Meacher","cremations",2.33871258021393
-"610","Baroness Meacher","scotland",2.32356654071415
-"611","Baroness Meacher","basis",2.23063390459269
-"612","Baroness Meacher","level",1.95591361395112
-"613","Baroness Miller of Chilthorne Domer","800th",7.11120534712431
-"614","Baroness Miller of Chilthorne Domer","anniversary",7.11120534712431
-"615","Baroness Miller of Chilthorne Domer","forest",6.84935674088551
-"616","Baroness Miller of Chilthorne Domer","charter",6.64625118270864
-"617","Baroness Miller of Chilthorne Domer","mark",6.01534769400275
-"618","Baroness Miller of Chilthorne Domer","celebrate",3.98506397046232
-"619","Baroness Miller of Chilthorne Domer","granting",3.94725568100664
-"620","Baroness Miller of Chilthorne Domer","2017",3.9015072919179
-"621","Baroness Miller of Chilthorne Domer","carta",3.12614137666199
-"622","Baroness Miller of Chilthorne Domer","magna",3.12614137666199
-"623","Baroness Miller of Chilthorne Domer","similar",2.53941356285557
-"624","Baroness Miller of Chilthorne Domer","way",2.24696236650233
-"625","Baroness Morgan of Huyton","literacy",6.1579870339585
-"626","Baroness Morgan of Huyton","light",4.28404688523641
-"627","Baroness Morgan of Huyton","parcels",3.72450728589427
-"628","Baroness Morgan of Huyton","skills",3.28318859405118
-"629","Baroness Morgan of Huyton","improvement",3.17376537805039
-"630","Baroness Morgan of Huyton","stop",3.16413841980111
-"631","Baroness Morgan of Huyton","showing",3.12614137666199
-"632","Baroness Morgan of Huyton","targets",3.04226273002551
-"633","Baroness Morgan of Huyton","governors",2.96944973466319
-"634","Baroness Morgan of Huyton","monitored",2.54262087428531
-"635","Baroness Morgan of Huyton","sent",2.45703163861456
-"636","Baroness Morgan of Huyton","libraries",2.38574330333962
-"637","Baroness Pinnock","foster",4.54543283655548
-"638","Baroness Pinnock","abused",3.5273201588906
-"639","Baroness Pinnock","compensation",3.49874213327648
-"640","Baroness Pinnock","injuries",3.31045049746779
-"641","Baroness Pinnock","children",2.86167618634881
-"642","Baroness Pinnock","parents",2.65125216004296
-"643","Baroness Pinnock","criminal",2.64839877233512
-"644","Baroness Pinnock","indefinitely",2.55888403691262
-"645","Baroness Pinnock","keeping",2.24730259686733
-"646","Baroness Pinnock","best",2.21489270550712
-"647","Baroness Pinnock","allege",1.79334018039318
-"648","Baroness Pinnock","claimants",1.79334018039318
-"649","Baroness Rebuck","least",2.90091680990377
-"650","Baroness Rebuck","literacy",2.71267848175249
-"651","Baroness Rebuck","studies",2.63362435843454
-"652","Baroness Rebuck","entry",2.55662983150491
-"653","Baroness Rebuck","skills",2.50757670884253
-"654","Baroness Rebuck","cent",2.50757670884253
-"655","Baroness Rebuck","recognised",2.46410638215638
-"656","Baroness Rebuck","qualifications",2.34924847749706
-"657","Baroness Rebuck","towards",2.31786575697609
-"658","Baroness Rebuck","materials",2.26226765164198
-"659","Baroness Rebuck","specific",2.23738373325425
-"660","Baroness Rebuck","higher",2.23738373325425
-"661","Baroness Redfern","sanctions",3.28318859405118
-"662","Baroness Redfern","targets",3.04226273002551
-"663","Baroness Redfern","met",2.89028380370323
-"664","Baroness Redfern","lasting",2.83330026878961
-"665","Baroness Redfern","imposed",2.63584201965588
-"666","Baroness Redfern","percentage",2.42688610118765
-"667","Baroness Redfern","education",2.34270470544706
-"668","Baroness Redfern","less",2.23027757963408
-"669","Baroness Redfern","upon",2.16605755572496
-"670","Baroness Redfern","accommodation",2.12537475660989
-"671","Baroness Redfern","allocated",2.05390474951407
-"672","Baroness Redfern","providers",1.80249846893443
-"673","Baroness Seccombe","bears",3.03028855770365
-"674","Baroness Seccombe","kingdom",1.89718413605117
-"675","Baroness Seccombe","aware",1.84131346144502
-"676","Baroness Seccombe","concerns",1.75130568951585
-"677","Baroness Seccombe","incurred",1.74348818471609
-"678","Baroness Seccombe","united",1.52767735362464
-"679","Baroness Seccombe","purse",1.51958062629746
-"680","Baroness Seccombe","european",1.50778592432058
-"681","Baroness Seccombe","private",1.39392219596654
-"682","Baroness Seccombe","human",1.39116876811131
-"683","Baroness Seccombe","rights",1.22523080063216
-"684","Baroness Seccombe","average",1.12280740675689
-"685","Baroness Sharples","delays",3.51440459815959
-"686","Baroness Sharples","inquests",3.35276739290178
-"687","Baroness Sharples","london",2.84703477522624
-"688","Baroness Sharples","six",2.6902088515967
-"689","Baroness Sharples","holding",2.6902088515967
-"690","Baroness Sharples","months",1.65040263970043
-"691","Baroness Sharples","convict",0
-"692","Baroness Sharples","five",0
-"693","Baroness Sharples","person",0
-"694","Baroness Sharples","rape",0
-"695","Baroness Sharples","year",0
-"696","Baroness Sharples","offenc",0
-"697","Baroness Smith of Basildon","genital",8.93223053387195
-"698","Baroness Smith of Basildon","mutilation",8.93223053387195
-"699","Baroness Smith of Basildon","phone",8.23289538544681
-"700","Baroness Smith of Basildon","whilst",7.76473381568405
-"701","Baroness Smith of Basildon","mobile",7.14782017876855
-"702","Baroness Smith of Basildon","cautioned",6.85492818553776
-"703","Baroness Smith of Basildon","prosecuted",6.76090201910854
-"704","Baroness Smith of Basildon","drug",6.5148143272348
-"705","Baroness Smith of Basildon","use",6.3139215915633
-"706","Baroness Smith of Basildon","drive",5.9288171025926
-"707","Baroness Smith of Basildon","female",5.82779433787318
-"708","Baroness Smith of Basildon","770)",5.10622671596857
-"709","Baroness Stern","inspector",40.8954673441832
-"710","Baroness Stern","chief",34.1526466617138
-"711","Baroness Stern","report",23.2568861469912
-"712","Baroness Stern","action",20.685449522607
-"713","Baroness Stern","hmp",19.0719061226577
-"714","Baroness Stern","conclusion",16.4447919437234
-"715","Baroness Stern","respect",12.8957207677207
-"716","Baroness Stern","response",12.2540866901423
-"717","Baroness Stern","prison",10.9046742608
-"718","Baroness Stern","young",10.8163542058159
-"719","Baroness Stern","light",10.8077460008117
-"720","Baroness Stern","finding",10.5654003835787
-"721","Baroness Taylor of Bolton","category",3.06425253703117
-"722","Baroness Taylor of Bolton","held",2.90601570463354
-"723","Baroness Taylor of Bolton","currently",2.74505165718986
-"724","Baroness Taylor of Bolton","prisoners",0.894159526383379
-"725","Baroness Taylor of Bolton","convict",0
-"726","Baroness Taylor of Bolton","five",0
-"727","Baroness Taylor of Bolton","person",0
-"728","Baroness Taylor of Bolton","rape",0
-"729","Baroness Taylor of Bolton","year",0
-"730","Baroness Taylor of Bolton","offenc",0
-"731","Baroness Taylor of Bolton","sexual",0
-"732","Baroness Taylor of Bolton","agreement",0
-"733","Baroness Thomas of Winchester","relevance",3.96546951770599
-"734","Baroness Thomas of Winchester","disabl",3.46281379188025
-"735","Baroness Thomas of Winchester","transforming",3.43069218890072
-"736","Baroness Thomas of Winchester","referenced",3.21410638215638
-"737","Baroness Thomas of Winchester","independence",2.96486165378729
-"738","Baroness Thomas of Winchester","hl2078",2.94946629760185
-"739","Baroness Thomas of Winchester","cross",2.71410638215638
-"740","Baroness Thomas of Winchester","system",2.68426676117044
-"741","Baroness Thomas of Winchester","payment",2.67895165812421
-"742","Baroness Thomas of Winchester","consultation",2.65332514880032
-"743","Baroness Thomas of Winchester","appeals",2.59259596105094
-"744","Baroness Thomas of Winchester","website",2.31786575697609
-"745","Baroness Thornton","conducted",4.28106789775998
-"746","Baroness Thornton","celebrant",3.56434957305558
-"747","Baroness Thornton","humanist",3.24812180703875
-"748","Baroness Thornton","workplace",3.06314042223207
-"749","Baroness Thornton","recognition",2.77298948091366
-"750","Baroness Thornton","marriages",2.57914917251452
-"751","Baroness Thornton","harassment",2.51386367274078
-"752","Baroness Thornton","enable",2.38261729153062
-"753","Baroness Thornton","concerning",2.34962314268375
-"754","Baroness Thornton","intend",2.30904350017104
-"755","Baroness Thornton","brought",2.21310248042081
-"756","Baroness Thornton","monitoring",2.12730924814564
-"757","Baroness Tonge","girls",3.04104746457308
-"758","Baroness Tonge","genital",2.64310543618979
-"759","Baroness Tonge","mutilation",2.64310543618979
-"760","Baroness Tonge","contain",2.37076455926199
-"761","Baroness Tonge","origin",2.25513921852908
-"762","Baroness Tonge","country",1.83729380353144
-"763","Baroness Tonge","female",1.72448246124158
-"764","Baroness Tonge","current",1.58485631321799
-"765","Baroness Tonge","protection",1.50473915547755
-"766","Baroness Tonge","orders",1.4185239260341
-"767","Baroness Tonge","information",1.41515167938967
-"768","Baroness Tonge","nationality",1.37211267113032
-"769","Baroness Uddin","spectrum",3.57484680302201
-"770","Baroness Uddin","autism",3.27333545844424
-"771","Baroness Uddin","disorder",2.61907845362646
-"772","Baroness Uddin","system",1.68817338102719
-"773","Baroness Uddin","justice",1.68533956695525
-"774","Baroness Uddin","currently",1.65532843218946
-"775","Baroness Uddin","training",1.49053224433803
-"776","Baroness Uddin","provide",1.43789635211168
-"777","Baroness Uddin","criminal",1.3551372370972
-"778","Baroness Uddin","staff",1.24172420135705
-"779","Baroness Uddin","people",1.05033300077928
-"780","Baroness Uddin","convict",0
-"781","Baroness Wheatcroft","women",8.32567242029279
-"782","Baroness Wheatcroft","current",8.08039528400836
-"783","Baroness Wheatcroft","proportion",5.81739787143962
-"784","Baroness Wheatcroft","jailed",5.71299783758061
-"785","Baroness Wheatcroft","woman",3.56434957305558
-"786","Baroness Wheatcroft","crime",3.53137225309141
-"787","Baroness Wheatcroft","children",3.51836401557083
-"788","Baroness Wheatcroft","prison",3.19758406426661
-"789","Baroness Wheatcroft","addiction",3.12614137666199
-"790","Baroness Wheatcroft","combined",3.06314042223207
-"791","Baroness Wheatcroft","keeping",3.0150728235643
-"792","Baroness Wheatcroft","violent",2.93639188796211
-"793","Baroness Whitaker","romany",5.27732913387793
-"794","Baroness Whitaker","gypsies",4.31248644372485
-"795","Baroness Whitaker","traveller",3.5988744333825
-"796","Baroness Whitaker","recommendations",3.43477364953329
-"797","Baroness Whitaker","inspectorate",3.35975679738186
-"798","Baroness Whitaker","humanist",3.24812180703875
-"799","Baroness Whitaker","response",2.74593816431707
-"800","Baroness Whitaker","marriages",2.57914917251452
-"801","Baroness Whitaker","now",2.57914917251452
-"802","Baroness Whitaker","report",2.15120063824805
-"803","Baroness Whitaker","closed",2.0387313466157
-"804","Baroness Whitaker","allow",1.94232786333897
-"805","Baroness Young of Hornsey","ago",3.42265523528935
-"806","Baroness Young of Hornsey","ten",3.13398010069454
-"807","Baroness Young of Hornsey","race",2.75237232997826
-"808","Baroness Young of Hornsey","senior",2.40549051337143
-"809","Baroness Young of Hornsey","posts",1.93605129243709
-"810","Baroness Young of Hornsey","level",1.6938708772895
-"811","Baroness Young of Hornsey","currently",1.58485631321799
-"812","Baroness Young of Hornsey","relations",1.29871292006789
-"813","Baroness Young of Hornsey","numbers",1.20781681702708
-"814","Baroness Young of Hornsey","five",1.07593336621344
-"815","Baroness Young of Hornsey","years",0.540401892843998
-"816","Baroness Young of Hornsey","prisons",0.516243243255912
-"817","Bayley, Sir Hugh","york",13.0371547541972
-"818","Bayley, Sir Hugh","1995",5.96279136138744
-"819","Bayley, Sir Hugh","crown",5.08727107884578
-"820","Bayley, Sir Hugh","cathedral",4.54543283655548
-"821","Bayley, Sir Hugh","reburial",4.54543283655548
-"822","Bayley, Sir Hugh","2004",4.53451374718337
-"823","Bayley, Sir Hugh","magristrates",4.28547517620851
-"824","Bayley, Sir Hugh","king",4.1918794459622
-"825","Bayley, Sir Hugh","richard",3.98506397046232
-"826","Bayley, Sir Hugh","magistrages",3.87635814759977
-"827","Bayley, Sir Hugh","leicester",3.83832605536893
-"828","Bayley, Sir Hugh","witness",3.62769813125812
-"829","Bebb, Guto","violent",2.07634261619918
-"830","Bebb, Guto","murdered",1.95149793852278
-"831","Bebb, Guto","subject",1.87041297747788
-"832","Bebb, Guto","assaulted",1.7322232976726
-"833","Bebb, Guto","licence",1.55333073247474
-"834","Bebb, Guto","committed",1.49893414480089
-"835","Bebb, Guto","crime",1.44022271990776
-"836","Bebb, Guto","released",1.31486854114797
-"837","Bebb, Guto","england",1.08648714188543
-"838","Bebb, Guto","wales",1.08044214622602
-"839","Bebb, Guto","five",0.99612073645634
-"840","Bebb, Guto","people",0.931020697091796
-"841","Beckett, Margaret","eastern",3.87635814759977
-"842","Beckett, Margaret","europe",2.83330026878961
-"843","Beckett, Margaret","care",2.02213962478468
-"844","Beckett, Margaret","countries",1.91899079172409
-"845","Beckett, Margaret","proceedings",1.86883185095217
-"846","Beckett, Margaret","involving",1.8560995589208
-"847","Beckett, Margaret","families",1.54835914959439
-"848","Beckett, Margaret","children",1.46426739097766
-"849","Beckett, Margaret","estimate",1.4100227593455
-"850","Beckett, Margaret","number",1.26152352199167
-"851","Beckett, Margaret","will",0.813041680110636
-"852","Beckett, Margaret","convict",0
-"853","Beith, Sir Alan","archives",8.97425786613916
-"854","Beith, Sir Alan","targets",7.18817073082264
-"855","Beith, Sir Alan","meet",5.48523435018643
-"856","Beith, Sir Alan","records",5.34581310112626
-"857","Beith, Sir Alan","departments",4.55589571969595
-"858","Beith, Sir Alan","national",4.24475906723051
-"859","Beith, Sir Alan","clearing",3.61880850954184
-"860","Beith, Sir Alan","release",2.75365546461672
-"861","Beith, Sir Alan","encourage",2.69838631099963
-"862","Beith, Sir Alan","obligations",2.57324779654187
-"863","Beith, Sir Alan","material",2.33645998385951
-"864","Beith, Sir Alan","engaged",2.12047628526286
-"865","Bellingham, Sir Henry","beachy",6.91809396928489
-"866","Bellingham, Sir Henry","head",5.86352223883743
-"867","Bellingham, Sir Henry","northmoor",3.21410638215638
-"868","Bellingham, Sir Henry","paid",3.14729788248713
-"869","Bellingham, Sir Henry","iraq",2.71410638215638
-"870","Bellingham, Sir Henry","leigh",2.71410638215638
-"871","Bellingham, Sir Henry","verdicts",2.68572709037698
-"872","Bellingham, Sir Henry","died",2.65536262541257
-"873","Bellingham, Sir Henry","historic",2.56786575697609
-"874","Bellingham, Sir Henry","detailed",2.41846584846456
-"875","Bellingham, Sir Henry","related",2.32709290623502
-"876","Bellingham, Sir Henry","inquests",2.19490148079316
-"877","Benn, Hilary","contesting",21.0426400661948
-"878","Benn, Hilary","levied",20.8412623786122
-"879","Benn, Hilary","notice",20.0981431556632
-"880","Benn, Hilary","fixed",19.6448711179794
-"881","Benn, Hilary","local",18.7119406571172
-"882","Benn, Hilary","consequent",18.6913849201242
-"883","Benn, Hilary","authorities",18.073354555465
-"884","Benn, Hilary","penalty",17.3356340731073
-"885","Benn, Hilary","upon",16.8914174082424
-"886","Benn, Hilary","guilty",16.4551287238767
-"887","Benn, Hilary","area",15.6825204393465
-"888","Benn, Hilary","found",15.1586232624822
-"889","Benton, Joe","shared",10.1914359958947
-"890","Benton, Joe","privatisation",5.45436059540865
-"891","Benton, Joe","services",4.47437049428268
-"892","Benton, Joe","bootle",4.28547517620851
-"893","Benton, Joe","robust",4.0655587238791
-"894","Benton, Joe","shored",3.56434957305558
-"895","Benton, Joe","steria",3.43310319184542
-"896","Benton, Joe","commercial",2.72224609610137
-"897","Benton, Joe","jobs",2.66614817783265
-"898","Benton, Joe","union",2.59704245528317
-"899","Benton, Joe","bid",2.4306848901984
-"900","Benton, Joe","house",2.3603582316201
-"901","Benyon, Richard","upheld",5.45679489153083
-"902","Benyon, Richard","advisory",5.0249057998964
-"903","Benyon, Richard","complaints",4.82324353165127
-"904","Benyon, Richard","family",3.09671829918877
-"905","Benyon, Richard","support",2.98831434599134
-"906","Benyon, Richard","children",2.92853478195532
-"907","Benyon, Richard","three",2.66142980394467
-"908","Benyon, Richard","service",2.10461148606787
-"909","Benyon, Richard","made",1.72589440933412
-"910","Benyon, Richard","court",1.71740675329739
-"911","Benyon, Richard","years",1.12886273736366
-"912","Benyon, Richard","convict",0
-"913","Berger, Luciana","health",30.9110698986386
-"914","Berger, Luciana","mental",30.2156725114019
-"915","Berger, Luciana","2010",28.2972756186629
-"916","Berger, Luciana","prison",25.0375804490613
-"917","Berger, Luciana","self",24.5492366707352
-"918","Berger, Luciana","year",20.7304385610648
-"919","Berger, Luciana","harm",19.0113170518428
-"920","Berger, Luciana","death",17.258932594008
-"921","Berger, Luciana","suicide",16.699586561703
-"922","Berger, Luciana","bill",16.2904025805833
-"923","Berger, Luciana","inflicted",14.4291129339406
-"924","Berger, Luciana","include",13.8098012298951
-"925","Berry, Jake","grandchildren",15.5088809566374
-"926","Berry, Jake","grandparents",15.1469266297984
-"927","Berry, Jake","gap",11.8892517275204
-"928","Berry, Jake","see",10.2320783611728
-"929","Berry, Jake","applications",8.80125006000612
-"930","Berry, Jake","contact",7.31820085760917
-"931","Berry, Jake","order",6.25444484818896
-"932","Berry, Jake","employee",5.53941275840237
-"933","Berry, Jake","percentage",5.52879973959939
-"934","Berry, Jake","earnings",5.39647439313095
-"935","Berry, Jake","final",5.36689246418323
-"936","Berry, Jake","permission",5.34062553857743
-"937","Berry, James","occurrence",3.42265523528935
-"938","Berry, James","dropped",3.04104746457308
-"939","Berry, James","delayed",2.48505932319183
-"940","Berry, James","caused",2.06575516700017
-"941","Berry, James","london",2.01315759583639
-"942","Berry, James","two",1.91322529603858
-"943","Berry, James","crown",1.64445354805812
-"944","Berry, James","data",1.59767179159901
-"945","Berry, James","magistrates",1.33310777291295
-"946","Berry, James","cases",1.14100107964996
-"947","Berry, James","courts",0.822145890325361
-"948","Berry, James","years",0.540401892843998
-"949","Bingham, Andrew","drake",7.53644634553629
-"950","Bingham, Andrew","books",7.08199798964202
-"951","Bingham, Andrew","manchester",5.4127040229326
-"952","Bingham, Andrew","delivered",5.27016566415286
-"953","Bingham, Andrew","contain",5.19408491056634
-"954","Bingham, Andrew","packages",5.15829834502905
-"955","Bingham, Andrew","library",4.79976722982164
-"956","Bingham, Andrew","users",4.49124084452485
-"957","Bingham, Andrew","judiciary",4.37414155051009
-"958","Bingham, Andrew","found",4.0774626932314
-"959","Bingham, Andrew","identify",3.99318480861032
-"960","Bingham, Andrew","access",3.93667588382649
-"961","Blackford, Ian","devolved",3.81674328312721
-"962","Blackford, Ian","administrations",3.53398434115333
-"963","Blackford, Ian","policies",3.25189712525413
-"964","Blackford, Ian","discuss",3.14102057054366
-"965","Blackford, Ian","leaving",3.08677074565337
-"966","Blackford, Ian","convict",0
-"967","Blackford, Ian","five",0
-"968","Blackford, Ian","person",0
-"969","Blackford, Ian","rape",0
-"970","Blackford, Ian","year",0
-"971","Blackford, Ian","offenc",0
-"972","Blackford, Ian","sexual",0
-"973","Blackman-Woods, Dr Roberta","organ",5.99502952955874
-"974","Blackman-Woods, Dr Roberta","durham",5.88983196468393
-"975","Blackman-Woods, Dr Roberta","donors",5.6992517289863
-"976","Blackman-Woods, Dr Roberta","staffing",3.99922226674898
-"977","Blackman-Woods, Dr Roberta","donation",3.87635814759977
-"978","Blackman-Woods, Dr Roberta","frankland",3.398473972902
-"979","Blackman-Woods, Dr Roberta","newton",3.398473972902
-"980","Blackman-Woods, Dr Roberta","register",3.38093196917507
-"981","Blackman-Woods, Dr Roberta","prison",3.31338025556582
-"982","Blackman-Woods, Dr Roberta","occupation",3.02990879034318
-"983","Blackman-Woods, Dr Roberta","record",3.02676478921064
-"984","Blackman-Woods, Dr Roberta","contraband",3.0150728235643
-"985","Blackman, Bob","sex",2.61766408736122
-"986","Blackman, Bob","light",2.56650589561098
-"987","Blackman, Bob","abuse",2.2625183190908
-"988","Blackman, Bob","supporting",1.87302514031479
-"989","Blackman, Bob","victims",1.67603082871324
-"990","Blackman, Bob","cases",1.49392109014922
-"991","Blackman, Bob","2014",1.35322662730182
-"992","Blackman, Bob","convict",0
-"993","Blackman, Bob","five",0
-"994","Blackman, Bob","person",0
-"995","Blackman, Bob","rape",0
-"996","Blackman, Bob","year",0
-"997","Blackman, Kirsty","scotland",15.3882107340866
-"998","Blackman, Kirsty","24107",11.2140153591914
-"999","Blackman, Kirsty","breach",10.3544129883203
-"1000","Blackman, Kirsty","tribunal",10.257975895473
-"1001","Blackman, Kirsty","devolved",9.51224252378059
-"1002","Blackman, Kirsty","data",8.91213674533955
-"1003","Blackman, Kirsty","whose",8.81560740711276
-"1004","Blackman, Kirsty","waiting",7.57242385821303
-"1005","Blackman, Kirsty","february",6.09663732618779
-"1006","Blackman, Kirsty","non",6.0805545883565
-"1007","Blackman, Kirsty","service",5.0523929203284
-"1008","Blackman, Kirsty","appeal",4.70367643537603
-"1009","Blackwood, Nicola","modernise",5.26724871686908
-"1010","Blackwood, Nicola","2020",2.87475914111963
-"1011","Blackwood, Nicola","system",2.79951884296644
-"1012","Blackwood, Nicola","expenditure",2.45912224807632
-"1013","Blackwood, Nicola","research",2.39687496642186
-"1014","Blackwood, Nicola","development",2.19242859459094
-"1015","Blackwood, Nicola","spending",2.10267453211564
-"1016","Blackwood, Nicola","tribunals",2.06766316995917
-"1017","Blackwood, Nicola","allocated",2.05390474951407
-"1018","Blackwood, Nicola","funding",1.60556119691145
-"1019","Blackwood, Nicola","departments",1.53817158977317
-"1020","Blackwood, Nicola","courts",1.42399845327747
-"1021","Blenkinsop, Tom","illegal",4.9876099342528
-"1022","Blenkinsop, Tom","gender",4.87795218983675
-"1023","Blenkinsop, Tom","ethnic",4.62078488123567
-"1024","Blenkinsop, Tom","high",4.59736466125669
-"1025","Blenkinsop, Tom","made",3.95987599066207
-"1026","Blenkinsop, Tom","border",3.87635814759977
-"1027","Blenkinsop, Tom","availability",3.84983734922377
-"1028","Blenkinsop, Tom","drugs",3.8484345715412
-"1029","Blenkinsop, Tom","teesside",3.75715434263479
-"1030","Blenkinsop, Tom","safety",3.73205405292339
-"1031","Blenkinsop, Tom","movement",3.398473972902
-"1032","Blenkinsop, Tom","staff",3.30089083585957
-"1033","Blomfield, Paul","traffickers",22.3262759383296
-"1034","Blomfield, Paul","tribunal",21.1121874140795
-"1035","Blomfield, Paul","tier",16.5799689019821
-"1036","Blomfield, Paul","fee",14.1435460179117
-"1037","Blomfield, Paul","chamber",13.928982377861
-"1038","Blomfield, Paul","damages",13.5517667606982
-"1039","Blomfield, Paul","awarded",13.3090020289332
-"1040","Blomfield, Paul","brought",12.5958207734721
-"1041","Blomfield, Paul","slavery",12.546503851481
-"1042","Blomfield, Paul","tort",12.2898452765362
-"1043","Blomfield, Paul","victims",11.5917083345421
-"1044","Blomfield, Paul","first",11.539126806482
-"1045","Blunkett, David","books",7.19344502659529
-"1046","Blunkett, David","withheld",4.85927209970932
-"1047","Blunkett, David","withhold",4.85927209970932
-"1048","Blunkett, David","first",3.9198706386331
-"1049","Blunkett, David","arrive",3.72537868068164
-"1050","Blunkett, David","borrowed",3.57484680302201
-"1051","Blunkett, David","reasons",3.3994743918576
-"1052","Blunkett, David","brixton",2.79545128374647
-"1053","Blunkett, David","belmarsh",2.47618282379502
-"1054","Blunkett, David","restrictions",2.41162176582563
-"1055","Blunkett, David","yet",2.23738373325425
-"1056","Blunkett, David","population",2.19242859459094
-"1057","Blunt, Crispin","1617",3.21410638215638
-"1058","Blunt, Crispin","102",2.81786575697609
-"1059","Blunt, Crispin","states",2.11602702646169
-"1060","Blunt, Crispin","directive",2.11602702646169
-"1061","Blunt, Crispin","oral",1.96410638215638
-"1062","Blunt, Crispin","agreement",1.65690170953241
-"1063","Blunt, Crispin","transfer",1.50273386942029
-"1064","Blunt, Crispin","june",1.49344561981592
-"1065","Blunt, Crispin","member",1.30676722713648
-"1066","Blunt, Crispin","official",1.29248125036058
-"1067","Blunt, Crispin","2016",1.1171020608201
-"1068","Blunt, Crispin","report",1.07354577610111
-"1069","Bone, Peter","wellingborough",21.3325576492367
-"1070","Bone, Peter","open",10.6292516600387
-"1071","Bone, Peter","new",7.60021064150482
-"1072","Bone, Peter","hmp",7.46108313342997
-"1073","Bone, Peter","site",6.46227261630916
-"1074","Bone, Peter","prison",6.41660861946399
-"1075","Bone, Peter","completed",5.36890327360954
-"1076","Bone, Peter","will",5.18274828435496
-"1077","Bone, Peter","victorian",4.85927209970932
-"1078","Bone, Peter","encroaching",4.54543283655548
-"1079","Bone, Peter","investment",4.47476746650851
-"1080","Bone, Peter","build",4.19204332059297
-"1081","Boswell, Phil","reconsideration",2.84879127854937
-"1082","Boswell, Phil","accepted",2.53941356285557
-"1083","Boswell, Phil","stage",2.38756776911296
-"1084","Boswell, Phil","mandatory",2.14312373374476
-"1085","Boswell, Phil","april",1.69974148357484
-"1086","Boswell, Phil","october",1.67062816592052
-"1087","Boswell, Phil","independence",1.61807647981551
-"1088","Boswell, Phil","decisions",1.59709098712623
-"1089","Boswell, Phil","payment",1.4620407879863
-"1090","Boswell, Phil","appealed",1.41491207216449
-"1091","Boswell, Phil","personal",1.24170946951188
-"1092","Boswell, Phil","2016",1.23931346468103
-"1093","Bottomley, Sir Peter","mire",16.5902100055016
-"1094","Bottomley, Sir Peter","benjamin",15.5223512514028
-"1095","Bottomley, Sir Peter","judicial",11.2695748552856
-"1096","Bottomley, Sir Peter","investigation",8.26688337091185
-"1097","Bottomley, Sir Peter","conduct",8.26688337091185
-"1098","Bottomley, Sir Peter","office",5.49982051088861
-"1099","Bottomley, Sir Peter","property",4.76941723791318
-"1100","Bottomley, Sir Peter","appointment",4.11142465389102
-"1101","Bottomley, Sir Peter","shown",3.98506397046232
-"1102","Bottomley, Sir Peter","report",3.88651369416376
-"1103","Bottomley, Sir Peter","councillor",3.87635814759977
-"1104","Bottomley, Sir Peter","gurpai",3.87635814759977
-"1105","Brabin, Tracy","code",5.29947484838107
-"1106","Brabin, Tracy","seconded",4.34325026359161
-"1107","Brabin, Tracy","exit",3.63151057986905
-"1108","Brabin, Tracy","crime",3.59240083594441
-"1109","Brabin, Tracy","takes",3.55172985105962
-"1110","Brabin, Tracy","organisations",3.30424900759097
-"1111","Brabin, Tracy","trade",3.13121927418238
-"1112","Brabin, Tracy","victims",2.95612051865623
-"1113","Brabin, Tracy","aware",2.95267033473516
-"1114","Brabin, Tracy","existence",2.93639188796211
-"1115","Brabin, Tracy","union",2.90358173523306
-"1116","Brabin, Tracy","committee",2.58158911469325
-"1117","Bradshaw, Ben","mediation",49.8582967313865
-"1118","Bradshaw, Ben","families",23.3006145453217
-"1119","Bradshaw, Ben","television",12.2243116731461
-"1120","Bradshaw, Ben","inform",12.1469948473432
-"1121","Bradshaw, Ben","221",11.1234574364979
-"1122","Bradshaw, Ben","4460",11.1234574364979
-"1123","Bradshaw, Ben","service",10.5028660965404
-"1124","Bradshaw, Ben","profit",10.0362574393813
-"1125","Bradshaw, Ben","devon",9.9797741087339
-"1126","Bradshaw, Ben","england",9.69125035800428
-"1127","Bradshaw, Ben","wales",9.63733019264764
-"1128","Bradshaw, Ben","curfew",9.2376127291468
-"1129","Brady, Graham","212354",6.23007891928364
-"1130","Brady, Graham","open",5.2285417591658
-"1131","Brady, Graham","serving",3.11824024378291
-"1132","Brady, Graham","offence",3.11743173065374
-"1133","Brady, Graham","broken",2.73752311295027
-"1134","Brady, Graham","robbery",2.51145226262694
-"1135","Brady, Graham","specific",2.39186382073675
-"1136","Brady, Graham","indeterminate",2.18542331562958
-"1137","Brady, Graham","serious",2.17219184191364
-"1138","Brady, Graham","imprisoned",2.14338692464114
-"1139","Brady, Graham","sentenced",2.06580258411467
-"1140","Brady, Graham","answer",2.06434766755989
-"1141","Brake, Tom","referendum",7.14788187823327
-"1142","Brake, Tom","outcome",5.30920372199253
-"1143","Brake, Tom","pool",5.30235469043411
-"1144","Brake, Tom","redeployment",4.85514109493415
-"1145","Brake, Tom","states",4.55940457314206
-"1146","Brake, Tom","civil",4.35198047281962
-"1147","Brake, Tom","exceeded",3.83630669925203
-"1148","Brake, Tom","legislation",3.83177851508317
-"1149","Brake, Tom","servants",3.81674328312721
-"1150","Brake, Tom","potential",3.62270361378746
-"1151","Brake, Tom","pan",3.21410638215638
-"1152","Brake, Tom","departments",3.17319985191685
-"1153","Brennan, Kevin","blind",8.5936040377554
-"1154","Brennan, Kevin","guide",7.66162595986859
-"1155","Brennan, Kevin","taxi",7.06876134138484
-"1156","Brennan, Kevin","licensed",6.98071904559484
-"1157","Brennan, Kevin","dogs",6.3531530792417
-"1158","Brennan, Kevin","occupancy",4.49408099739619
-"1159","Brennan, Kevin","readmission",4.0655587238791
-"1160","Brennan, Kevin","guitars",3.87635814759977
-"1161","Brennan, Kevin","strung",3.87635814759977
-"1162","Brennan, Kevin","equality",3.48475195106254
-"1163","Brennan, Kevin","steel",3.398473972902
-"1164","Brennan, Kevin","partially",3.33130058958113
-"1165","Bridgen, Andrew","gastric",6.13286939357901
-"1166","Bridgen, Andrew","holiday",5.83029096398379
-"1167","Bridgen, Andrew","customers",4.4145647416738
-"1168","Bridgen, Andrew","illegitimate",4.31026736023359
-"1169","Bridgen, Andrew","package",4.21877534935129
-"1170","Bridgen, Andrew","declined",3.42382100930146
-"1171","Bridgen, Andrew","illegitimate",3.16876301142263
-"1172","Bridgen, Andrew","molestation",3.09048767596813
-"1173","Bridgen, Andrew","non",2.83158484067264
-"1174","Bridgen, Andrew","claims",2.5664473945705
-"1175","Bridgen, Andrew","handling",2.51145226262694
-"1176","Bridgen, Andrew","fraudulent",2.47790272318285
-"1177","Brock, Deidre","media",5.88347350699198
-"1178","Brock, Deidre","leaves",4.62298306897999
-"1179","Brock, Deidre","portfolio",4.0655587238791
-"1180","Brock, Deidre","schengen",4.0655587238791
-"1181","Brock, Deidre","advertising",3.46063735173971
-"1182","Brock, Deidre","partners",3.24812180703875
-"1183","Brock, Deidre","matters",3.07114171377589
-"1184","Brock, Deidre","month",2.87552404902184
-"1185","Brock, Deidre","international",2.81058502920784
-"1186","Brock, Deidre","engagements",2.73752311295027
-"1187","Brock, Deidre","departmental",2.66614817783265
-"1188","Brock, Deidre","continue",2.63508283207643
-"1189","Brooke, Annette","guidelines",3.10615630769572
-"1190","Brooke, Annette","violence",2.37275188695556
-"1191","Brooke, Annette","domestic",2.35516915487073
-"1192","Brooke, Annette","review",1.80689590148317
-"1193","Brooke, Annette","sentencing",1.42572177895689
-"1194","Brooke, Annette","will",1.10086363896476
-"1195","Brooke, Annette","convict",0
-"1196","Brooke, Annette","five",0
-"1197","Brooke, Annette","person",0
-"1198","Brooke, Annette","rape",0
-"1199","Brooke, Annette","year",0
-"1200","Brooke, Annette","offenc",0
-"1201","Brown, Lyn","red",4.28547517620851
-"1202","Brown, Lyn","box",3.75715434263479
-"1203","Brown, Lyn","gateway",3.61880850954184
-"1204","Brown, Lyn","ict",3.61880850954184
-"1205","Brown, Lyn","journeys",3.28547517620851
-"1206","Brown, Lyn","transportation",2.89550017572774
-"1207","Brown, Lyn","car",2.84483247791272
-"1208","Brown, Lyn","ministers",2.32459415975456
-"1209","Brown, Lyn","progress",2.09552330676486
-"1210","Brown, Lyn","made",1.90804806117778
-"1211","Brown, Lyn","management",1.86634589531096
-"1212","Brown, Lyn","system",1.86634589531096
-"1213","Brown, Nicholas","subscriptions",7.1579362566573
-"1214","Brown, Nicholas","organisations",7.03706702141458
-"1215","Brown, Nicholas","rehabilitation",6.65887487046704
-"1216","Brown, Nicholas","probation",5.17644270875136
-"1217","Brown, Nicholas","transforming",4.86231930921982
-"1218","Brown, Nicholas","publish",4.38691593920083
-"1219","Brown, Nicholas","agencies",4.24913837306788
-"1220","Brown, Nicholas","rights",4.24292663794087
-"1221","Brown, Nicholas","report",4.08407921977999
-"1222","Brown, Nicholas","northumbria",3.83832605536893
-"1223","Brown, Nicholas","implement",3.82009877522051
-"1224","Brown, Nicholas","classified",3.72450728589427
-"1225","Bruce, Fiona","abortions",13.5194772043894
-"1226","Bruce, Fiona","1986",12.4733259387359
-"1227","Bruce, Fiona","1861",9.16946197089928
-"1228","Bruce, Fiona","act",8.1672187698088
-"1229","Bruce, Fiona","section",7.81700567341495
-"1230","Bruce, Fiona","performing",7.36899294803125
-"1231","Bruce, Fiona","vulnerable",6.2987513618085
-"1232","Bruce, Fiona","offence",6.16702753806337
-"1233","Bruce, Fiona","people",6.00325632892314
-"1234","Bruce, Fiona","1929",5.93692148414294
-"1235","Bruce, Fiona","miscarriage",5.7461565375544
-"1236","Bruce, Fiona","recorded",5.65733995320207
-"1237","Bryant, Chris","waive",4.26021258338486
-"1238","Bryant, Chris","universal",2.51226765164198
-"1239","Bryant, Chris","local",2.29615904930097
-"1240","Bryant, Chris","fully",2.23738373325425
-"1241","Bryant, Chris","authorities",2.21779757504583
-"1242","Bryant, Chris","rolled",2.1922406718438
-"1243","Bryant, Chris","age",2.18854142260176
-"1244","Bryant, Chris","extending",2.03899645262111
-"1245","Bryant, Chris","credit",1.98738373325425
-"1246","Bryant, Chris","remission",1.98738373325425
-"1247","Bryant, Chris","fees",1.98677504739601
-"1248","Bryant, Chris","claimants",1.90212450379549
-"1249","Buck, Karen","authorities",8.38261088438084
-"1250","Buck, Karen","judicial",7.83765945275594
-"1251","Buck, Karen","local",6.84709253542573
-"1252","Buck, Karen","2004",6.43057861385615
-"1253","Buck, Karen","review",4.84758772015571
-"1254","Buck, Karen","successful",4.79927877224229
-"1255","Buck, Karen","applications",4.57181672849752
-"1256","Buck, Karen","england",4.45251639714015
-"1257","Buck, Karen","five",4.08218720831479
-"1258","Buck, Karen","mortgage",3.95214184287518
-"1259","Buck, Karen","children",3.85477745610266
-"1260","Buck, Karen","landlord",3.42382100930146
-"1261","Buckland, Robert","injury",4.62474133398428
-"1262","Buckland, Robert","fraud",4.09423371253565
-"1263","Buckland, Robert","12th",3.71133036988416
-"1264","Buckland, Robert","personal",3.68549456094398
-"1265","Buckland, Robert","genuine",3.16876301142263
-"1266","Buckland, Robert","elements",3.0124252070077
-"1267","Buckland, Robert","discourage",2.81546286706411
-"1268","Buckland, Robert","adopt",2.75237232997826
-"1269","Buckland, Robert","exaggerating",2.68572709037698
-"1270","Buckland, Robert","treated",2.68572709037698
-"1271","Buckland, Robert","proposal",2.66312222609193
-"1272","Buckland, Robert","fabricating",2.54820162515169
-"1273","Burden, Richard","week",12.8998432553751
-"1274","Burden, Richard","hours",12.6967321740662
-"1275","Burden, Richard","per",12.4374205404108
-"1276","Burden, Richard","unemployed",11.382036212322
-"1277","Burden, Richard","classed",10.5483799831236
-"1278","Burden, Richard","proportion",10.2617087597553
-"1279","Burden, Richard","work",9.71821984016902
-"1280","Burden, Richard","antisemitism",9.50600314642163
-"1281","Burden, Richard","cells",9.33942441116939
-"1282","Burden, Richard","spent",9.02325368125415
-"1283","Burden, Richard","drone",7.63423187131152
-"1284","Burden, Richard","data",7.2453165931031
-"1285","Burgon, Richard","prison",32.4643323206335
-"1286","Burgon, Richard","2010",24.294614074447
-"1287","Burgon, Richard","officer",21.2293760537854
-"1288","Burgon, Richard","2016",19.3559241788484
-"1289","Burgon, Richard","year",17.6589899767865
-"1290","Burgon, Richard","will",17.0093942793185
-"1291","Burgon, Richard","cell",16.7135972339824
-"1292","Burgon, Richard","service",15.7382060515413
-"1293","Burgon, Richard","bedford",14.7947367529322
-"1294","Burgon, Richard","establishment",14.5588176307019
-"1295","Burgon, Richard","month",14.4594603024692
-"1296","Burgon, Richard","incident",14.0434577247085
-"1297","Burley, Aidan","growth",5.63573151395219
-"1298","Burley, Aidan","culture",4.63573151395219
-"1299","Burley, Aidan","address",3.8844813436876
-"1300","Burley, Aidan","compensation",2.96878114567547
-"1301","Burley, Aidan","convict",0
-"1302","Burley, Aidan","five",0
-"1303","Burley, Aidan","person",0
-"1304","Burley, Aidan","rape",0
-"1305","Burley, Aidan","year",0
-"1306","Burley, Aidan","offenc",0
-"1307","Burley, Aidan","sexual",0
-"1308","Burley, Aidan","agreement",0
-"1309","Burnham, Andy","tenants",4.26021258338486
-"1310","Burnham, Andy","evicted",3.79819167604396
-"1311","Burnham, Andy","manchester",3.14952638886365
-"1312","Burnham, Andy","greater",3.12631916435718
-"1313","Burnham, Andy","2010",1.28782961157414
-"1314","Burnham, Andy","courts",1.07644164991795
-"1315","Burnham, Andy","year",0.707552165615724
-"1316","Burnham, Andy","convict",0
-"1317","Burnham, Andy","five",0
-"1318","Burnham, Andy","person",0
-"1319","Burnham, Andy","rape",0
-"1320","Burnham, Andy","offenc",0
-"1321","Burns, Sir Simon","chelmsford",3.60370129795068
-"1322","Burns, Sir Simon","wildlife",3.398473972902
-"1323","Burns, Sir Simon","00156",3.21410638215638
-"1324","Burns, Sir Simon","sc133/14/00156",3.21410638215638
-"1325","Burns, Sir Simon","ref",2.96410638215638
-"1326","Burns, Sir Simon","trade",2.67031276928871
-"1327","Burns, Sir Simon","inspectorate",2.53488617054572
-"1328","Burns, Sir Simon","illegal",2.36880142471095
-"1329","Burns, Sir Simon","hmp",2.28633378400705
-"1330","Burns, Sir Simon","concerning",2.24027776537461
-"1331","Burns, Sir Simon","ely",2.21410638215638
-"1332","Burns, Sir Simon","send",2.13362435843454
-"1333","Burrowes, David","141a",13.7909123584348
-"1334","Burrowes, David","sentence",10.6287299468013
-"1335","Burrowes, David","custodial",10.1470402533738
-"1336","Burrowes, David","knives",9.53923625106614
-"1337","Burrowes, David","criminal",9.42378900207783
-"1338","Burrowes, David","section",9.39935265499191
-"1339","Burrowes, David","implementation",8.45444366859758
-"1340","Burrowes, David","length",7.98764029360404
-"1341","Burrowes, David","1998",7.57983526879287
-"1342","Burrowes, David","convicted",7.39746170621584
-"1343","Burrowes, David","suppliers",7.36403905166654
-"1344","Burrowes, David","act",7.33879249487137
-"1345","Burstow, Paul","stigma",4.54543283655548
-"1346","Burstow, Paul","pledge",3.98506397046232
-"1347","Burstow, Paul","signing",2.81058502920784
-"1348","Burstow, Paul","discrimination",2.73195743460209
-"1349","Burstow, Paul","mental",2.24457997622849
-"1350","Burstow, Paul","health",2.18139790396614
-"1351","Burstow, Paul","result",1.95040398158957
-"1352","Burstow, Paul","time",1.58134575821989
-"1353","Burstow, Paul","convict",0
-"1354","Burstow, Paul","five",0
-"1355","Burstow, Paul","person",0
-"1356","Burstow, Paul","rape",0
-"1357","Butler, Dawn","equal",11.3141222807118
-"1358","Butler, Dawn","tribunal",10.0902200574146
-"1359","Butler, Dawn","pay",8.98440365525128
-"1360","Butler, Dawn","fees",8.8835366775969
-"1361","Butler, Dawn","employers",8.28082518922751
-"1362","Butler, Dawn","men",7.26317703153937
-"1363","Butler, Dawn","answer",6.85868601091917
-"1364","Butler, Dawn","2016",6.68390543352986
-"1365","Butler, Dawn","women",6.03138731006016
-"1366","Butler, Dawn","51088",6.02542229001739
-"1367","Butler, Dawn","33501",5.92821276431277
-"1368","Butler, Dawn","brought",5.71232474716979
-"1369","Byles, Dan","faulty",2.4722356219127
-"1370","Byles, Dan","incorrectly",2.4722356219127
-"1371","Byles, Dan","contributory",2.4722356219127
-"1372","Byles, Dan","seat",2.4722356219127
-"1373","Byles, Dan","passenger",2.35026250882946
-"1374","Byles, Dan","factor",2.14174809477239
-"1375","Byles, Dan","fitted",1.9880801457246
-"1376","Byles, Dan","accident",1.82845511664639
-"1377","Byles, Dan","traffic",1.82845511664639
-"1378","Byles, Dan","car",1.77956573166752
-"1379","Byles, Dan","inquest",1.71243908359357
-"1380","Byles, Dan","road",1.65759261858429
-"1381","Byrne, Liam","birmingham",17.9257052733577
-"1382","Byrne, Liam","human",12.0014231934519
-"1383","Byrne, Liam","rights",10.5698989835732
-"1384","Byrne, Liam","hodge",9.04884582330077
-"1385","Byrne, Liam","european",8.6134533025368
-"1386","Byrne, Liam","mortem",8.29227267344015
-"1387","Byrne, Liam","hill",7.7764217139165
-"1388","Byrne, Liam","signatory",7.63199115780069
-"1389","Byrne, Liam","convention",7.27847834579525
-"1390","Byrne, Liam","city",6.27157873066135
-"1391","Byrne, Liam","midlands",6.1708012543721
-"1392","Byrne, Liam","post",5.5342039357506
-"1393","Cadbury, Ruth","hardship",6.40731555913878
-"1394","Cadbury, Ruth","avoidable",6.07871195836422
-"1395","Cadbury, Ruth","exceptional",4.84694738305701
-"1396","Cadbury, Ruth","legislation",4.60700791659635
-"1397","Cadbury, Ruth","enterprise",4.47476746650851
-"1398","Cadbury, Ruth","joint",4.34325026359161
-"1399","Cadbury, Ruth","unsafe",3.74933095786226
-"1400","Cadbury, Ruth","within",3.61696083225212
-"1401","Cadbury, Ruth","review",3.54746755182806
-"1402","Cadbury, Ruth","forthcoming",3.27333545844424
-"1403","Cadbury, Ruth","disqualification",3.13398010069454
-"1404","Cadbury, Ruth","pleading",2.79545128374647
-"1405","Cameron, Dr Lisa","childhood",6.26796020138908
-"1406","Cameron, Dr Lisa","complainants",4.9273943907669
-"1407","Cameron, Dr Lisa","agreed",4.9273943907669
-"1408","Cameron, Dr Lisa","special",4.37113234593276
-"1409","Cameron, Dr Lisa","measures",4.13151033400033
-"1410","Cameron, Dr Lisa","applied",3.84896386446239
-"1411","Cameron, Dr Lisa","military",3.57484680302201
-"1412","Cameron, Dr Lisa","abuse",3.45605381948594
-"1413","Cameron, Dr Lisa","domestic",3.33071216050097
-"1414","Cameron, Dr Lisa","dependencies",3.28318859405118
-"1415","Cameron, Dr Lisa","five",3.27564248255662
-"1416","Cameron, Dr Lisa","combat",3.27333545844424
-"1417","Campbell, Gregory","campaign",8.92794129211439
-"1418","Campbell, Gregory","reoffending",7.24309660468607
-"1419","Campbell, Gregory","nspccs",6.5767615672584
-"1420","Campbell, Gregory","rate",6.46788357996815
-"1421","Campbell, Gregory","population",6.2446849293019
-"1422","Campbell, Gregory","treats",5.57422143734441
-"1423","Campbell, Gregory","10000",5.28038596398365
-"1424","Campbell, Gregory","way",4.49392473300466
-"1425","Campbell, Gregory","seeking",4.35796078235748
-"1426","Campbell, Gregory","people",4.30296274920612
-"1427","Campbell, Gregory","drug",4.20820006045262
-"1428","Campbell, Gregory","television",4.15230640541991
-"1429","Campbell, Ronnie","northumberland",2.84483247791272
-"1430","Campbell, Ronnie","stalking",2.68302353552264
-"1431","Campbell, Ronnie","harassment",2.64984497767234
-"1432","Campbell, Ronnie","two",2.20920227937655
-"1433","Campbell, Ronnie","received",1.46158343807783
-"1434","Campbell, Ronnie","sentences",1.16409695787249
-"1435","Campbell, Ronnie","people",1.16118682283765
-"1436","Campbell, Ronnie","years",0.624002356608131
-"1437","Campbell, Ronnie","prison",0.596106350922253
-"1438","Campbell, Ronnie","convict",0
-"1439","Campbell, Ronnie","five",0
-"1440","Campbell, Ronnie","person",0
-"1441","Carmichael, Alistair","legal",6.47623325493263
-"1442","Carmichael, Alistair","review",5.67898674468476
-"1443","Carmichael, Alistair","recognition",5.36443292022196
-"1444","Carmichael, Alistair","obtaining",5.31398650568272
-"1445","Carmichael, Alistair","will",5.1095845429594
-"1446","Carmichael, Alistair","punishment",4.97742543720109
-"1447","Carmichael, Alistair","aid",4.93749046037235
-"1448","Carmichael, Alistair","civil",4.73881108420018
-"1449","Carmichael, Alistair","introduced",4.44444817560717
-"1450","Carmichael, Alistair","gender",4.34438208161248
-"1451","Carmichael, Alistair","act",3.98519205504625
-"1452","Carmichael, Alistair","reforms",3.96125444600002
-"1453","Carmichael, Neil","drug",3.49990291034483
-"1454","Carmichael, Neil","reduction",3.4018773081697
-"1455","Carmichael, Neil","need",2.92141897371393
-"1456","Carmichael, Neil","use",2.76570197435
-"1457","Carmichael, Neil","reoffending",2.68260903280906
-"1458","Carmichael, Neil","education",2.53041028815706
-"1459","Carmichael, Neil","receive",1.79006681989671
-"1460","Carmichael, Neil","prisoners",1.76256468260781
-"1461","Carmichael, Neil","convict",0
-"1462","Carmichael, Neil","five",0
-"1463","Carmichael, Neil","person",0
-"1464","Carmichael, Neil","rape",0
-"1465","Carswell, Douglas","2014",7.22717374906449
-"1466","Carswell, Douglas","emergency",7.11040571079568
-"1467","Carswell, Douglas","2015",6.48008198882272
-"1468","Carswell, Douglas","order",6.18881858023803
-"1469","Carswell, Douglas","local",5.89751296765072
-"1470","Carswell, Douglas","president",5.71624556225518
-"1471","Carswell, Douglas","authorities",5.69624737556352
-"1472","Carswell, Douglas","march",5.34672671473729
-"1473","Carswell, Douglas","reasons",5.25526495681517
-"1474","Carswell, Douglas","2011",5.25526495681517
-"1475","Carswell, Douglas","england",5.11998952386202
-"1476","Carswell, Douglas","january",4.920387835732
-"1477","Caulfield, Maria","modernise",5.26724871686908
-"1478","Caulfield, Maria","estate",3.0441206019243
-"1479","Caulfield, Maria","will",1.34827709592357
-"1480","Caulfield, Maria","prison",0.894159526383379
-"1481","Caulfield, Maria","convict",0
-"1482","Caulfield, Maria","five",0
-"1483","Caulfield, Maria","person",0
-"1484","Caulfield, Maria","rape",0
-"1485","Caulfield, Maria","year",0
-"1486","Caulfield, Maria","offenc",0
-"1487","Caulfield, Maria","sexual",0
-"1488","Caulfield, Maria","agreement",0
-"1489","Chalk, Alex","imprisoned",6.22554027007914
-"1490","Chalk, Alex","incentivise",5.92821276431277
-"1491","Chalk, Alex","tariff",5.59799593999216
-"1492","Chalk, Alex","subject",4.66562968899864
-"1493","Chalk, Alex","cruelty",3.66115306706041
-"1494","Chalk, Alex","recruit",3.65091833847395
-"1495","Chalk, Alex","sentence",3.64815579538675
-"1496","Chalk, Alex","psychiatric",3.57484680302201
-"1497","Chalk, Alex","served",3.51430868526958
-"1498","Chalk, Alex","protection",3.47504622590054
-"1499","Chalk, Alex","arabia",3.46063735173971
-"1500","Chalk, Alex","animal",3.42022720303473
-"1501","Champion, Sarah","modern",10.9417926893542
-"1502","Champion, Sarah","traffickers",10.8520650428597
-"1503","Champion, Sarah","slavery",10.6399343104724
-"1504","Champion, Sarah","remote",9.82604768952721
-"1505","Champion, Sarah","probation",9.46257277657383
-"1506","Champion, Sarah","compensate",9.37894939266724
-"1507","Champion, Sarah","force",8.5685946779902
-"1508","Champion, Sarah","england",7.48180960538076
-"1509","Champion, Sarah","wales",7.44018232343197
-"1510","Champion, Sarah","private",6.95895034013313
-"1511","Champion, Sarah","enable",6.94689284832266
-"1512","Champion, Sarah","evidence",6.82995752116492
-"1513","Chapman, Jenny","england",21.9903952421796
-"1514","Chapman, Jenny","wales",21.8680451115035
-"1515","Chapman, Jenny","officer",20.6628927486045
-"1516","Chapman, Jenny","prison",17.5804101875946
-"1517","Chapman, Jenny","month",17.4707908027187
-"1518","Chapman, Jenny","2013",15.5405096513609
-"1519","Chapman, Jenny","institution",13.5365890520457
-"1520","Chapman, Jenny","young",12.4143976535181
-"1521","Chapman, Jenny","staff",11.3395292400826
-"1522","Chapman, Jenny","sick",10.5294938305919
-"1523","Chapman, Jenny","offender",10.378155803036
-"1524","Chapman, Jenny","assault",10.2353569076879
-"1525","Chishti, Rehman","gypsies",10.7350286298976
-"1526","Chishti, Rehman","tobacco",9.93248197779578
-"1527","Chishti, Rehman","traveller",8.9586415127135
-"1528","Chishti, Rehman","install",8.22504849162305
-"1529","Chishti, Rehman","medway",6.79472021199886
-"1530","Chishti, Rehman","kent",6.68776963027678
-"1531","Chishti, Rehman","young",6.56334145615621
-"1532","Chishti, Rehman","selling",6.15563932705029
-"1533","Chishti, Rehman","illicit",5.99776342017476
-"1534","Chishti, Rehman","centre",5.75089812028855
-"1535","Chishti, Rehman","loops",5.74956828593407
-"1536","Chishti, Rehman","induction",5.04075150725396
-"1537","Chope, Christopher","european",7.42274120273764
-"1538","Chope, Christopher","human",6.84864181874805
-"1539","Chope, Christopher","convention",6.48104174970722
-"1540","Chope, Christopher","rights",6.03173898895075
-"1541","Chope, Christopher","accede",5.85590220516915
-"1542","Chope, Christopher","foreign",4.43410875018806
-"1543","Chope, Christopher","governments",4.38661137846893
-"1544","Chope, Christopher","england",4.34484126659009
-"1545","Chope, Christopher","wales",4.32066744475199
-"1546","Chope, Christopher","par",4.28547517620851
-"1547","Chope, Christopher","defendants",4.24572746735505
-"1548","Chope, Christopher","muslim",4.23205405292339
-"1549","Churchill, Jo","edmunds",4.9226688134498
-"1550","Churchill, Jo","suffolk",4.71174721711286
-"1551","Churchill, Jo","bury",4.26734298226969
-"1552","Churchill, Jo","allowance",3.12144906219678
-"1553","Churchill, Jo","successful",2.98197938115395
-"1554","Churchill, Jo","independence",2.96486165378729
-"1555","Churchill, Jo","decisions",2.92640915581428
-"1556","Churchill, Jo","payment",2.67895165812421
-"1557","Churchill, Jo","appealed",2.59259596105094
-"1558","Churchill, Jo","claims",2.52148355769529
-"1559","Churchill, Jo","support",2.51840943990854
-"1560","Churchill, Jo","personal",2.27523039684756
-"1561","Clark, Katy","hardship",6.54667091688848
-"1562","Clark, Katy","compensation",5.22726826401484
-"1563","Clark, Katy","injuries",4.94595262120681
-"1564","Clark, Katy","applications",4.92096605562716
-"1565","Clark, Katy","criminal",3.95681942987857
-"1566","Clark, Katy","successful",3.53838086172213
-"1567","Clark, Katy","authoritys",3.53838086172213
-"1568","Clark, Katy","aimed",3.398473972902
-"1569","Clark, Katy","emotional",3.398473972902
-"1570","Clark, Katy","fund",3.21112239382291
-"1571","Clark, Katy","2012",2.90837995368856
-"1572","Clark, Katy","reached",2.40920177346954
-"1573","Clegg, Nick","cultivation",3.31951479760817
-"1574","Clegg, Nick","cannabis",2.91027923963108
-"1575","Clegg, Nick","mitigation",2.91027923963108
-"1576","Clegg, Nick","cited",2.71999554143551
-"1577","Clegg, Nick","medical",2.31075998345843
-"1578","Clegg, Nick","serious",1.68257256569982
-"1579","Clegg, Nick","purse",1.6646171739419
-"1580","Clegg, Nick","condition",1.65595394027634
-"1581","Clegg, Nick","records",1.54559425485367
-"1582","Clegg, Nick","prosecuted",1.40423351395645
-"1583","Clegg, Nick","cost",1.12900298309909
-"1584","Clegg, Nick","public",1.09615775535814
-"1585","Clwyd, Ann","macur",33.6458038881538
-"1586","Clwyd, Ann","lady",16.7020366676705
-"1587","Clwyd, Ann","review",12.9265720837365
-"1588","Clwyd, Ann","19906",11.1406922859991
-"1589","Clwyd, Ann","updated",10.7247367411583
-"1590","Clwyd, Ann","gordon",9.21043257725263
-"1591","Clwyd, Ann","redactions",9.21043257725263
-"1592","Clwyd, Ann","reinstated",8.93731349170599
-"1593","Clwyd, Ann","report",8.93312828863306
-"1594","Clwyd, Ann","consider",7.28147867806785
-"1595","Clwyd, Ann","publish",6.97445408405933
-"1596","Clwyd, Ann","angelsea",6.63616271088302
-"1597","Coaker, Vernon","nottinghamshire",16.4557875959754
-"1598","Coaker, Vernon","framework",12.4721101140848
-"1599","Coaker, Vernon","true",9.50607385998472
-"1600","Coaker, Vernon","vision",8.88453525820181
-"1601","Coaker, Vernon","northern",8.77206066225221
-"1602","Coaker, Vernon","ireland",8.68493755867733
-"1603","Coaker, Vernon","portal",8.66269852916468
-"1604","Coaker, Vernon","human",8.47444290115201
-"1605","Coaker, Vernon","nottingham",8.31266614090767
-"1606","Coaker, Vernon","reform",8.02562467328355
-"1607","Coaker, Vernon","police",8.00470864889922
-"1608","Coaker, Vernon","rights",7.46361526990464
-"1609","Coffey, Ann","intermediaries",31.3372873894427
-"1610","Coffey, Ann","registered",26.1971921881121
-"1611","Coffey, Ann","greater",17.5207580937869
-"1612","Coffey, Ann","sexual",17.1097414858253
-"1613","Coffey, Ann","manchester",15.6298015297423
-"1614","Coffey, Ann","2014",15.1852194864011
-"1615","Coffey, Ann","complete",13.2403778964692
-"1616","Coffey, Ann","2013",13.2058553101187
-"1617","Coffey, Ann","prosecuted",12.0525847593443
-"1618","Coffey, Ann","requester",11.8839493752224
-"1619","Coffey, Ann","old",11.4866407045231
-"1620","Coffey, Ann","offence",10.9221109660268
-"1621","Coffey, Dr Thérèse","dissolved",4.85927209970932
-"1622","Coffey, Dr Thérèse","partnerships",3.66115306706041
-"1623","Coffey, Dr Thérèse","county",2.8757419427
-"1624","Coffey, Dr Thérèse","can",2.82116768671028
-"1625","Coffey, Dr Thérèse","civil",2.23524826333986
-"1626","Coffey, Dr Thérèse","court",1.07644164991795
-"1627","Coffey, Dr Thérèse","will",1.01920168406233
-"1628","Coffey, Dr Thérèse","convict",0
-"1629","Coffey, Dr Thérèse","five",0
-"1630","Coffey, Dr Thérèse","person",0
-"1631","Coffey, Dr Thérèse","rape",0
-"1632","Coffey, Dr Thérèse","year",0
-"1633","Colvile, Oliver","drugs",6.53090774148254
-"1634","Colvile, Oliver","combat",5.42821276431277
-"1635","Colvile, Oliver","supply",4.42821276431277
-"1636","Colvile, Oliver","covenant",3.43310319184542
-"1637","Colvile, Oliver","level",3.387741754579
-"1638","Colvile, Oliver","clerks",3.33130058958113
-"1639","Colvile, Oliver","armed",3.0150728235643
-"1640","Colvile, Oliver","accordance",2.80064765981174
-"1641","Colvile, Oliver","forces",1.95110159969754
-"1642","Colvile, Oliver","prisons",1.9266460128952
-"1643","Colvile, Oliver","operate",1.90480917926102
-"1644","Colvile, Oliver","given",1.79822935816472
-"1645","Cooper, Julie","lancashire",11.7779083049811
-"1646","Cooper, Julie","burnley",9.78366231713421
-"1647","Cooper, Julie","reduction",5.14753573202463
-"1648","Cooper, Julie","sold",4.593537911754
-"1649","Cooper, Julie","sanctions",4.34325026359161
-"1650","Cooper, Julie","bargaining",4.0655587238791
-"1651","Cooper, Julie","time",4.062341416456
-"1652","Cooper, Julie","benefit",3.51176775723039
-"1653","Cooper, Julie","mothers",3.50428363736641
-"1654","Cooper, Julie","court",3.28750086197651
-"1655","Cooper, Julie","attended",3.04720937404941
-"1656","Cooper, Julie","committee",2.98096234061031
-"1657","Cooper, Rosie","wigan",8.89780167683854
-"1658","Cooper, Rosie","skelmersdale",8.57016707005398
-"1659","Cooper, Rosie","decision",8.21765168918847
-"1660","Cooper, Rosie","lancashire",8.21229239359518
-"1661","Cooper, Rosie","court",7.11133312528218
-"1662","Cooper, Rosie","magistrates",6.59025589306877
-"1663","Cooper, Rosie","ombudsman",5.99946392135142
-"1664","Cooper, Rosie","ormskirk",5.83964206900234
-"1665","Cooper, Rosie","statutory",5.80736782154113
-"1666","Cooper, Rosie","reverse",5.27498646097085
-"1667","Cooper, Rosie","proposal",5.26896677855382
-"1668","Cooper, Rosie","considered",5.1662736801977
-"1669","Corbyn, Jeremy","victims",9.46325072995739
-"1670","Corbyn, Jeremy","will",5.99541773573192
-"1671","Corbyn, Jeremy","romanian",5.74956828593407
-"1672","Corbyn, Jeremy","give",5.46012841528714
-"1673","Corbyn, Jeremy","crown",5.44215634262288
-"1674","Corbyn, Jeremy","mandatory",5.15142834112038
-"1675","Corbyn, Jeremy","trials",4.71420220526257
-"1676","Corbyn, Jeremy","implement",4.55073604426266
-"1677","Corbyn, Jeremy","disappearances",4.54543283655548
-"1678","Corbyn, Jeremy","right",4.16255819458182
-"1679","Corbyn, Jeremy","transcripts",4.10334315369087
-"1680","Corbyn, Jeremy","born",4.04686740189623
-"1681","Costa, Alberto","glen",6.07340847302224
-"1682","Costa, Alberto","parva",6.07340847302224
-"1683","Costa, Alberto","education",4.38279918308302
-"1684","Costa, Alberto","redeveloped",4.1918794459622
-"1685","Costa, Alberto","leicester",3.83832605536893
-"1686","Costa, Alberto","2020",2.87475914111963
-"1687","Costa, Alberto","ratio",2.69838631099963
-"1688","Costa, Alberto","accommodate",2.49222281348348
-"1689","Costa, Alberto","adequacy",2.44270562350646
-"1690","Costa, Alberto","complete",2.30395737218284
-"1691","Costa, Alberto","prison",1.89679879370472
-"1692","Costa, Alberto","hmp",1.82386341203212
-"1693","Cowan, Ronnie","inverclyde",4.28547517620851
-"1694","Cowan, Ronnie","awards",2.11095452418951
-"1695","Cowan, Ronnie","successful",1.95591361395112
-"1696","Cowan, Ronnie","independence",1.94468590519903
-"1697","Cowan, Ronnie","payments",1.75715434263479
-"1698","Cowan, Ronnie","appeals",1.70051267548735
-"1699","Cowan, Ronnie","personal",1.49234905385142
-"1700","Cowan, Ronnie","2016",1.4894694144268
-"1701","Cowan, Ronnie","2015",1.24756112085878
-"1702","Cowan, Ronnie","convict",0
-"1703","Cowan, Ronnie","five",0
-"1704","Cowan, Ronnie","rape",0
-"1705","Cox, Geoffrey","constructor",3.03028855770365
-"1706","Cox, Geoffrey","plymouth",3.03028855770365
-"1707","Cox, Geoffrey","geoamey",2.48300485726285
-"1708","Cox, Geoffrey","transport",2.04742780918392
-"1709","Cox, Geoffrey","deliver",1.96407477962185
-"1710","Cox, Geoffrey","failure",1.92238429128494
-"1711","Cox, Geoffrey","investigate",1.59545980594724
-"1712","Cox, Geoffrey","defendants",1.52767735362464
-"1713","Cox, Geoffrey","purse",1.51958062629746
-"1714","Cox, Geoffrey","october",1.41976093633107
-"1715","Cox, Geoffrey","crown",1.34269069948392
-"1716","Cox, Geoffrey","2016",1.05321392331115
-"1717","Coyle, Neil","psychiatric",5.30235469043411
-"1718","Coyle, Neil","requested",3.1640656215701
-"1719","Coyle, Neil","british",3.09726191723672
-"1720","Coyle, Neil","introduction",2.94697614483916
-"1721","Coyle, Neil","bill",2.93865096047327
-"1722","Coyle, Neil","assessments",2.90638459537085
-"1723","Coyle, Neil","judges",2.84632332126694
-"1724","Coyle, Neil","universal",2.51226765164198
-"1725","Coyle, Neil","rights",2.32471199363358
-"1726","Coyle, Neil","adjourned",2.31786575697609
-"1727","Coyle, Neil","proposals",2.14230353744611
-"1728","Coyle, Neil","sufficient",2.03899645262111
-"1729","Crausby, David","commissioners",4.56827897291929
-"1730","Crausby, David","refusals",4.50800435190759
-"1731","Crausby, David","review",4.23488564654146
-"1732","Crausby, David","devolution",3.72450728589427
-"1733","Crausby, David","police",3.63137924771511
-"1734","Crausby, David","external",3.59200009332702
-"1735","Crausby, David","crime",3.53002593212836
-"1736","Crausby, David","funding",3.48824858225007
-"1737","Crausby, David","fighting",3.398473972902
-"1738","Crausby, David","motor",3.28601931495429
-"1739","Crausby, David","repossession",3.27333545844424
-"1740","Crausby, David","eviction",3.02990879034318
-"1741","Crausby, Sir David","capabl",5.87530699098492
-"1742","Crausby, Sir David","bolton",4.26021258338486
-"1743","Crausby, Sir David","repossessions",4.10334315369087
-"1744","Crausby, Sir David","five",3.63043616615656
-"1745","Crausby, Sir David","appeals",3.04097078039078
-"1746","Crausby, Sir David","work",2.64578461856019
-"1747","Crausby, Sir David","outcome",2.63896072857686
-"1748","Crausby, Sir David","nine",2.43725762059819
-"1749","Crausby, Sir David","resolved",2.43725762059819
-"1750","Crausby, Sir David","previous",2.3761000869598
-"1751","Crausby, Sir David","assessments",2.29769876944969
-"1752","Crausby, Sir David","financial",2.11981299668154
-"1753","Crawley, Angela","consent",2.87475914111963
-"1754","Crawley, Angela","scottish",2.61907845362646
-"1755","Crawley, Angela","repeal",2.59555981135252
-"1756","Crawley, Angela","parliament",2.42688610118765
-"1757","Crawley, Angela","seek",2.36880142471095
-"1758","Crawley, Angela","1998",2.17467147921726
-"1759","Crawley, Angela","human",1.7795890675973
-"1760","Crawley, Angela","legislative",1.73305738067267
-"1761","Crawley, Angela","rights",1.56732050637441
-"1762","Crawley, Angela","proposed",1.44434075030068
-"1763","Crawley, Angela","act",1.24274410550915
-"1764","Crawley, Angela","convict",0
-"1765","Creagh, Mary","wakefield",6.08869953969506
-"1766","Creagh, Mary","five",5.65443924495947
-"1767","Creagh, Mary","inmates",5.10990963671029
-"1768","Creagh, Mary","rejected",5.00999827684004
-"1769","Creagh, Mary","patients",3.98506397046232
-"1770","Creagh, Mary","granted",3.97191378126868
-"1771","Creagh, Mary","year",3.82368265765316
-"1772","Creagh, Mary","force",3.64140631336009
-"1773","Creagh, Mary","received",3.56977986453754
-"1774","Creagh, Mary","civil",3.56622252868861
-"1775","Creagh, Mary","applications",3.5030330232844
-"1776","Creagh, Mary","discharge",3.27795718927577
-"1777","Creasy, Stella","55a",3.31951479760817
-"1778","Creasy, Stella","parentage",3.31951479760817
-"1779","Creasy, Stella","1986",2.39388146013676
-"1780","Creasy, Stella","declaration",2.33645998385951
-"1781","Creasy, Stella","county",1.96450574016346
-"1782","Creasy, Stella","high",1.86980294960517
-"1783","Creasy, Stella","applications",1.44323858077113
-"1784","Creasy, Stella","law",1.43843203333643
-"1785","Creasy, Stella","section",1.36303108707121
-"1786","Creasy, Stella","family",1.32593555945627
-"1787","Creasy, Stella","magistrates",1.19236784062669
-"1788","Creasy, Stella","act",1.06422247140201
-"1789","Cunningham, Alex","substances",14.2986407757581
-"1790","Cunningham, Alex","psychoactive",10.077318670711
-"1791","Cunningham, Alex","families",8.06138336876923
-"1792","Cunningham, Alex","domestic",7.56651953988717
-"1793","Cunningham, Alex","new",7.56398294457637
-"1794","Cunningham, Alex","jail",6.76052064195506
-"1795","Cunningham, Alex","broken",6.66292494234059
-"1796","Cunningham, Alex","involving",6.39306815348332
-"1797","Cunningham, Alex","abuse",6.354748280114
-"1798","Cunningham, Alex","detect",6.10392169475882
-"1799","Cunningham, Alex","illicit",5.94737220869284
-"1800","Cunningham, Alex","child",5.92302690613325
-"1801","Cunningham, Jim","made",23.9429391999516
-"1802","Cunningham, Jim","prison",21.8877567376359
-"1803","Cunningham, Jim","midlands",20.930897655971
-"1804","Cunningham, Jim","will",18.4316502867953
-"1805","Cunningham, Jim","year",17.5742383923816
-"1806","Cunningham, Jim","west",17.2448461868815
-"1807","Cunningham, Jim","england",16.2102155384907
-"1808","Cunningham, Jim","number",16.115652327131
-"1809","Cunningham, Jim","five",15.1206426031285
-"1810","Cunningham, Jim","claim",15.1019796294686
-"1811","Cunningham, Jim","wales",13.6822189040233
-"1812","Cunningham, Jim","estimate",13.4917921310633
-"1813","Cunningham, Sir Tony","cert",3.11814120131826
-"1814","Cunningham, Sir Tony","gary",3.11814120131826
-"1815","Cunningham, Sir Tony","jbirqk61bb77//e/1",3.11814120131826
-"1816","Cunningham, Sir Tony","owh0080",3.11814120131826
-"1817","Cunningham, Sir Tony","tomlinson",3.11814120131826
-"1818","Cunningham, Sir Tony","workington",3.11814120131826
-"1819","Cunningham, Sir Tony","withdrawn",2.24866008047404
-"1820","Cunningham, Sir Tony","constituent",1.56777649975397
-"1821","Cunningham, Sir Tony","reasons",1.31296224844248
-"1822","Cunningham, Sir Tony","funding",1.29151289140489
-"1823","Cunningham, Sir Tony","member",1.26775042484217
-"1824","Cunningham, Sir Tony","claim",1.20336664054642
-"1825","Curran, Margaret","scotland",2.84577620407675
-"1826","Curran, Margaret","processed",2.1478601170062
-"1827","Curran, Margaret","employment",1.51553132933529
-"1828","Curran, Margaret","tribunals",1.4620586486878
-"1829","Curran, Margaret","service",1.23393786031977
-"1830","Curran, Margaret","2010",1.20465429476315
-"1831","Curran, Margaret","courts",1.00691896271166
-"1832","Curran, Margaret","year",0.661854446750993
-"1833","Curran, Margaret","convict",0
-"1834","Curran, Margaret","five",0
-"1835","Curran, Margaret","person",0
-"1836","Curran, Margaret","rape",0
-"1837","Dakin, Nic","embed",6.42821276431277
-"1838","Dakin, Nic","component",5.63573151395219
-"1839","Dakin, Nic","nothing",5.63573151395219
-"1840","Dakin, Nic","independence",4.47624636825777
-"1841","Dakin, Nic","decision",4.4181921065413
-"1842","Dakin, Nic","enhanced",4.13573151395219
-"1843","Dakin, Nic","standard",4.05076901323103
-"1844","Dakin, Nic","payments",4.04458926948534
-"1845","Dakin, Nic","mobility",3.92821276431277
-"1846","Dakin, Nic","appeal",3.91421240184674
-"1847","Dakin, Nic","quarter",3.82348608149829
-"1848","Dakin, Nic","beef",3.71133036988416
-"1849","Danczuk, Simon","albany",2.94946629760185
-"1850","Danczuk, Simon","ashwell",2.94946629760185
-"1851","Danczuk, Simon","askham",2.94946629760185
-"1852","Danczuk, Simon","buckley",2.94946629760185
-"1853","Danczuk, Simon","grange",2.41677945971859
-"1854","Danczuk, Simon","ashfield",2.30541490792287
-"1855","Danczuk, Simon","unemployed",1.52047728657507
-"1856","Danczuk, Simon","classed",1.40911273477935
-"1857","Danczuk, Simon","week",1.36768662052877
-"1858","Danczuk, Simon","hours",1.34615207139606
-"1859","Danczuk, Simon","cells",1.34098045146564
-"1860","Danczuk, Simon","per",1.31865894261325
-"1861","David, Wayne","spent",8.65392736021658
-"1862","David, Wayne","per",8.1857993858467
-"1863","David, Wayne","number",7.75222003225956
-"1864","David, Wayne","unemployed",7.72738031142994
-"1865","David, Wayne","classed",7.16140260657656
-"1866","David, Wayne","week",6.95086651868799
-"1867","David, Wayne","hours",6.84142348231189
-"1868","David, Wayne","cells",6.81514023929251
-"1869","David, Wayne","2011",6.31178576189719
-"1870","David, Wayne","christmas",5.66018287751524
-"1871","David, Wayne","2012",5.62332312100681
-"1872","David, Wayne","five",5.60232191539126
-"1873","Davidson, Ian","development",2.74835469134796
-"1874","Davidson, Ian","foreign",2.55842741495289
-"1875","Davidson, Ian","action",2.45634330665509
-"1876","Davidson, Ian","home",2.40558226530176
-"1877","Davidson, Ian","plan",2.18448722198653
-"1878","Davidson, Ian","national",1.79651719356078
-"1879","Davidson, Ian","offenders",1.31420029804509
-"1880","Davidson, Ian","convict",0
-"1881","Davidson, Ian","five",0
-"1882","Davidson, Ian","person",0
-"1883","Davidson, Ian","rape",0
-"1884","Davidson, Ian","year",0
-"1885","Davies, Byron","anticorruption",3.74933095786226
-"1886","Davies, Byron","corporate",2.97159039142941
-"1887","Davies, Byron","liability",2.83009143875762
-"1888","Davies, Byron","action",2.05512425612285
-"1889","Davies, Byron","expects",2.03339537666691
-"1890","Davies, Byron","progress",1.98798796180341
-"1891","Davies, Byron","introduced",1.98321074297139
-"1892","Davies, Byron","plan",1.8276731371106
-"1893","Davies, Byron","criminal",1.42127992475239
-"1894","Davies, Byron","made",0.905066663758513
-"1895","Davies, Byron","convict",0
-"1896","Davies, Byron","five",0
-"1897","Davies, David T. C.","seekers",5.66913452064925
-"1898","Davies, David T. C.","wish",5.05431574721918
-"1899","Davies, David T. C.","gwent",4.84036545307348
-"1900","Davies, David T. C.","served",4.50953570363963
-"1901","Davies, David T. C.","spent",4.23905308652826
-"1902","Davies, David T. C.","five",4.18454909875453
-"1903","Davies, David T. C.","magistrates",3.9505407738351
-"1904","Davies, David T. C.","asylum",3.70411114354803
-"1905","Davies, David T. C.","translators",3.55172985105962
-"1906","Davies, David T. C.","district",3.35276739290178
-"1907","Davies, David T. C.","sufficient",3.3296672641778
-"1908","Davies, David T. C.","immigration",3.2866137150952
-"1909","Davies, Mims","vulnerable",6.80586091349106
-"1910","Davies, Mims","intimidated",6.37959899253249
-"1911","Davies, Mims","witness",4.1146734693443
-"1912","Davies, Mims","screens",3.87635814759977
-"1913","Davies, Mims","defines",2.98317831100567
-"1914","Davies, Mims","safeguard",2.72224609610137
-"1915","Davies, Mims","appropriate",2.65536262541257
-"1916","Davies, Mims","participate",2.54533961642677
-"1917","Davies, Mims","give",2.48803603528226
-"1918","Davies, Mims","adequacy",2.44270562350646
-"1919","Davies, Mims","special",2.28274941795632
-"1920","Davies, Mims","arrangements",2.19009490478894
-"1921","Davies, Philip","offence",226.167240895477
-"1922","Davies, Philip","sentence",202.112881655131
-"1923","Davies, Philip","prison",150.468404951876
-"1924","Davies, Philip","year",140.391224753454
-"1925","Davies, Philip","offender",132.671904894463
-"1926","Davies, Philip","release",125.571717682777
-"1927","Davies, Philip","proportion",121.303317533407
-"1928","Davies, Philip","convicted",119.867110755519
-"1929","Davies, Philip","commit",110.539975867394
-"1930","Davies, Philip","court",97.8007856436498
-"1931","Davies, Philip","serve",90.2140559329498
-"1932","Davies, Philip","licence",89.7376957747472
-"1933","Day, Martyn","visa",7.67665211073786
-"1934","Day, Martyn","appeals",6.83382807970845
-"1935","Day, Martyn","pension",6.49568134305895
-"1936","Day, Martyn","alpha",6.0248504140154
-"1937","Day, Martyn","scotland",5.09067923285354
-"1938","Day, Martyn","carries",4.93515365200848
-"1939","Day, Martyn","retirement",4.92822646902415
-"1940","Day, Martyn","potential",4.90794644761181
-"1941","Day, Martyn","officers",4.85964036676769
-"1942","Day, Martyn","age",4.70101531315458
-"1943","Day, Martyn","manual",4.6015555121686
-"1944","Day, Martyn","country",4.50043232622936
-"1945","de Bois, Nick","born",17.9051819848046
-"1946","de Bois, Nick","blade",16.2868426924527
-"1947","de Bois, Nick","point",15.3129609299975
-"1948","de Bois, Nick","article",13.8961908968381
-"1949","de Bois, Nick","offensive",12.2284450547241
-"1950","de Bois, Nick","self",10.8021470624191
-"1951","de Bois, Nick","weapon",10.7741317563836
-"1952","de Bois, Nick","inception",10.1181229249729
-"1953","de Bois, Nick","threatening",9.54189318314191
-"1954","de Bois, Nick","aged",8.69401068253521
-"1955","de Bois, Nick","certificated",8.59047764488263
-"1956","de Bois, Nick","economy",8.4185138288612
-"1957","De Piero, Gloria","ashfield",16.618915809276
-"1958","De Piero, Gloria","constituency",12.975596769324
-"1959","De Piero, Gloria","nottinghamshire",12.5689139940735
-"1960","De Piero, Gloria","five",8.94425067784536
-"1961","De Piero, Gloria","tribunal",8.24697192335756
-"1962","De Piero, Gloria","year",8.24513867300299
-"1963","De Piero, Gloria","pay",7.90850290013461
-"1964","De Piero, Gloria","discrimination",7.08321396904052
-"1965","De Piero, Gloria","men",6.83324741258567
-"1966","De Piero, Gloria","convicted",6.51531732405714
-"1967","De Piero, Gloria","successful",5.98638689766213
-"1968","De Piero, Gloria","people",5.90190567445936
-"1969","Debbonaire, Thangam","bristol",5.93023194413188
-"1970","Debbonaire, Thangam","synnex",5.04075150725396
-"1971","Debbonaire, Thangam","concentrix",4.85514109493415
-"1972","Debbonaire, Thangam","private",4.61608508661946
-"1973","Debbonaire, Thangam","genital",4.09468133465334
-"1974","Debbonaire, Thangam","mutilation",4.09468133465334
-"1975","Debbonaire, Thangam","representation",3.9652435409037
-"1976","Debbonaire, Thangam","close",3.72219715744768
-"1977","Debbonaire, Thangam","intimate",3.56573088174181
-"1978","Debbonaire, Thangam","regardless",3.56434957305558
-"1979","Debbonaire, Thangam","business",3.43750753757393
-"1980","Debbonaire, Thangam","labour",3.42382100930146
-"1981","Djanogly, Jonathan","merger",5.40371671931768
-"1982","Djanogly, Jonathan","marital",5.24861374353734
-"1983","Djanogly, Jonathan","peterborough",5.20474121201711
-"1984","Djanogly, Jonathan","cambridgeshire",4.92430098544712
-"1985","Djanogly, Jonathan","law",3.8194846038957
-"1986","Djanogly, Jonathan","east",3.81113212384202
-"1987","Djanogly, Jonathan","south",3.78845301987528
-"1988","Djanogly, Jonathan","anticorruption",3.42265523528935
-"1989","Djanogly, Jonathan","coroner",3.37943535795317
-"1990","Djanogly, Jonathan","matrimonial",3.2883807836292
-"1991","Djanogly, Jonathan","relating",3.13537034525707
-"1992","Djanogly, Jonathan","north",3.06681952992252
-"1993","Dobbin, Jim","tranquilisers",5.74956828593407
-"1994","Dobbin, Jim","prescription",5.30235469043411
-"1995","Dobbin, Jim","danny",4.54543283655548
-"1996","Dobbin, Jim","fitzsimons",4.54543283655548
-"1997","Dobbin, Jim","illicit",4.09468133465334
-"1998","Dobbin, Jim","trade",3.96071390393424
-"1999","Dobbin, Jim","iraq",3.83832605536893
-"2000","Dobbin, Jim","achieve",3.27795718927577
-"2001","Dobbin, Jim","regard",2.58158911469325
-"2002","Dobbin, Jim","agreement",2.3432128691399
-"2003","Dobbin, Jim","transfer",2.12518661877157
-"2004","Dobbin, Jim","prisoner",1.43202685805714
-"2005","Dobson, Frank","coroners",2.87777102449042
-"2006","Dobson, Frank","progress",2.56648142284181
-"2007","Dobson, Frank","implementation",2.52460750442972
-"2008","Dobson, Frank","hour",2.39549516757162
-"2009","Dobson, Frank","system",2.28579756352484
-"2010","Dobson, Frank","made",1.16843603864808
-"2011","Dobson, Frank","convict",0
-"2012","Dobson, Frank","five",0
-"2013","Dobson, Frank","person",0
-"2014","Dobson, Frank","rape",0
-"2015","Dobson, Frank","year",0
-"2016","Dobson, Frank","offenc",0
-"2017","Docherty-Hughes, Martin","charter",4.30069056821956
-"2018","Docherty-Hughes, Martin","fundamental",4.19330722170474
-"2019","Docherty-Hughes, Martin","party",3.04720937404941
-"2020","Docherty-Hughes, Martin","remaining",3.0198101183243
-"2021","Docherty-Hughes, Martin","governments",2.78100017741942
-"2022","Docherty-Hughes, Martin","rights",2.12216199769319
-"2023","Docherty-Hughes, Martin","convict",0
-"2024","Docherty-Hughes, Martin","five",0
-"2025","Docherty-Hughes, Martin","person",0
-"2026","Docherty-Hughes, Martin","rape",0
-"2027","Docherty-Hughes, Martin","year",0
-"2028","Docherty-Hughes, Martin","offenc",0
-"2029","Dodds, Nigel","topics",4.1918794459622
-"2030","Dodds, Nigel","europe",3.32233905826068
-"2031","Dodds, Nigel","correspondence",3.32233905826068
-"2032","Dodds, Nigel","message",3.25379110666075
-"2033","Dodds, Nigel","origin",2.95267033473516
-"2034","Dodds, Nigel","content",2.84530496609973
-"2035","Dodds, Nigel","arrangements",2.61766408736122
-"2036","Dodds, Nigel","return",2.51231933069401
-"2037","Dodds, Nigel","prohibit",2.50757670884253
-"2038","Dodds, Nigel","commissioner",2.46560444080364
-"2039","Dodds, Nigel","sending",2.46369719538345
-"2040","Dodds, Nigel","countries",2.40558226530176
-"2041","Donaldson, Stuart Blair","band",3.51440459815959
-"2042","Donaldson, Stuart Blair","adviser",3.48419398729183
-"2043","Donaldson, Stuart Blair","name",3.26535130717057
-"2044","Donaldson, Stuart Blair","special",3.09085732327292
-"2045","Donaldson, Stuart Blair","pay",2.6531540061169
-"2046","Donaldson, Stuart Blair","affairs",2.61907845362646
-"2047","Donaldson, Stuart Blair","missing",2.42688610118765
-"2048","Donaldson, Stuart Blair","help",2.39687496642186
-"2049","Donaldson, Stuart Blair","responsibilities",2.23776650358638
-"2050","Donaldson, Stuart Blair","legislative",1.73305738067267
-"2051","Donaldson, Stuart Blair","financial",1.69102577761923
-"2052","Donaldson, Stuart Blair","protect",1.57164879006173
-"2053","Donelan, Michelle","chippenham",3.71133036988416
-"2054","Donelan, Michelle","wiltshire",3.42265523528935
-"2055","Donelan, Michelle","retrospectively",3.31951479760817
-"2056","Donelan, Michelle","abolition",3.06131590786101
-"2057","Donelan, Michelle","225",3.06131590786101
-"2058","Donelan, Michelle","upheld",2.61224167530896
-"2059","Donelan, Michelle","initial",2.2679546969101
-"2060","Donelan, Michelle","assessments",1.87606318925752
-"2061","Donelan, Michelle","constituency",1.86602727749074
-"2062","Donelan, Michelle","2003",1.82006220436519
-"2063","Donelan, Michelle","applied",1.72130896877564
-"2064","Donelan, Michelle","independence",1.68414739628389
-"2065","Dorries, Nadine","stalking",14.5063714627072
-"2066","Dorries, Nadine","attorney",12.3711910377458
-"2067","Dorries, Nadine","elderly",11.3372013120428
-"2068","Dorries, Nadine","power",10.0934564260279
-"2069","Dorries, Nadine","protect",8.8967085389117
-"2070","Dorries, Nadine","abuse",8.60251134421133
-"2071","Dorries, Nadine","vulnerable",7.89847088960762
-"2072","Dorries, Nadine","new",7.32754454444003
-"2073","Dorries, Nadine","people",5.94567096403692
-"2074","Dorries, Nadine","laws",5.79631613040304
-"2075","Dorries, Nadine","better",5.25959366330941
-"2076","Dorries, Nadine","training",5.14345336214922
-"2077","Doughty, Stephen","lessons",12.8737167965578
-"2078","Doughty, Stephen","car",11.3426621569435
-"2079","Doughty, Stephen","tests",9.83087798073373
-"2080","Doughty, Stephen","drive",8.66076944571886
-"2081","Doughty, Stephen","abscond",7.73543749760746
-"2082","Doughty, Stephen","2013",6.58554674890636
-"2083","Doughty, Stephen","missing",6.08452546005101
-"2084","Doughty, Stephen","parking",5.85055601323255
-"2085","Doughty, Stephen","prison",5.66025547149102
-"2086","Doughty, Stephen","ka505a",4.54543283655548
-"2087","Doughty, Stephen","maya",4.54543283655548
-"2088","Doughty, Stephen","202937",4.54543283655548
-"2089","Dowd, Jim","passed",2.40920177346954
-"2090","Dowd, Jim","maximum",2.06075581964016
-"2091","Dowd, Jim","fraud",2.04256488665471
-"2092","Dowd, Jim","length",1.6922621702771
-"2093","Dowd, Jim","increase",1.60002236735152
-"2094","Dowd, Jim","legislative",1.59418092621847
-"2095","Dowd, Jim","proposals",1.32860025338325
-"2096","Dowd, Jim","average",1.32120389470613
-"2097","Dowd, Jim","custodial",1.27293682360404
-"2098","Dowd, Jim","convictions",1.11592796969529
-"2099","Dowd, Jim","five",1.0337233412943
-"2100","Dowd, Jim","sentence",0.968587216435596
-"2101","Dowd, Peter","probate",12.5975480066718
-"2102","Dowd, Peter","registries",12.0032973147448
-"2103","Dowd, Peter","cafcass",10.1235391658366
-"2104","Dowd, Peter","fee",7.82352612785566
-"2105","Dowd, Peter","grant",6.18361892303768
-"2106","Dowd, Peter","proposals",5.89283343753363
-"2107","Dowd, Peter","expended",5.83971195843831
-"2108","Dowd, Peter","liquid",5.7813664715923
-"2109","Dowd, Peter","reflect",5.18861527796988
-"2110","Dowd, Peter","departments",5.00027376515491
-"2111","Dowd, Peter","filed",4.80613722435685
-"2112","Dowd, Peter","actual",4.56652583745013
-"2113","Dowden, Oliver","specialise",4.4813076267001
-"2114","Dowden, Oliver","belief",3.79819167604396
-"2115","Dowden, Oliver","religion",3.72537868068164
-"2116","Dowden, Oliver","characteristic",3.60370129795068
-"2117","Dowden, Oliver","judges",2.40558226530176
-"2118","Dowden, Oliver","protected",1.9701660231828
-"2119","Dowden, Oliver","train",1.86848105176083
-"2120","Dowden, Oliver","convict",0
-"2121","Dowden, Oliver","five",0
-"2122","Dowden, Oliver","person",0
-"2123","Dowden, Oliver","rape",0
-"2124","Dowden, Oliver","year",0
-"2125","Drax, Richard","marine",3.87635814759977
-"2126","Drax, Richard","sergeant",3.57484680302201
-"2127","Drax, Richard","blackman",3.398473972902
-"2128","Drax, Richard","expediting",3.398473972902
-"2129","Drax, Richard","alexander",3.27333545844424
-"2130","Drax, Richard","investigations",2.04091904126721
-"2131","Drax, Richard","commission",1.98685091153302
-"2132","Drax, Richard","criminal",1.3551372370972
-"2133","Drax, Richard","review",1.33448106334806
-"2134","Drax, Richard","case",1.19173676033031
-"2135","Drax, Richard","will",0.813041680110636
-"2136","Drax, Richard","convict",0
-"2137","Drew, Dr David","stroud",3.71133036988416
-"2138","Drew, Dr David","district",2.37076455926199
-"2139","Drew, Dr David","allowance",1.77309464136928
-"2140","Drew, Dr David","successful",1.6938708772895
-"2141","Drew, Dr David","independence",1.68414739628389
-"2142","Drew, Dr David","payment",1.52174029909188
-"2143","Drew, Dr David","appeals",1.47268717642949
-"2144","Drew, Dr David","support",1.43054658067463
-"2145","Drew, Dr David","personal",1.292412191949
-"2146","Drew, Dr David","employment",1.23742614869112
-"2147","Drew, Dr David","2010",0.983596112874016
-"2148","Drew, Dr David","year",0.540401892843998
-"2149","Dromey, Jack","unfairly",4.85927209970932
-"2150","Dromey, Jack","people",4.42635478148887
-"2151","Dromey, Jack","dangerous",4.42414291169228
-"2152","Dromey, Jack","treated",3.79819167604396
-"2153","Dromey, Jack","citizenship",3.71133036988416
-"2154","Dromey, Jack","release",3.6609506899699
-"2155","Dromey, Jack","mappa",3.56573088174181
-"2156","Dromey, Jack","marketing",3.55172985105962
-"2157","Dromey, Jack","press",3.51859493300094
-"2158","Dromey, Jack","knives",3.46063735173971
-"2159","Dromey, Jack","drivers",3.45982640536948
-"2160","Dromey, Jack","unlawful",3.28318859405118
-"2161","Drummond, Flick","electronic",3.78551165488164
-"2162","Drummond, Flick","monitoring",3.36357125584028
-"2163","Drummond, Flick","progress",3.14328496014729
-"2164","Drummond, Flick","made",1.43103604588334
-"2165","Drummond, Flick","convict",0
-"2166","Drummond, Flick","five",0
-"2167","Drummond, Flick","person",0
-"2168","Drummond, Flick","rape",0
-"2169","Drummond, Flick","year",0
-"2170","Drummond, Flick","offenc",0
-"2171","Drummond, Flick","sexual",0
-"2172","Drummond, Flick","agreement",0
-"2173","Duddridge, James","rwanda",4.4813076267001
-"2174","Duddridge, James","entrustment",4.4813076267001
-"2175","Duddridge, James","jersey",3.9816657709599
-"2176","Duddridge, James","facilitate",3.66115306706041
-"2177","Duddridge, James","trade",3.34741420767242
-"2178","Duddridge, James","agreement",2.50499992588602
-"2179","Duddridge, James","decision",2.17646814407056
-"2180","Duddridge, James","convict",0
-"2181","Duddridge, James","five",0
-"2182","Duddridge, James","person",0
-"2183","Duddridge, James","rape",0
-"2184","Duddridge, James","year",0
-"2185","Dugher, Michael","yorkshire",7.94953493301701
-"2186","Dugher, Michael","south",7.90222921823866
-"2187","Dugher, Michael","breathalysed",4.1918794459622
-"2188","Dugher, Michael","influence",3.370953895301
-"2189","Dugher, Michael","probation",3.34062365178744
-"2190","Dugher, Michael","alcohol",2.8835764369274
-"2191","Dugher, Michael","staff",2.74555551267003
-"2192","Dugher, Michael","five",2.56012470945585
-"2193","Dugher, Michael","year",2.53386151657539
-"2194","Dugher, Michael","people",2.39281143781709
-"2195","Dugher, Michael","service",2.32673554291981
-"2196","Dugher, Michael","drive",2.30395737218284
-"2197","Eagle, Maria","remit",4.46934638030619
-"2198","Eagle, Maria","engagement",4.0561974420849
-"2199","Eagle, Maria","resources",3.92628444651649
-"2200","Eagle, Maria","process",3.60602459097343
-"2201","Eagle, Maria","independence",3.46296751803207
-"2202","Eagle, Maria","bodies",3.27338264004571
-"2203","Eagle, Maria","organisations",3.26394477041396
-"2204","Eagle, Maria","payments",3.12902376494086
-"2205","Eagle, Maria","unsuccessful",3.06314042223207
-"2206","Eagle, Maria","65647",3.03028855770365
-"2207","Eagle, Maria","appeal",3.02816004552253
-"2208","Eagle, Maria","within",3.02687570473462
-"2209","Edwards, Jonathan","election",6.54674467443656
-"2210","Edwards, Jonathan","carmarthen",6.02542229001739
-"2211","Edwards, Jonathan","guildhall)",6.02542229001739
-"2212","Edwards, Jonathan","general",5.92641978901195
-"2213","Edwards, Jonathan","capacity",5.29744438634971
-"2214","Edwards, Jonathan","visited",5.19490192540945
-"2215","Edwards, Jonathan","financial",4.62379526251548
-"2216","Edwards, Jonathan","probate",4.30145034209128
-"2217","Edwards, Jonathan","wales",4.23566293662512
-"2218","Edwards, Jonathan","2008",3.79325145234411
-"2219","Edwards, Jonathan","official",3.78189249204024
-"2220","Edwards, Jonathan","write",3.46063735173971
-"2221","Elliott, Tom","covers",4.1062846694254
-"2222","Elliott, Tom","future",3.43957280256281
-"2223","Elliott, Tom","statutes",3.398473972902
-"2224","Elliott, Tom","bill",3.28551165488164
-"2225","Elliott, Tom","fully",3.16413841980111
-"2226","Elliott, Tom","consumers",2.72839744576541
-"2227","Elliott, Tom","passed",2.61907845362646
-"2228","Elliott, Tom","rights",2.59910702293687
-"2229","Elliott, Tom","considered",2.53002304633413
-"2230","Elliott, Tom","industry",2.44270562350646
-"2231","Elliott, Tom","defendant",2.29151603043696
-"2232","Elliott, Tom","mental",2.24457997622849
-"2233","Ellman, Louise","danish",3.87635814759977
-"2234","Ellman, Louise","diver",3.87635814759977
-"2235","Ellman, Louise","omalley",3.87635814759977
-"2236","Ellman, Louise","reopening",3.87635814759977
-"2237","Ellman, Louise","stephen",3.27333545844424
-"2238","Ellman, Louise","counterpart",3.02990879034318
-"2239","Ellman, Louise","commercial",2.59555981135252
-"2240","Ellman, Louise","inquest",2.47618282379502
-"2241","Ellman, Louise","commissioners",2.10267453211564
-"2242","Ellman, Louise","commissioners",1.98685091153302
-"2243","Ellman, Louise","grant",1.88640955245588
-"2244","Ellman, Louise","death",1.86030238312883
-"2245","Elmore, Chris","pregnant",7.72215166323271
-"2246","Elmore, Chris","barriers",4.26021258338486
-"2247","Elmore, Chris","women",4.02363613065053
-"2248","Elmore, Chris","justice",3.97589795036191
-"2249","Elmore, Chris","obstacles",3.95214184287518
-"2250","Elmore, Chris","accessing",3.93667588382649
-"2251","Elmore, Chris","experienced",3.46063735173971
-"2252","Elmore, Chris","faced",3.28547517620851
-"2253","Elmore, Chris","remove",2.57571417056019
-"2254","Elmore, Chris","potential",1.9229875624584
-"2255","Elmore, Chris","will",1.01920168406233
-"2256","Elmore, Chris","made",0.954024030588891
-"2257","Elphicke, Charlie","1998",2.72609496920126
-"2258","Elphicke, Charlie","human",2.23083295605124
-"2259","Elphicke, Charlie","reform",2.11268495438503
-"2260","Elphicke, Charlie","rights",1.96474023243783
-"2261","Elphicke, Charlie","received",1.6572798417963
-"2262","Elphicke, Charlie","act",1.55786218121204
-"2263","Elphicke, Charlie","will",1.01920168406233
-"2264","Elphicke, Charlie","convict",0
-"2265","Elphicke, Charlie","five",0
-"2266","Elphicke, Charlie","person",0
-"2267","Elphicke, Charlie","rape",0
-"2268","Elphicke, Charlie","year",0
-"2269","Esterson, Bill","james",10.6032178883612
-"2270","Esterson, Bill","thompson",10.2127864930934
-"2271","Esterson, Bill","unemployed",8.99843503390181
-"2272","Esterson, Bill","classed",8.339361272484
-"2273","Esterson, Bill","commission",8.2827894370734
-"2274","Esterson, Bill","criminal",8.16065163420763
-"2275","Esterson, Bill","week",8.09419470466866
-"2276","Esterson, Bill","hours",7.96674969574544
-"2277","Esterson, Bill","cells",7.93614319713163
-"2278","Esterson, Bill","per",7.80404083095993
-"2279","Esterson, Bill","spent",6.53339177699389
-"2280","Esterson, Bill","three",5.99227327679603
-"2281","Evans, Chris","internet",6.54911970654705
-"2282","Evans, Chris","dangerous",6.50419106995516
-"2283","Evans, Chris","bringing",6.215686463526
-"2284","Evans, Chris","legislative",6.12065933622543
-"2285","Evans, Chris","proposals",5.10099538342316
-"2286","Evans, Chris","drive",5.08649301312725
-"2287","Evans, Chris","death",4.81591601100754
-"2288","Evans, Chris","reoffending",4.22009860920581
-"2289","Evans, Chris","trolling",4.1918794459622
-"2290","Evans, Chris","porn",3.95214184287518
-"2291","Evans, Chris","rate",3.76843054704939
-"2292","Evans, Chris","revenge",3.75715434263479
-"2293","Evans, Graham","complex",2.51226765164198
-"2294","Evans, Graham","disputes",2.21410638215638
-"2295","Evans, Graham","skilled",2.1716251317958
-"2296","Evans, Graham","relevantly",2.06786575697609
-"2297","Evans, Graham","judiciary",1.99961113337449
-"2298","Evans, Graham","proceedings",1.54955351146843
-"2299","Evans, Graham","planning",1.44490248289367
-"2300","Evans, Graham","increase",1.4422406718438
-"2301","Evans, Graham","potential",1.4422406718438
-"2302","Evans, Graham","provision",1.40212450379549
-"2303","Evans, Graham","management",1.39975942148322
-"2304","Evans, Graham","members",1.30676722713648
-"2305","Evans, Jonathan","alternative",3.42469510436916
-"2306","Evans, Jonathan","dispute",3.13121927418238
-"2307","Evans, Jonathan","resolution",3.13121927418238
-"2308","Evans, Jonathan","awareness",2.76197019216753
-"2309","Evans, Jonathan","raise",2.59255877883951
-"2310","Evans, Jonathan","public",1.50097582298471
-"2311","Evans, Jonathan","services",1.23393786031977
-"2312","Evans, Jonathan","will",0.953375877446062
-"2313","Evans, Jonathan","convict",0
-"2314","Evans, Jonathan","five",0
-"2315","Evans, Jonathan","person",0
-"2316","Evans, Jonathan","rape",0
-"2317","Evans, Nigel","wrongfully",6.61877412151497
-"2318","Evans, Nigel","english",6.03010125026641
-"2319","Evans, Nigel","terrorism",5.31072525082514
-"2320","Evans, Nigel","recalled",4.98707717473703
-"2321","Evans, Nigel","limb",4.0655587238791
-"2322","Evans, Nigel","repetitive",4.0655587238791
-"2323","Evans, Nigel","strain",4.0655587238791
-"2324","Evans, Nigel","people",3.97615624368488
-"2325","Evans, Nigel","compensation",3.75524411795945
-"2326","Evans, Nigel","population",3.63573151395219
-"2327","Evans, Nigel","capacity",3.62085784225516
-"2328","Evans, Nigel","released",3.41527836237301
-"2329","Fabricant, Michael","meals",3.56434957305558
-"2330","Fabricant, Michael","served",3.18872327604643
-"2331","Fabricant, Michael","soldiers",3.04104746457308
-"2332","Fabricant, Michael","daily",2.97159039142941
-"2333","Fabricant, Michael","vexatious",2.96511597206594
-"2334","Fabricant, Michael","minimised",2.90091680990377
-"2335","Fabricant, Michael","overseas",2.55662983150491
-"2336","Fabricant, Michael","defence",2.40549051337143
-"2337","Fabricant, Michael","ways",2.33871258021393
-"2338","Fabricant, Michael","remand",2.25423123461042
-"2339","Fabricant, Michael","can",2.15470241208555
-"2340","Fabricant, Michael","discuss",2.02752005996842
-"2341","Farrelly, Paul","yet",3.38260625463544
-"2342","Farrelly, Paul","war",2.79458629730814
-"2343","Farrelly, Paul","implemented",2.33733237163766
-"2344","Farrelly, Paul","armed",2.24730259686733
-"2345","Farrelly, Paul","crime",2.03678250333142
-"2346","Farrelly, Paul","complainants",2.01160033647182
-"2347","Farrelly, Paul","favour",2.01160033647182
-"2348","Farrelly, Paul","sections",1.99527320595587
-"2349","Farrelly, Paul","pensions",1.90955082551733
-"2350","Farrelly, Paul","quarter",1.80240862399988
-"2351","Farrelly, Paul","took",1.61080285123965
-"2352","Farrelly, Paul","2013",1.56819969405029
-"2353","Farron, Tim","five",15.0379427713356
-"2354","Farron, Tim","people",12.6960283500794
-"2355","Farron, Tim","year",10.7679595017294
-"2356","Farron, Tim","guards",8.53546031630048
-"2357","Farron, Tim","disqualified",8.38661444340947
-"2358","Farron, Tim","prison",8.32742335671251
-"2359","Farron, Tim","transsexual",8.24527655384718
-"2360","Farron, Tim","possession",7.7269300226452
-"2361","Farron, Tim","gender",7.41848776203476
-"2362","Farron, Tim","explicit",7.32150391569037
-"2363","Farron, Tim","fire",7.07060808900175
-"2364","Farron, Tim","workers",6.93055699932485
-"2365","Fernandes, Suella","college",3.46284409553132
-"2366","Fernandes, Suella","progress",3.14328496014729
-"2367","Fernandes, Suella","secure",2.40057154656217
-"2368","Fernandes, Suella","made",1.43103604588334
-"2369","Fernandes, Suella","convict",0
-"2370","Fernandes, Suella","five",0
-"2371","Fernandes, Suella","person",0
-"2372","Fernandes, Suella","rape",0
-"2373","Fernandes, Suella","year",0
-"2374","Fernandes, Suella","offenc",0
-"2375","Fernandes, Suella","sexual",0
-"2376","Fernandes, Suella","agreement",0
-"2377","Ferrier, Margaret","129",7.76362524892973
-"2378","Ferrier, Margaret","oral",7.71798930990443
-"2379","Ferrier, Margaret","parliamentary",7.63206763072292
-"2380","Ferrier, Margaret","contribution",7.11411112277113
-"2381","Ferrier, Margaret","2016",6.91890329270209
-"2382","Ferrier, Margaret","official",5.07882697401704
-"2383","Ferrier, Margaret","report",4.21851631811548
-"2384","Ferrier, Margaret","1998",4.08249623844148
-"2385","Ferrier, Margaret","shoplifting",3.83832605536893
-"2386","Ferrier, Margaret","employ",3.72188056734512
-"2387","Ferrier, Margaret","50967",3.71133036988416
-"2388","Ferrier, Margaret","july",3.65996141593421
-"2389","Field, Frank","outsource",13.4609639747647
-"2390","Field, Frank","income",12.8130683629519
-"2391","Field, Frank","low",8.93726132507474
-"2392","Field, Frank","wage",8.55788876767085
-"2393","Field, Frank","direct",8.39732350687769
-"2394","Field, Frank","birkenhead",8.00912846449611
-"2395","Field, Frank","people",7.99275504380798
-"2396","Field, Frank","less",7.81365845473446
-"2397","Field, Frank","liverpool",7.55907463362241
-"2398","Field, Frank","foundation",7.43980304202609
-"2399","Field, Frank","call",7.36314094974792
-"2400","Field, Frank","employed",7.32787573715115
-"2401","Field, Mark","traffickers",4.0449829724651
-"2402","Field, Mark","human",2.90705815711288
-"2403","Field, Mark","orders",2.42027623722724
-"2404","Field, Mark","victim",2.18408064977124
-"2405","Field, Mark","august",2.06991966946267
-"2406","Field, Mark","convicted",1.98173457947083
-"2407","Field, Mark","confiscation",1.90212450379549
-"2408","Field, Mark","money",1.87471838100186
-"2409","Field, Mark","awarded",1.58321589314213
-"2410","Field, Mark","purse",1.5636355645199
-"2411","Field, Mark","value",1.53212626851558
-"2412","Field, Mark","compensation",1.44007038152496
-"2413","Fitzpatrick, Jim","fraud",15.1519154385989
-"2414","Fitzpatrick, Jim","insurance",9.87776738194865
-"2415","Fitzpatrick, Jim","injury",8.20970914375738
-"2416","Fitzpatrick, Jim","personal",6.5423850138194
-"2417","Fitzpatrick, Jim","20722",5.72814499660718
-"2418","Fitzpatrick, Jim","exaggerated",5.54217644198516
-"2419","Fitzpatrick, Jim","fabricated",5.25838349955417
-"2420","Fitzpatrick, Jim","project",4.61148427847358
-"2421","Fitzpatrick, Jim","reform",4.30338325436452
-"2422","Fitzpatrick, Jim","estimate",4.30137169881145
-"2423","Fitzpatrick, Jim","scale",4.1918794459622
-"2424","Fitzpatrick, Jim","made",4.16525979079402
-"2425","Flello, Robert","fenton",6.33752602284526
-"2426","Flello, Robert","urban",6.33752602284526
-"2427","Flello, Robert","trent",5.80300353902042
-"2428","Flello, Robert","town",5.80300353902042
-"2429","Flello, Robert","vision",5.63092573412822
-"2430","Flello, Robert","stoke",5.63092573412822
-"2431","Flello, Robert","city",4.17570643259917
-"2432","Flello, Robert","discuss",3.75423764842162
-"2433","Flello, Robert","make",3.52453530328396
-"2434","Flello, Robert","council",3.38505796653323
-"2435","Flello, Robert","regulation",3.37395053592368
-"2436","Flello, Robert","introduce",3.13573151395219
-"2437","Fletcher, Colleen","coventry",25.3215488654547
-"2438","Fletcher, Colleen","midlands",22.805572350868
-"2439","Fletcher, Colleen","jobseekers",21.0642038228684
-"2440","Fletcher, Colleen","credits",19.7836112242485
-"2441","Fletcher, Colleen","tax",19.3342300798459
-"2442","Fletcher, Colleen","west",18.7893798851157
-"2443","Fletcher, Colleen","allowance",18.1039626139395
-"2444","Fletcher, Colleen","appellants",17.7894211271128
-"2445","Fletcher, Colleen","income",17.6073635314921
-"2446","Fletcher, Colleen","appeal",17.4147327999478
-"2447","Fletcher, Colleen","support",16.9164143336454
-"2448","Fletcher, Colleen","independence",16.1358970741132
-"2449","Flint, Caroline","prison",8.29198618151041
-"2450","Flint, Caroline","officers",7.50435424203064
-"2451","Flint, Caroline","incidence",7.20069640988115
-"2452","Flint, Caroline","staff",6.56728661055602
-"2453","Flint, Caroline","private",6.28081762932064
-"2454","Flint, Caroline","safety",6.21480708338494
-"2455","Flint, Caroline","violent",5.91840883531259
-"2456","Flint, Caroline","2010",5.67795475657176
-"2457","Flint, Caroline","causes",5.45144202004806
-"2458","Flint, Caroline","run",5.4258672519847
-"2459","Flint, Caroline","increases",4.39480547319832
-"2460","Flint, Caroline","access",4.31993497454006
-"2461","Flynn, Paul","rainsbrook",28.493157339663
-"2462","Flynn, Paul","centre",21.3706211671069
-"2463","Flynn, Paul","secure",19.4909299281396
-"2464","Flynn, Paul","training",18.5784629208325
-"2465","Flynn, Paul","drug",17.8802210874177
-"2466","Flynn, Paul","prison",15.0862196220301
-"2467","Flynn, Paul","contract",13.7391014037113
-"2468","Flynn, Paul","run",12.4334837860886
-"2469","Flynn, Paul","population",10.8586178578396
-"2470","Flynn, Paul","made",10.8564467478631
-"2471","Flynn, Paul","medway",10.0676724744972
-"2472","Flynn, Paul","g4s",9.78810502494782
-"2473","Foster, Kevin","certificate",4.81110550945045
-"2474","Foster, Kevin","declaration",4.75492583232407
-"2475","Foster, Kevin","recognition",4.60774028822616
-"2476","Foster, Kevin","statutory",4.37858758994322
-"2477","Foster, Kevin","dated",4.15230640541991
-"2478","Foster, Kevin","gender",3.73157510637031
-"2479","Foster, Kevin","six",3.46259257018717
-"2480","Foster, Kevin","within",3.22028508309323
-"2481","Foster, Kevin","application",2.93713243852758
-"2482","Foster, Kevin","panel",2.26413643011456
-"2483","Foster, Kevin","states",2.18542331562958
-"2484","Foster, Kevin","months",2.12424842578755
-"2485","Fovargue, Yvonne","directly",5.2074599956297
-"2486","Fovargue, Yvonne","jobseekers",4.89954582923779
-"2487","Fovargue, Yvonne","1300",3.87635814759977
-"2488","Fovargue, Yvonne","allowance",3.55547118240797
-"2489","Fovargue, Yvonne","april",3.54755528870702
-"2490","Fovargue, Yvonne","hindley",3.27795718927577
-"2491","Fovargue, Yvonne","march",3.18819364804398
-"2492","Fovargue, Yvonne","chain",3.09696262832424
-"2493","Fovargue, Yvonne","went",3.02990879034318
-"2494","Fovargue, Yvonne","appeals",2.95308366193765
-"2495","Fovargue, Yvonne","employed",2.80798078962991
-"2496","Fovargue, Yvonne","2012",2.79185020092955
-"2497","Fox, Dr Liam","spread",5.24861374353734
-"2498","Fox, Dr Liam","population",4.78642810728924
-"2499","Fox, Dr Liam","islamic",4.10251589588201
-"2500","Fox, Dr Liam","extremism",3.65363233685082
-"2501","Fox, Dr Liam","prevent",2.78999237932388
-"2502","Fox, Dr Liam","extremists",2.63362435843454
-"2503","Fox, Dr Liam","radicalising",2.31786575697609
-"2504","Fox, Dr Liam","overseas",2.21410638215638
-"2505","Fox, Dr Liam","terrorist",2.21410638215638
-"2506","Fox, Dr Liam","muslim",2.11602702646169
-"2507","Fox, Dr Liam","recruiting",1.82545916923697
-"2508","Fox, Dr Liam","risks",1.81042892112758
-"2509","Foxcroft, Vicky","tagging",8.65206638599957
-"2510","Foxcroft, Vicky","electronic",8.13820619644844
-"2511","Foxcroft, Vicky","offender",7.14846862832907
-"2512","Foxcroft, Vicky","violence",6.72436475558889
-"2513","Foxcroft, Vicky","abuse",5.65733995320207
-"2514","Foxcroft, Vicky","immigration",5.57754244039026
-"2515","Foxcroft, Vicky","live",5.09003700921607
-"2516","Foxcroft, Vicky","make",5.00314578110031
-"2517","Foxcroft, Vicky","incidence",4.88184587445554
-"2518","Foxcroft, Vicky","contact",4.60924598630848
-"2519","Foxcroft, Vicky","rogue",4.54543283655548
-"2520","Foxcroft, Vicky","estimate",4.52770038508589
-"2521","Freer, Mike","division",2.51145226262694
-"2522","Freer, Mike","president",2.28094038323926
-"2523","Freer, Mike","committee",1.95149793852278
-"2524","Freer, Mike","policies",1.943380239358
-"2525","Freer, Mike","evidence",1.64525641290533
-"2526","Freer, Mike","given",1.51978119303064
-"2527","Freer, Mike","december",1.49139820847216
-"2528","Freer, Mike","access",1.47915665750199
-"2529","Freer, Mike","2011",1.44681393115052
-"2530","Freer, Mike","family",1.37247369523216
-"2531","Freer, Mike","aid",1.28753278062342
-"2532","Freer, Mike","legal",1.12297548005066
-"2533","Fuller, Richard","six",8.49083214164476
-"2534","Fuller, Richard","building",8.18463474093529
-"2535","Fuller, Richard","listed",7.09722122513738
-"2536","Fuller, Richard","shire",7.01345775073619
-"2537","Fuller, Richard","closed",6.58404212512324
-"2538","Fuller, Richard","months",6.55654583452613
-"2539","Fuller, Richard","preceding",5.72513706767297
-"2540","Fuller, Richard","three",5.68682672436371
-"2541","Fuller, Richard","bedford",5.63996246293441
-"2542","Fuller, Richard","counted",5.55536825524891
-"2543","Fuller, Richard","fewer",4.88085630848418
-"2544","Fuller, Richard","asylum)",4.75181151272038
-"2545","Garnier, Sir Edward","trafficking",4.59665910905788
-"2546","Garnier, Sir Edward","continuance",3.72656987909899
-"2547","Garnier, Sir Edward","human",3.30353809877978
-"2548","Garnier, Sir Edward","birds",3.03028855770365
-"2549","Garnier, Sir Edward","638",3.03028855770365
-"2550","Garnier, Sir Edward","england",2.79957905597792
-"2551","Garnier, Sir Edward","wales",2.78400276189295
-"2552","Garnier, Sir Edward","will",2.7403710111762
-"2553","Garnier, Sir Edward","consideration",2.68302353552264
-"2554","Garnier, Sir Edward","court",2.56368187545173
-"2555","Garnier, Sir Edward","search",2.51145226262694
-"2556","Garnier, Sir Edward","rspca",2.48300485726285
-"2557","Ghani, Nusrat","attacker",2.12678584630282
-"2558","Ghani, Nusrat","speech",2.08786744673619
-"2559","Ghani, Nusrat","crossexamined",2.06991966946267
-"2560","Ghani, Nusrat","social",1.63157171377893
-"2561","Ghani, Nusrat","2017",1.49984035049494
-"2562","Ghani, Nusrat","abuse",1.45183299982653
-"2563","Ghani, Nusrat","february",1.43150085255322
-"2564","Ghani, Nusrat","domestic",1.39917897119383
-"2565","Ghani, Nusrat","centre",1.37917895962982
-"2566","Ghani, Nusrat","justice",1.35568658566521
-"2567","Ghani, Nusrat","reform",1.35568658566521
-"2568","Ghani, Nusrat","data",1.34231279435367
-"2569","Gibb, Nick","ford",7.84165971879275
-"2570","Gibb, Nick","open",4.64801515390884
-"2571","Gibb, Nick","absconders",3.17590435439377
-"2572","Gibb, Nick","subsidiaries",3.06131590786101
-"2573","Gibb, Nick","failed",2.41818492389736
-"2574","Gibb, Nick","temporary",2.12730924814564
-"2575","Gibb, Nick","return",2.10195715788052
-"2576","Gibb, Nick","departmental",2.06518949825342
-"2577","Gibb, Nick","testing",1.90989561502547
-"2578","Gibb, Nick","executive",1.86227739551569
-"2579","Gibb, Nick","2013",1.85551890116679
-"2580","Gibb, Nick","licence",1.83792570857222
-"2581","Gillan, Cheryl","midlands)",3.03028855770365
-"2582","Gillan, Cheryl","petitioners",2.79458629730814
-"2583","Gillan, Cheryl","rail",2.55888403691262
-"2584","Gillan, Cheryl","select",2.15808655168045
-"2585","Gillan, Cheryl","speed",2.13288639644668
-"2586","Gillan, Cheryl","appearing",1.89718413605117
-"2587","Gillan, Cheryl","committee",1.7210594097955
-"2588","Gillan, Cheryl","high",1.70688875598074
-"2589","Gillan, Cheryl","london",1.6437362938691
-"2590","Gillan, Cheryl","bill",1.54880504722283
-"2591","Gillan, Cheryl","west",1.49267025883082
-"2592","Gillan, Cheryl","decision",1.35726635138996
-"2593","Gilmore, Sheila","pensions",5.39442136342349
-"2594","Gilmore, Sheila","sorting",5.30733472832811
-"2595","Gilmore, Sheila","147",5.30733472832811
-"2596","Gilmore, Sheila","sadler",5.30733472832811
-"2597","Gilmore, Sheila","purpose",5.20191178613496
-"2598","Gilmore, Sheila","january",5.06058956318425
-"2599","Gilmore, Sheila","kevin",5.04548584416387
-"2600","Gilmore, Sheila","visit",4.94922820458637
-"2601","Gilmore, Sheila","interpretation",4.72383378271118
-"2602","Gilmore, Sheila","2014",4.53708589129806
-"2603","Gilmore, Sheila","support",4.43654941919013
-"2604","Gilmore, Sheila","treasury",4.41206748011501
-"2605","Glass, Pat","unemployed",7.91814375214064
-"2606","Glass, Pat","classed",7.33819393125413
-"2607","Glass, Pat","week",7.12246040427227
-"2608","Glass, Pat","hours",7.01031558160645
-"2609","Glass, Pat","cells",6.98338349231972
-"2610","Glass, Pat","per",6.86714044323345
-"2611","Glass, Pat","spent",5.74903692524184
-"2612","Glass, Pat","working",5.30285818630134
-"2613","Glass, Pat","three",5.27288145427751
-"2614","Glass, Pat","2011",5.0698478085526
-"2615","Glass, Pat","overcrowding",4.76724871686908
-"2616","Glass, Pat","proportion",4.72218854137181
-"2617","Glen, John","outstanding",5.61034365919003
-"2618","Glen, John","imposed",5.31263921602989
-"2619","Glen, John","penalties",4.95085277556659
-"2620","Glen, John","financial",4.27256321617122
-"2621","Glen, John","current",4.18236993407183
-"2622","Glen, John","balance",3.83832605536893
-"2623","Glen, John","despatch",3.71133036988416
-"2624","Glen, John","total",3.62040725445897
-"2625","Glen, John","hire",2.84530496609973
-"2626","Glen, John","ministerial",2.58350820134967
-"2627","Glen, John","car",2.46369719538345
-"2628","Glen, John","2007",2.46369719538345
-"2629","Glindon, Mary","insolvency",8.27263850297023
-"2630","Glindon, Mary","punishment",7.35275688913234
-"2631","Glindon, Mary","service",7.03876832037541
-"2632","Glindon, Mary","officer",6.94219631694706
-"2633","Glindon, Mary","commence",6.41409528646848
-"2634","Glindon, Mary","noms",5.85206175594584
-"2635","Glindon, Mary","ordinated",5.68802752857598
-"2636","Glindon, Mary","staff",5.61571844003811
-"2637","Glindon, Mary","2012",5.04907606494421
-"2638","Glindon, Mary","aid",5.04332245812555
-"2639","Glindon, Mary","agreements",5.02504414635059
-"2640","Glindon, Mary","determined",4.92822646902415
-"2641","Godsiff, Roger","benefit",14.2152454498622
-"2642","Godsiff, Roger","tribunal",12.8227921321455
-"2643","Godsiff, Roger","reach",11.1727338547662
-"2644","Godsiff, Roger","disabled",10.3520301860628
-"2645","Godsiff, Roger","concentrix",9.12047402491915
-"2646","Godsiff, Roger","contract",8.73690093023861
-"2647","Godsiff, Roger","appeal",7.43659689612237
-"2648","Godsiff, Roger","collect",7.15099451397486
-"2649","Godsiff, Roger","birmingham",6.86616133990268
-"2650","Godsiff, Roger","fines",6.3590668988839
-"2651","Godsiff, Roger","synnex",6.34300530497638
-"2652","Godsiff, Roger","time",5.75289483051304
-"2653","Goldsmith, Zac","breached",15.5343114902785
-"2654","Goldsmith, Zac","issued",12.5754085251127
-"2655","Goldsmith, Zac","order",11.8712777417331
-"2656","Goldsmith, Zac","resulted",9.9194210320524
-"2657","Goldsmith, Zac","imposition",8.11198595110691
-"2658","Goldsmith, Zac","five",7.9282882669227
-"2659","Goldsmith, Zac","contempt",7.81926494488039
-"2660","Goldsmith, Zac","sequestration",7.14969360604401
-"2661","Goldsmith, Zac","courts",6.88033668601097
-"2662","Goldsmith, Zac","twice",6.50757107527853
-"2663","Goldsmith, Zac","molestation",5.59090256749294
-"2664","Goldsmith, Zac","restraining",5.54597896182733
-"2665","Goodman, Helen","libraries",11.4340555620648
-"2666","Goodman, Helen","probate",10.4398540429488
-"2667","Goodman, Helen","stalking",9.41781483398532
-"2668","Goodman, Helen","book",8.53675284941467
-"2669","Goodman, Helen","prison",6.19236219001313
-"2670","Goodman, Helen","foreign",6.02474216656789
-"2671","Goodman, Helen","help",6.00928356325243
-"2672","Goodman, Helen","serious",5.45476687593102
-"2673","Goodman, Helen","order",5.19616750042781
-"2674","Goodman, Helen","newspapers",5.13573151395219
-"2675","Goodman, Helen","building",5.12250153335803
-"2676","Goodman, Helen","charge",4.96009212740627
-"2677","Gove, Michael","lisbon",2.52779841611991
-"2678","Gove, Michael","triggering",2.52779841611991
-"2679","Gove, Michael","treaty",2.40308399192499
-"2680","Gove, Michael","white",1.86954912664401
-"2681","Gove, Michael","documents",1.85196813501885
-"2682","Gove, Michael","papers",1.71606761931717
-"2683","Gove, Michael","article",1.66553069264827
-"2684","Gove, Michael","assist",1.57013211821826
-"2685","Gove, Michael","make",1.50286690296156
-"2686","Gove, Michael","list",1.48164582605757
-"2687","Gove, Michael","leave",1.47156021377911
-"2688","Gove, Michael","governments",1.45232997629266
-"2689","Graham, Richard","stalking",11.3606040815888
-"2690","Graham, Richard","offences",7.69990352870374
-"2691","Graham, Richard","people",4.91676035799172
-"2692","Graham, Richard","restraining",4.65816733033775
-"2693","Graham, Richard","convicted",4.64001851804385
-"2694","Graham, Richard","orders",4.02884633347388
-"2695","Graham, Richard","hospitalisation",3.71133036988416
-"2696","Graham, Richard","therapeutic",3.71133036988416
-"2697","Graham, Richard","psychological",3.42382100930146
-"2698","Graham, Richard","breaches",3.41577058926626
-"2699","Graham, Richard","motoring",3.28601931495429
-"2700","Graham, Richard","surrender",3.1762704856974
-"2701","Grant, Peter","exemption",6.3622286936724
-"2702","Grant, Peter","individual)",5.30733472832811
-"2703","Grant, Peter","2000",5.17737759342571
-"2704","Grant, Peter","freedom",5.05356960093534
-"2705","Grant, Peter","wholly",5.04548584416387
-"2706","Grant, Peter","endanger",4.85970110422156
-"2707","Grant, Peter","request",4.79016876775989
-"2708","Grant, Peter","application",4.51361790645582
-"2709","Grant, Peter","disclosur",4.20641043963525
-"2710","Grant, Peter","likely",3.85345316464997
-"2711","Grant, Peter","section",3.57414132689762
-"2712","Grant, Peter","information",3.31905114486514
-"2713","Greatrex, Tom","handling",4.20246343337705
-"2714","Greatrex, Tom","share",3.55514009994706
-"2715","Greatrex, Tom","governments",3.04643305919697
-"2716","Greatrex, Tom","data",2.47510249662734
-"2717","Greatrex, Tom","personal",2.00219635834157
-"2718","Greatrex, Tom","convict",0
-"2719","Greatrex, Tom","five",0
-"2720","Greatrex, Tom","rape",0
-"2721","Greatrex, Tom","year",0
-"2722","Greatrex, Tom","offenc",0
-"2723","Greatrex, Tom","sexual",0
-"2724","Greatrex, Tom","agreement",0
-"2725","Green, Damian","submission",3.43310319184542
-"2726","Green, Damian","final",2.93189404102191
-"2727","Green, Damian","papers",2.54533961642677
-"2728","Green, Damian","immigration",2.06638952551378
-"2729","Green, Damian","hearing",2.02812109561414
-"2730","Green, Damian","appeal",1.61324797335805
-"2731","Green, Damian","average",1.5064042122892
-"2732","Green, Damian","time",1.41439864452425
-"2733","Green, Damian","months",1.27839638761931
-"2734","Green, Damian","will",0.852725308031161
-"2735","Green, Damian","convict",0
-"2736","Green, Damian","five",0
-"2737","Green, Kate","women",26.1929534529086
-"2738","Green, Kate","bench",16.5849065105322
-"2739","Green, Kate","recall",16.1238535381
-"2740","Green, Kate","half",13.6287241863966
-"2741","Green, Kate","number",12.8634880299416
-"2742","Green, Kate","community",12.631447279654
-"2743","Green, Kate","member",12.4766195671866
-"2744","Green, Kate","rehabilitation",12.0996141913085
-"2745","Green, Kate","service",11.8738447173206
-"2746","Green, Kate","year",11.8342896264061
-"2747","Green, Kate","sit",11.554321546158
-"2748","Green, Kate","training",11.494248908147
-"2749","Griffith, Nia","welsh",7.12844718726869
-"2750","Griffith, Nia","website",4.14632431625404
-"2751","Griffith, Nia","forms",3.47438573672608
-"2752","Griffith, Nia","cremation",3.30743904943112
-"2753","Griffith, Nia","allow",2.50753448919549
-"2754","Griffith, Nia","application",2.28196056113284
-"2755","Griffith, Nia","departments",2.28147716339386
-"2756","Griffith, Nia","members",2.13394194605068
-"2757","Griffith, Nia","proportion",1.76763127179559
-"2758","Griffith, Nia","public",1.73317759089468
-"2759","Griffith, Nia","convict",0
-"2760","Griffith, Nia","five",0
-"2761","Griffiths, Andrew","deradicalisation",10.9375796995461
-"2762","Griffiths, Andrew","drug",8.16016471404602
-"2763","Griffiths, Andrew","needles",8.0561544297221
-"2764","Griffiths, Andrew","programme",8.03664690644694
-"2765","Griffiths, Andrew","year",7.83919103513883
-"2766","Griffiths, Andrew","neglect",7.63199115780069
-"2767","Griffiths, Andrew","national",6.74187234750849
-"2768","Griffiths, Andrew","visitors",6.2209469478065
-"2769","Griffiths, Andrew","management",5.96214198155447
-"2770","Griffiths, Andrew","prosecuted",5.86294185887318
-"2771","Griffiths, Andrew","four",5.57444483097806
-"2772","Griffiths, Andrew","substance",5.42305157534106
-"2773","Gwynne, Andrew","reuse",10.1427201435076
-"2774","Gwynne, Andrew","graves",8.43179637157995
-"2775","Gwynne, Andrew","freedom",7.85311126692176
-"2776","Gwynne, Andrew","request",7.44379345514295
-"2777","Gwynne, Andrew","ward",6.796947945804
-"2778","Gwynne, Andrew","valuation",6.65327226137734
-"2779","Gwynne, Andrew","admitted",6.54667091688848
-"2780","Gwynne, Andrew","month",6.10211667530482
-"2781","Gwynne, Andrew","respond",5.78145500534438
-"2782","Gwynne, Andrew","2010",5.69846378876602
-"2783","Gwynne, Andrew","recruitment",5.46706722840512
-"2784","Gwynne, Andrew","owned",5.2052265070204
-"2785","Haigh, Louise","contractual",10.8194782939764
-"2786","Haigh, Louise","servants",10.153911669459
-"2787","Haigh, Louise","internships",9.09086567311096
-"2788","Haigh, Louise","limited",8.75839882265022
-"2789","Haigh, Louise","remedies",8.74280603532615
-"2790","Haigh, Louise","civil",8.67629483281357
-"2791","Haigh, Louise","heeley",8.56720973394385
-"2792","Haigh, Louise","sheffield",8.25174817451978
-"2793","Haigh, Louise","pip",8.24527655384718
-"2794","Haigh, Louise","g4s",7.96169713852001
-"2795","Haigh, Louise","payroll",7.75662983294301
-"2796","Haigh, Louise","agreement",7.73418910374076
-"2797","Halfon, Robert","bereaved",3.84983734922377
-"2798","Halfon, Robert","homicide",3.49364665469693
-"2799","Halfon, Robert","assistance",3.2935369167669
-"2800","Halfon, Robert","makes",3.15244021089631
-"2801","Halfon, Robert","families",2.29658775654052
-"2802","Halfon, Robert","convict",0
-"2803","Halfon, Robert","five",0
-"2804","Halfon, Robert","person",0
-"2805","Halfon, Robert","rape",0
-"2806","Halfon, Robert","year",0
-"2807","Halfon, Robert","offenc",0
-"2808","Halfon, Robert","sexual",0
-"2809","Hames, Duncan","type",3.17431544421342
-"2810","Hames, Duncan","aged",2.89516816908388
-"2811","Hames, Duncan","2010",1.70363844162505
-"2812","Hames, Duncan","prison",0.894159526383379
-"2813","Hames, Duncan","convict",0
-"2814","Hames, Duncan","five",0
-"2815","Hames, Duncan","person",0
-"2816","Hames, Duncan","rape",0
-"2817","Hames, Duncan","year",0
-"2818","Hames, Duncan","offenc",0
-"2819","Hames, Duncan","sexual",0
-"2820","Hames, Duncan","agreement",0
-"2821","Hamilton, Fabian","afforded",2.90091680990377
-"2822","Hamilton, Fabian","comparable",2.61224167530896
-"2823","Hamilton, Fabian","disordered",2.50757670884253
-"2824","Hamilton, Fabian","extend",2.35443030159498
-"2825","Hamilton, Fabian","mentally",1.8326918762094
-"2826","Hamilton, Fabian","system",1.6163029575881
-"2827","Hamilton, Fabian","justice",1.61358978717729
-"2828","Hamilton, Fabian","rights",1.50059513934525
-"2829","Hamilton, Fabian","criminal",1.29744512552689
-"2830","Hamilton, Fabian","victims",1.280089689943
-"2831","Hamilton, Fabian","offenders",1.00373705735419
-"2832","Hamilton, Fabian","will",0.77842814427368
-"2833","Hammond, Stephen","general",12.3644292424024
-"2834","Hammond, Stephen","regulation",10.2985315954906
-"2835","Hammond, Stephen","data",8.44665564590298
-"2836","Hammond, Stephen","protection",7.95533447486424
-"2837","Hammond, Stephen","knife",5.21370593674529
-"2838","Hammond, Stephen","implement",4.95775560789576
-"2839","Hammond, Stephen","enact",4.43211716260961
-"2840","Hammond, Stephen","sector",4.20845492814707
-"2841","Hammond, Stephen","london",3.96649629835076
-"2842","Hammond, Stephen","fca",3.43602425333506
-"2843","Hammond, Stephen","crime",3.42106368359872
-"2844","Hammond, Stephen","financial",3.27249694285175
-"2845","Hancock, Mike","portsmouth",4.84036545307348
-"2846","Hancock, Mike","overdoses",4.54543283655548
-"2847","Hancock, Mike","kingston",3.3296672641778
-"2848","Hancock, Mike","sale",3.26535130717057
-"2849","Hancock, Mike","site",3.09085732327292
-"2850","Hancock, Mike","raised",2.99362901770583
-"2851","Hancock, Mike","died",2.96878566766741
-"2852","Hancock, Mike","waiting",2.52933024643765
-"2853","Hancock, Mike","asylum",2.32888228793411
-"2854","Hancock, Mike","drug",2.14324406990666
-"2855","Hancock, Mike","two",2.09583330445966
-"2856","Hancock, Mike","one",2.04413046560326
-"2857","Hanson, David","2010",51.6482055556194
-"2858","Hanson, David","year",39.207847583305
-"2859","Hanson, David","prison",22.7810296705821
-"2860","Hanson, David","wales",22.0438452290348
-"2861","Hanson, David","offender",21.5979210540104
-"2862","Hanson, David","immediate",20.0490942583037
-"2863","Hanson, David","absconded",19.6173379372487
-"2864","Hanson, David","police",19.3544425881744
-"2865","Hanson, David","sentence",16.8706882281961
-"2866","Hanson, David","force",16.0750680130835
-"2867","Hanson, David","hostel",15.0009290116801
-"2868","Hanson, David","bail",14.3496151755286
-"2869","Harman, Harriet","history",15.052738101006
-"2870","Harman, Harriet","right",14.2379518577568
-"2871","Harman, Harriet","rape",12.6419719186216
-"2872","Harman, Harriet","complainants",12.4466589758056
-"2873","Harman, Harriet","previous",10.7914805818591
-"2874","Harman, Harriet","evidence",10.5673208408267
-"2875","Harman, Harriet","1999",10.2820105242804
-"2876","Harman, Harriet","sexual",9.76140578978141
-"2877","Harman, Harriet","subsection",9.6321853656226
-"2878","Harman, Harriet","proposal",8.05530578510417
-"2879","Harman, Harriet","bill",7.69977588060967
-"2880","Harman, Harriet","use",7.06122958879419
-"2881","Harrington, Richard","exercised",2.84530496609973
-"2882","Harrington, Richard","lasting",2.71267848175249
-"2883","Harrington, Richard","attorney",2.48505932319183
-"2884","Harrington, Richard","awareness",2.25513921852908
-"2885","Harrington, Richard","raise",2.11681537877662
-"2886","Harrington, Richard","power",2.02752005996842
-"2887","Harrington, Richard","bodies",1.91322529603858
-"2888","Harrington, Richard","may",1.45568603281517
-"2889","Harrington, Richard","communities",1.42880766297041
-"2890","Harrington, Richard","companies",1.38129988599616
-"2891","Harrington, Richard","public",1.22554162752219
-"2892","Harrington, Richard","will",0.77842814427368
-"2893","Harris, Carolyn","establishment",8.10267945096529
-"2894","Harris, Carolyn","autonomy",7.53644634553629
-"2895","Harris, Carolyn","999",7.23761701908369
-"2896","Harris, Carolyn","plus",6.84279973416052
-"2897","Harris, Carolyn","january",6.67133066480003
-"2898","Harris, Carolyn","regardless",5.63573151395219
-"2899","Harris, Carolyn","governors",5.45386962845809
-"2900","Harris, Carolyn","calls",4.95344051594896
-"2901","Harris, Carolyn","prison",4.74378190690581
-"2902","Harris, Carolyn","society",4.68185678520046
-"2903","Harris, Carolyn","grades",4.6482500099925
-"2904","Harris, Carolyn","justice",4.34510641568197
-"2905","Harris, Rebecca","leigh",4.10334315369087
-"2906","Harris, Rebecca","day",2.3011388781657
-"2907","Harris, Rebecca","paid",2.1569216975365
-"2908","Harris, Rebecca","claims",1.87531146429675
-"2909","Harris, Rebecca","aid",1.82084632035759
-"2910","Harris, Rebecca","legal",1.58812715410008
-"2911","Harris, Rebecca","2013",1.56819969405029
-"2912","Harris, Rebecca","convict",0
-"2913","Harris, Rebecca","five",0
-"2914","Harris, Rebecca","person",0
-"2915","Harris, Rebecca","rape",0
-"2916","Harris, Rebecca","year",0
-"2917","Hayes, Helen","beneficial",9.94460464692715
-"2918","Hayes, Helen","ownership",9.09796287544843
-"2919","Hayes, Helen","dependencies",8.41007880508194
-"2920","Hayes, Helen","central",8.19476335287659
-"2921","Hayes, Helen","leaders",6.57095035241702
-"2922","Hayes, Helen","registers",6.47372278259308
-"2923","Hayes, Helen","crown",5.51527850840869
-"2924","Hayes, Helen","accessible",5.35837871863402
-"2925","Hayes, Helen","nine",2.90091680990377
-"2926","Hayes, Helen","proposed",2.87705001830618
-"2927","Hayes, Helen","adopted",2.87475914111963
-"2928","Hayes, Helen","publicly",2.83026715421212
-"2929","Hayman, Sue","manorial",5.74956828593407
-"2930","Hayman, Sue","cumbria",4.49408099739619
-"2931","Hayman, Sue","feudal",4.0655587238791
-"2932","Hayman, Sue","tenure",3.74933095786226
-"2933","Hayman, Sue","rights",3.51726408378396
-"2934","Hayman, Sue","supreme",3.42469510436916
-"2935","Hayman, Sue","royal",3.27795718927577
-"2936","Hayman, Sue","abolish",3.17779514846045
-"2937","Hayman, Sue","legislation",3.13630485784933
-"2938","Hayman, Sue","7ws",2.94946629760185
-"2939","Hayman, Sue","land",2.86156738244361
-"2940","Hayman, Sue","purse",2.2793709394462
-"2941","Heald, Sir Oliver","paperless",5.74956828593407
-"2942","Heald, Sir Oliver","progress",2.81143953741682
-"2943","Heald, Sir Oliver","working",1.98499019636359
-"2944","Heald, Sir Oliver","made",1.27995755073906
-"2945","Heald, Sir Oliver","courts",1.2736629365532
-"2946","Heald, Sir Oliver","convict",0
-"2947","Heald, Sir Oliver","five",0
-"2948","Heald, Sir Oliver","person",0
-"2949","Heald, Sir Oliver","rape",0
-"2950","Heald, Sir Oliver","year",0
-"2951","Heald, Sir Oliver","offenc",0
-"2952","Heald, Sir Oliver","sexual",0
-"2953","Healey, John","must",7.11046993519059
-"2954","Healey, John","mark",6.87822955216921
-"2955","Healey, John","exceeded",6.77903388851131
-"2956","Healey, John","met",5.51656028874891
-"2957","Healey, John","performance",5.03091820755412
-"2958","Healey, John","civil",4.26632214775465
-"2959","Healey, John","management",4.03917109871134
-"2960","Healey, John","system",4.03917109871134
-"2961","Healey, John","officials",3.72960726819107
-"2962","Healey, John","service",3.52528235304966
-"2963","Healey, John","received",3.16317869922793
-"2964","Healey, John","employment",3.09235091918736
-"2965","Heaton-Harris, Chris","stillbirth",8.23063858456235
-"2966","Heaton-Harris, Chris","coroner",4.57880205259924
-"2967","Heaton-Harris, Chris","coronial",4.4813076267001
-"2968","Heaton-Harris, Chris","neonatal",4.28547517620851
-"2969","Heaton-Harris, Chris","perinatal",4.0655587238791
-"2970","Heaton-Harris, Chris","lorry",4.0655587238791
-"2971","Heaton-Harris, Chris","retrieve",4.0655587238791
-"2972","Heaton-Harris, Chris","deaths",4.00774326684498
-"2973","Heaton-Harris, Chris","balance",3.43310319184542
-"2974","Heaton-Harris, Chris","jurisdictions",3.42022720303473
-"2975","Heaton-Harris, Chris","consistency",3.22883350906107
-"2976","Heaton-Harris, Chris","conclusions",3.14952638886365
-"2977","Hemming, John","contempt",21.5928173268159
-"2978","Hemming, John","yardley",19.8328438674155
-"2979","Hemming, John","birmingham",19.2025880995769
-"2980","Hemming, John","committal",17.0353685672133
-"2981","Hemming, John","analysis",16.2241912200288
-"2982","Hemming, John","name",14.5000041393791
-"2983","Hemming, John","team",13.1820935386102
-"2984","Hemming, John","letter",12.6871511429431
-"2985","Hemming, John","performance",12.6424424640262
-"2986","Hemming, John","judge",12.6138432990582
-"2987","Hemming, John","sent",12.5984852271567
-"2988","Hemming, John","february",12.5663226841391
-"2989","Henderson, Gordon","kent",3.51149914457939
-"2990","Henderson, Gordon","deportation",3.09048767596813
-"2991","Henderson, Gordon","stalking",3.04226273002551
-"2992","Henderson, Gordon","awaiting",2.95214184287518
-"2993","Henderson, Gordon","guidelines",2.8757419427
-"2994","Henderson, Gordon","sentence",2.48405883751426
-"2995","Henderson, Gordon","foreign",2.25632089579173
-"2996","Henderson, Gordon","completed",2.17219184191364
-"2997","Henderson, Gordon","officers",2.01392746036401
-"2998","Henderson, Gordon","employed",1.91701234641691
-"2999","Henderson, Gordon","system",1.86634589531096
-"3000","Henderson, Gordon","england",1.81804072191759
-"3001","Hendrick, Mark","lancashire",40.5612256150699
-"3002","Hendrick, Mark","magistrates",37.1324812387165
-"3003","Hendrick, Mark","court",30.2910115075777
-"3004","Hendrick, Mark","preston",30.161305139401
-"3005","Hendrick, Mark","2014",25.2251317649051
-"3006","Hendrick, Mark","people",20.0069861310059
-"3007","Hendrick, Mark","crown",18.2804059824287
-"3008","Hendrick, Mark","2013",15.6370858122379
-"3009","Hendrick, Mark","convicted",15.5336490345536
-"3010","Hendrick, Mark","2011",14.3010072907857
-"3011","Hendrick, Mark","west",13.1722296598022
-"3012","Hendrick, Mark","cost",12.9415247006434
-"3013","Hepburn, Stephen","jarrow",6.71343734001864
-"3014","Hepburn, Stephen","tyneside",6.71343734001864
-"3015","Hepburn, Stephen","east",4.50124740599504
-"3016","Hepburn, Stephen","south",4.47446159679626
-"3017","Hepburn, Stephen","constituency",3.66015749206495
-"3018","Hepburn, Stephen","north",3.62215557087595
-"3019","Hepburn, Stephen","repossessed",3.43310319184542
-"3020","Hepburn, Stephen","1997",2.56193127140856
-"3021","Hepburn, Stephen","homes",2.01265452191727
-"3022","Hepburn, Stephen","allowance",1.53554500273985
-"3023","Hepburn, Stephen","successful",1.46693521046334
-"3024","Hepburn, Stephen","independence",1.45851442889927
-"3025","Herbert, Nick","unimplemented",4.0655587238791
-"3026","Herbert, Nick","judgements",3.17779514846045
-"3027","Herbert, Nick","europe",2.97159039142941
-"3028","Herbert, Nick","european",2.0229070933789
-"3029","Herbert, Nick","council",2.00262730004275
-"3030","Herbert, Nick","human",1.86644876020292
-"3031","Herbert, Nick","member",1.65294432376555
-"3032","Herbert, Nick","rights",1.643819615004
-"3033","Herbert, Nick","court",0.900615699382737
-"3034","Herbert, Nick","years",0.591980613658294
-"3035","Herbert, Nick","convict",0
-"3036","Herbert, Nick","five",0
-"3037","Hillier, Meg","hearing",11.1838475786084
-"3038","Hillier, Meg","tier",7.78334035730273
-"3039","Hillier, Meg","immigration",7.27223733919843
-"3040","Hillier, Meg","chamber",6.81753935559006
-"3041","Hillier, Meg","first",6.79455452680267
-"3042","Hillier, Meg","appeal",6.16395249151965
-"3043","Hillier, Meg","asylum",6.07005825026231
-"3044","Hillier, Meg","tribunal",6.06426026003975
-"3045","Hillier, Meg","time",5.40418224159909
-"3046","Hillier, Meg","upper",4.8462206044191
-"3047","Hillier, Meg","submission",3.83832605536893
-"3048","Hillier, Meg","london",3.73480214832391
-"3049","Hilling, Julie","girls",3.9816657709599
-"3050","Hilling, Julie","youth",2.18854142260176
-"3051","Hilling, Julie","potential",2.18046294194366
-"3052","Hilling, Julie","young",1.95404797866737
-"3053","Hilling, Julie","children",1.83555631563551
-"3054","Hilling, Julie","custody",1.7347204813758
-"3055","Hilling, Julie","made",1.08176156987901
-"3056","Hilling, Julie","convict",0
-"3057","Hilling, Julie","five",0
-"3058","Hilling, Julie","person",0
-"3059","Hilling, Julie","rape",0
-"3060","Hilling, Julie","year",0
-"3061","Hodge, Margaret","barking",6.48397114315036
-"3062","Hodge, Margaret","dagenham",6.48397114315036
-"3063","Hodge, Margaret","kpmg",5.7813664715923
-"3064","Hodge, Margaret","deloitte",5.49613020197267
-"3065","Hodge, Margaret","ernst",5.49613020197267
-"3066","Hodge, Margaret","pwc",5.49613020197267
-"3067","Hodge, Margaret","borough",5.39022309446641
-"3068","Hodge, Margaret","list",3.99199811068805
-"3069","Hodge, Margaret","london",3.81378048932048
-"3070","Hodge, Margaret","firms",3.72877545307478
-"3071","Hodge, Margaret","secondees",3.31951479760817
-"3072","Hodge, Margaret","civil",3.23416432090494
-"3073","Hodgson, Sharon","white",13.0630970024813
-"3074","Hodgson, Sharon","departments",10.5709840121525
-"3075","Hodgson, Sharon","members",10.3995787454141
-"3076","Hodgson, Sharon","british",10.3171766004938
-"3077","Hodgson, Sharon","marriages",9.77479211136698
-"3078","Hodgson, Sharon","executive",8.72010651389793
-"3079","Hodgson, Sharon","proportion",8.64919347357779
-"3080","Hodgson, Sharon","satisfaction",8.29460894229344
-"3081","Hodgson, Sharon","inciting",7.96333154191981
-"3082","Hodgson, Sharon","hatred",7.96333154191981
-"3083","Hodgson, Sharon","formal",7.84479518736608
-"3084","Hodgson, Sharon","board",7.52862143860573
-"3085","Hoey, Kate","paralegal",15.9170974526022
-"3086","Hoey, Kate","mercy",12.0230610341602
-"3087","Hoey, Kate","prerogative",12.0230610341602
-"3088","Hoey, Kate","royal",11.0927040145979
-"3089","Hoey, Kate","britain",10.6037604073107
-"3090","Hoey, Kate","great",10.6037604073107
-"3091","Hoey, Kate","survivors",9.52793830765455
-"3092","Hoey, Kate","patent",9.33851643334332
-"3093","Hoey, Kate","terrorism",9.03367161904374
-"3094","Hoey, Kate","brixton",8.85716531230866
-"3095","Hoey, Kate","profession",8.62434824672124
-"3096","Hoey, Kate","list",8.4477596787323
-"3097","Hollern, Kate","blackburn",12.0313704677059
-"3098","Hollern, Kate","overturned",10.3348756351079
-"3099","Hollern, Kate","dismissed",9.66679435262049
-"3100","Hollern, Kate","consideration",9.19278313915513
-"3101","Hollern, Kate","mandatory",8.8251114777479
-"3102","Hollern, Kate","lancashire",8.77869457223285
-"3103","Hollern, Kate","refused",7.85662057418034
-"3104","Hollern, Kate","constituency",7.38260936071498
-"3105","Hollern, Kate","local",6.93828707984582
-"3106","Hollern, Kate","authorities",6.70150278367623
-"3107","Hollern, Kate","applications",6.38388474320053
-"3108","Hollern, Kate","2011",6.18269720660946
-"3109","Hollingbery, George","support",2.21619323317072
-"3110","Hollingbery, George","victims",1.98310642032042
-"3111","Hollingbery, George","five",1.66682880358941
-"3112","Hollingbery, George","made",1.27995755073906
-"3113","Hollingbery, George","years",0.837187012497507
-"3114","Hollingbery, George","convict",0
-"3115","Hollingbery, George","person",0
-"3116","Hollingbery, George","rape",0
-"3117","Hollingbery, George","offenc",0
-"3118","Hollingbery, George","sexual",0
-"3119","Hollingbery, George","agreement",0
-"3120","Hollingbery, George","becom",0
-"3121","Hollinrake, Kevin","guardianship",5.24788201790788
-"3122","Hollinrake, Kevin","legislation",4.78964822062336
-"3123","Hollinrake, Kevin","missing",4.55597706316112
-"3124","Hollinrake, Kevin","proposals",3.99172247947518
-"3125","Hollinrake, Kevin","address",3.47438573672608
-"3126","Hollinrake, Kevin","needs",3.20025414365343
-"3127","Hollinrake, Kevin","families",2.90672428658086
-"3128","Hollinrake, Kevin","landlords",2.74516396509527
-"3129","Hollinrake, Kevin","eviction",2.68572709037698
-"3130","Hollinrake, Kevin","women",2.52977693017819
-"3131","Hollinrake, Kevin","affairs",2.50757670884253
-"3132","Hollinrake, Kevin","system",2.50396577486581
-"3133","Hollobone, Philip","foreign",27.1867050965525
-"3134","Hollobone, Philip","national",19.0903923467856
-"3135","Hollobone, Philip","countries",12.998143590499
-"3136","Hollobone, Philip","offenders",11.6865720876398
-"3137","Hollobone, Philip","return",11.4346783551283
-"3138","Hollobone, Philip","compulsory",11.0904442418211
-"3139","Hollobone, Philip","transfer",9.28455910298514
-"3140","Hollobone, Philip","agreements",8.027874400026
-"3141","Hollobone, Philip","largest",7.51966007803516
-"3142","Hollobone, Philip","prison",7.18256325992081
-"3143","Hollobone, Philip","detention",5.99823586488234
-"3144","Hollobone, Philip","507w",5.24861374353734
-"3145","Hopkins, Kelvin","electronic",12.8029066685629
-"3146","Hopkins, Kelvin","monitoring",9.87163530855181
-"3147","Hopkins, Kelvin","agenda",8.15223593344098
-"3148","Hopkins, Kelvin","transforming",7.94366092842604
-"3149","Hopkins, Kelvin","introduction",7.31497506383593
-"3150","Hopkins, Kelvin","homicide",7.09526417251683
-"3151","Hopkins, Kelvin","following",6.61781506142319
-"3152","Hopkins, Kelvin","reoffending",6.57102330976328
-"3153","Hopkins, Kelvin","technology",6.36612967598153
-"3154","Hopkins, Kelvin","introduce",5.44072356979878
-"3155","Hopkins, Kelvin","rehabilitation",5.40986134196452
-"3156","Hopkins, Kelvin","tagging",5.39948070959441
-"3157","Horwood, Martin","programme",5.30250181186118
-"3158","Horwood, Martin","transforming",4.54293950699337
-"3159","Horwood, Martin","rehabilitation",4.44551916968309
-"3160","Horwood, Martin","successor",3.56573088174181
-"3161","Horwood, Martin","shortage",3.48477266477566
-"3162","Horwood, Martin","mutuals",3.27333545844424
-"3163","Horwood, Martin","become",2.98317831100567
-"3164","Horwood, Martin","indicated",2.83330026878961
-"3165","Horwood, Martin","work",2.81780445529242
-"3166","Horwood, Martin","withdrawn",2.79545128374647
-"3167","Horwood, Martin","signed",2.64984497767234
-"3168","Horwood, Martin","interventions",2.59465887360667
-"3169","Howarth, George","insurance",7.15871550851781
-"3170","Howarth, George","billion",5.6868858266447
-"3171","Howarth, George","save",5.0741746043649
-"3172","Howarth, George","injury",4.70382010435823
-"3173","Howarth, George","whiplash",3.90932842747095
-"3174","Howarth, George","reform",3.81725309358936
-"3175","Howarth, George","claims",3.78789658766637
-"3176","Howarth, George","genuine",3.74933095786226
-"3177","Howarth, George","personal",3.74851308610077
-"3178","Howarth, George","fraudulent",2.93189404102191
-"3179","Howarth, George","vow",2.87478414296704
-"3180","Howarth, George","comes",2.83009143875762
-"3181","Howell, John","gambling",5.24861374353734
-"3182","Howell, John","education",3.57854054788012
-"3183","Howell, John","problems",3.28601931495429
-"3184","Howell, John","help",3.24538404638696
-"3185","Howell, John","programmes",2.42399965496672
-"3186","Howell, John","prison",1.76256468260781
-"3187","Howell, John","will",1.55685628854736
-"3188","Howell, John","service",1.42482871163778
-"3189","Howell, John","convict",0
-"3190","Howell, John","five",0
-"3191","Howell, John","person",0
-"3192","Howell, John","rape",0
-"3193","Howlett, Ben","intersex",4.28547517620851
-"3194","Howlett, Ben","bias",3.95214184287518
-"3195","Howlett, Ben","charge",3.47041521612069
-"3196","Howlett, Ben","court",3.32897372211154
-"3197","Howlett, Ben","unsold",3.31951479760817
-"3198","Howlett, Ben","will",2.75107867201082
-"3199","Howlett, Ben","sold",2.65208034988392
-"3200","Howlett, Ben","criminal",2.59489025105377
-"3201","Howlett, Ben","people",2.39281143781709
-"3202","Howlett, Ben","gender",2.36717934215402
-"3203","Howlett, Ben","receipt",2.36406537080784
-"3204","Howlett, Ben","make",2.34969020218931
-"3205","Huddleston, Nigel","just",4.23205405292339
-"3206","Huddleston, Nigel","solutions",4.07799290524222
-"3207","Huddleston, Nigel","international",3.97476746650851
-"3208","Huddleston, Nigel","future",3.43957280256281
-"3209","Huddleston, Nigel","convict",0
-"3210","Huddleston, Nigel","five",0
-"3211","Huddleston, Nigel","person",0
-"3212","Huddleston, Nigel","rape",0
-"3213","Huddleston, Nigel","year",0
-"3214","Huddleston, Nigel","offenc",0
-"3215","Huddleston, Nigel","sexual",0
-"3216","Huddleston, Nigel","agreement",0
-"3217","Hunt, Tristram","abolished",6.86689055136285
-"3218","Hunt, Tristram","relocated",6.42130314514237
-"3219","Hunt, Tristram","jobs",5.46562416993857
-"3220","Hunt, Tristram","trent",5.04951886677335
-"3221","Hunt, Tristram","stoke",4.89978431698144
-"3222","Hunt, Tristram","2020",4.26796164029886
-"3223","Hunt, Tristram","ministerial",4.00611275613461
-"3224","Hunt, Tristram","advisory",3.73006992017433
-"3225","Hunt, Tristram","statutory",3.73006992017433
-"3226","Hunt, Tristram","departmental",3.58037271374495
-"3227","Hunt, Tristram","accountable",3.42304186276409
-"3228","Hunt, Tristram","executive",3.2285885522696
-"3229","Huppert, Dr Julian","guardianship",4.14632431625404
-"3230","Huppert, Dr Julian","launch",3.81674328312721
-"3231","Huppert, Dr Julian","private",3.74028574263235
-"3232","Huppert, Dr Julian","missing",3.59965380639627
-"3233","Huppert, Dr Julian","fund",3.36785357919879
-"3234","Huppert, Dr Julian","contractors",2.86156738244361
-"3235","Huppert, Dr Julian","longer",2.80064765981174
-"3236","Huppert, Dr Julian","people",2.65949414700761
-"3237","Huppert, Dr Julian","consultation",2.47510249662734
-"3238","Huppert, Dr Julian","enable",2.38261729153062
-"3239","Huppert, Dr Julian","sector",2.28081468926633
-"3240","Huppert, Dr Julian","2014",2.26438125180991
-"3241","Huq, Dr Rupa","fraud",5.11242902624509
-"3242","Huq, Dr Rupa","benefit",4.87568384466262
-"3243","Huq, Dr Rupa","model",3.79819167604396
-"3244","Huq, Dr Rupa","overturned",3.42022720303473
-"3245","Huq, Dr Rupa","house",2.82116768671028
-"3246","Huq, Dr Rupa","convictions",2.79310712758443
-"3247","Huq, Dr Rupa","2014",2.48541725320677
-"3248","Huq, Dr Rupa","2010",2.36530516856514
-"3249","Huq, Dr Rupa","health",2.3320124516766
-"3250","Huq, Dr Rupa","abuse",2.2625183190908
-"3251","Huq, Dr Rupa","potential",2.18046294194366
-"3252","Huq, Dr Rupa","conducted",2.14053394887999
-"3253","Hussain, Imran","bradford",9.09024840045826
-"3254","Hussain, Imran","humber",9.09024840045826
-"3255","Hussain, Imran","discount",7.37919238516902
-"3256","Hussain, Imran","yorkshire",7.03534121798697
-"3257","Hussain, Imran","2008",6.60573830482494
-"3258","Hussain, Imran","brought",6.19362587914656
-"3259","Hussain, Imran","motor",6.13179551903103
-"3260","Hussain, Imran","insurance",5.14056238014058
-"3261","Hussain, Imran","invasive",4.6015555121686
-"3262","Hussain, Imran","rate",4.47005483733151
-"3263","Hussain, Imran","olds",4.46126780918538
-"3264","Hussain, Imran","potential",4.39480547319832
-"3265","Irranca-Davies, Huw","ogmore",4.54543283655548
-"3266","Irranca-Davies, Huw","recently",3.79819167604396
-"3267","Irranca-Davies, Huw","books",2.77156191585442
-"3268","Irranca-Davies, Huw","rules",2.63584201965588
-"3269","Irranca-Davies, Huw","governing",2.57470586172593
-"3270","Irranca-Davies, Huw","provision",2.11981299668154
-"3271","Irranca-Davies, Huw","successful",2.07455966975989
-"3272","Irranca-Davies, Huw","independence",2.0626508862662
-"3273","Irranca-Davies, Huw","reason",2.0461038836634
-"3274","Irranca-Davies, Huw","payment",1.86374362690268
-"3275","Irranca-Davies, Huw","appeals",1.80366606649618
-"3276","Irranca-Davies, Huw","personal",1.5828752038135
-"3277","Jackson, Stewart","education",4.38279918308302
-"3278","Jackson, Stewart","meaningful",3.2883807836292
-"3279","Jackson, Stewart","medical",2.98317831100567
-"3280","Jackson, Stewart","general",2.70051267548735
-"3281","Jackson, Stewart","research",2.64984497767234
-"3282","Jackson, Stewart","encourage",2.48215439173454
-"3283","Jackson, Stewart","regulation",2.24930035728245
-"3284","Jackson, Stewart","enable",2.08969360247652
-"3285","Jackson, Stewart","potential",1.9229875624584
-"3286","Jackson, Stewart","data",1.84483247791272
-"3287","Jackson, Stewart","part",1.78808567676192
-"3288","Jackson, Stewart","prisons",1.760522993878
-"3289","James, Margot","nine",3.17779514846045
-"3290","James, Margot","comply",2.65536262541257
-"3291","James, Margot","wage",2.56193127140856
-"3292","James, Margot","minimum",2.54533961642677
-"3293","James, Margot","employees",2.29943850898823
-"3294","James, Margot","successfully",1.85554257798505
-"3295","James, Margot","legislation",1.81764591523608
-"3296","James, Margot","companies",1.51313821247883
-"3297","James, Margot","tribunal",1.30770501022297
-"3298","James, Margot","years",0.591980613658294
-"3299","James, Margot","convict",0
-"3300","James, Margot","five",0
-"3301","James, Siân C.","english",14.3677342585261
-"3302","James, Siân C.","postcode",10.0567208340992
-"3303","James, Siân C.","welsh",8.75347999097391
-"3304","James, Siân C.","home",5.67865307472008
-"3305","James, Siân C.","women",5.04711655052522
-"3306","James, Siân C.","speakers",4.84036545307348
-"3307","James, Siân C.","wales",3.60696259502595
-"3308","James, Siân C.","held",3.50787126329775
-"3309","James, Siân C.","prisoners",2.95793373168006
-"3310","James, Siân C.","remanded",2.52030713879609
-"3311","James, Siân C.","whose",2.46369719538345
-"3312","James, Siân C.","language",2.46369719538345
-"3313","Jamieson, Cathy","scotland",14.5084940668389
-"3314","Jamieson, Cathy","ordinarily",7.49866191572452
-"3315","Jamieson, Cathy","accommodated",6.95044651430334
-"3316","Jamieson, Cathy","units",6.39070452290697
-"3317","Jamieson, Cathy","england",6.0421093591811
-"3318","Jamieson, Cathy","resident",4.9407624812118
-"3319","Jamieson, Cathy","transferred",4.90790826570383
-"3320","Jamieson, Cathy","secure",4.73396992862935
-"3321","Jamieson, Cathy","three",3.60359298974821
-"3322","Jamieson, Cathy","young",3.46271834705357
-"3323","Jamieson, Cathy","people",3.43482170446428
-"3324","Jamieson, Cathy","scottish",3.07114171377589
-"3325","Jarvis, Dan","secure",68.8272020916216
-"3326","Jarvis, Dan","youth",63.0501934248257
-"3327","Jarvis, Dan","college",62.4497003289723
-"3328","Jarvis, Dan","offender",56.2273418035604
-"3329","Jarvis, Dan","2014",52.6424448255151
-"3330","Jarvis, Dan","2010",50.2958464992416
-"3331","Jarvis, Dan","estimate",45.7643268400189
-"3332","Jarvis, Dan","victim",45.0389201498574
-"3333","Jarvis, Dan","official",44.2166105918459
-"3334","Jarvis, Dan","may",43.0614225083544
-"3335","Jarvis, Dan","homicide",40.863624061054
-"3336","Jarvis, Dan","made",40.5966489697253
-"3337","Jenkin, Bernard","renegotiation",2.24065381335005
-"3338","Jenkin, Bernard","referendum",1.89909583802198
-"3339","Jenkin, Bernard","europe",1.77586492552981
-"3340","Jenkin, Bernard","specific",1.69130312731772
-"3341","Jenkin, Bernard","strategy",1.67370710383621
-"3342","Jenkin, Bernard","matters",1.64159429702559
-"3343","Jenkin, Bernard","relationship",1.62685320785461
-"3344","Jenkin, Bernard","communications",1.56315958217859
-"3345","Jenkin, Bernard","consequences",1.50232089081311
-"3346","Jenkin, Bernard","equivalent",1.49338095103485
-"3347","Jenkin, Bernard","deal",1.45261206052098
-"3348","Jenkin, Bernard","guidelines",1.43787097135
-"3349","Jenkyns, Andrea","incestuous",3.71133036988416
-"3350","Jenkyns, Andrea","juvenile",2.79625184343734
-"3351","Jenkyns, Andrea","eligibility",2.2679546969101
-"3352","Jenkyns, Andrea","limitations",2.19638418859702
-"3353","Jenkyns, Andrea","apply",1.9244819322312
-"3354","Jenkyns, Andrea","abuse",1.72802690974297
-"3355","Jenkyns, Andrea","compensation",1.71402659362082
-"3356","Jenkyns, Andrea","sexual",1.64155130505809
-"3357","Jenkyns, Andrea","injury",1.62178290750776
-"3358","Jenkyns, Andrea","claim",1.43229278945972
-"3359","Jenkyns, Andrea","criminal",1.29744512552689
-"3360","Jenkyns, Andrea","victims",1.280089689943
-"3361","Johnson, Alan","ashes",16.7038873477225
-"3362","Johnson, Alan","loss",15.9010104663471
-"3363","Johnson, Alan","1996",12.7801476698044
-"3364","Johnson, Alan","son",12.1568428700236
-"3365","Johnson, Alan","hull",11.2491354794711
-"3366","Johnson, Alan","jenni",8.77015194683978
-"3367","Johnson, Alan","murray",8.77015194683978
-"3368","Johnson, Alan","chloe",8.77015194683978
-"3369","Johnson, Alan","louise",8.77015194683978
-"3370","Johnson, Alan","medlam",8.77015194683978
-"3371","Johnson, Alan","angela",8.77015194683978
-"3372","Johnson, Alan","reece",8.77015194683978
-"3373","Johnson, Diana","contrary",74.6015816604468
-"3374","Johnson, Diana","four",66.2131579600152
-"3375","Johnson, Diana","section",65.8346104006774
-"3376","Johnson, Diana","convicted",57.5160695257432
-"3377","Johnson, Diana","ashes",57.1449448737775
-"3378","Johnson, Diana","act",57.1344540738954
-"3379","Johnson, Diana","2003",53.2422926477424
-"3380","Johnson, Diana","hull",51.0082443718416
-"3381","Johnson, Diana","offence",50.9234654883687
-"3382","Johnson, Diana","loss",45.6288491225477
-"3383","Johnson, Diana","people",42.8487908714743
-"3384","Johnson, Diana","sexual",40.848724668082
-"3385","Johnson, Gareth","video",5.31072525082514
-"3386","Johnson, Gareth","link",4.86136978039679
-"3387","Johnson, Gareth","spaces",3.34741420767242
-"3388","Johnson, Gareth","availability",3.25370641570922
-"3389","Johnson, Gareth","scope",3.17779514846045
-"3390","Johnson, Gareth","efficiency",3.06314042223207
-"3391","Johnson, Gareth","infanticide",3.04104746457308
-"3392","Johnson, Gareth","east",3.00464178162622
-"3393","Johnson, Gareth","south",2.98676190206969
-"3394","Johnson, Gareth","via",2.97159039142941
-"3395","Johnson, Gareth","sufficient",2.8835764369274
-"3396","Johnson, Gareth","manslaughter",2.75237232997826
-"3397","Jones, David","fitting",2.64439379870175
-"3398","Jones, David","contractors",2.50976062055959
-"3399","Jones, David","possible",2.36704370058914
-"3400","Jones, David","construction",2.26206346474295
-"3401","Jones, David","based",2.16666767781905
-"3402","Jones, David","carried",1.88931757970644
-"3403","Jones, David","north",1.77420688856103
-"3404","Jones, David","locally",1.68492009985882
-"3405","Jones, David","new",1.45789430931389
-"3406","Jones, David","work",1.23103866084069
-"3407","Jones, David","wales",1.12122780361465
-"3408","Jones, David","will",0.747889569674787
-"3409","Jones, Gerald","justice",2.28196056113284
-"3410","Jones, Gerald","access",2.25944911590024
-"3411","Jones, Gerald","fees",2.14596231804009
-"3412","Jones, Gerald","employment",1.74998484191408
-"3413","Jones, Gerald","tribunal",1.68823990878185
-"3414","Jones, Gerald","made",1.16843603864808
-"3415","Jones, Gerald","convict",0
-"3416","Jones, Gerald","five",0
-"3417","Jones, Gerald","person",0
-"3418","Jones, Gerald","rape",0
-"3419","Jones, Gerald","year",0
-"3420","Jones, Gerald","offenc",0
-"3421","Jones, Graham","191341",4.54543283655548
-"3422","Jones, Graham","hyndburn",4.54543283655548
-"3423","Jones, Graham","xiy",4.48283398317258
-"3424","Jones, Graham","xiiy",4.48283398317258
-"3425","Jones, Graham","viiy",4.1011843711962
-"3426","Jones, Graham","100",3.90589726335257
-"3427","Jones, Graham","viy",3.86526098777769
-"3428","Jones, Graham","2004",3.53580107160243
-"3429","Jones, Graham","two",2.89252476306058
-"3430","Jones, Graham","submitted",2.84577620407675
-"3431","Jones, Graham","one",2.82116806623052
-"3432","Jones, Graham","previously",2.74368404965547
-"3433","Jones, Graham P","coroners",6.03021123538673
-"3434","Jones, Graham P","mergers",4.6015555121686
-"3435","Jones, Graham P","offices",3.85238329239812
-"3436","Jones, Graham P","2010",2.91479550854606
-"3437","Jones, Graham P","closed",2.88320152041909
-"3438","Jones, Graham P","subject",2.85710301670671
-"3439","Jones, Graham P","year",1.60143069848958
-"3440","Jones, Graham P","convict",0
-"3441","Jones, Graham P","five",0
-"3442","Jones, Graham P","person",0
-"3443","Jones, Graham P","rape",0
-"3444","Jones, Graham P","offenc",0
-"3445","Jones, Helen","warrington",8.35092127556373
-"3446","Jones, Helen","pharmacies",7.4802602295914
-"3447","Jones, Helen","risley",7.32150391569037
-"3448","Jones, Helen","helplines",6.37234805415421
-"3449","Jones, Helen","claims",5.68715567248604
-"3450","Jones, Helen","fraudulent",5.66192885640488
-"3451","Jones, Helen","library",5.55948872402818
-"3452","Jones, Helen","will",5.55406715177639
-"3453","Jones, Helen","region",5.25096775761661
-"3454","Jones, Helen","north",5.07103379905765
-"3455","Jones, Helen","west",5.02019630989066
-"3456","Jones, Helen","officer",4.96459695791654
-"3457","Jones, Kevan","budget",5.06977234109145
-"3458","Jones, Kevan","financial",4.23962599336308
-"3459","Jones, Kevan","departments",3.85640026341653
-"3460","Jones, Kevan","seabrook",3.71133036988416
-"3461","Jones, Kevan","steering",3.71133036988416
-"3462","Jones, Kevan","advertising",3.46063735173971
-"3463","Jones, Kevan","communications",3.12631916435718
-"3464","Jones, Kevan","2014",2.70645325460363
-"3465","Jones, Kevan","2010",2.57565922314829
-"3466","Jones, Kevan","dealing",2.21890157424772
-"3467","Jones, Kevan","contact",2.17502206078864
-"3468","Jones, Kevan","solicitors",2.16473832385233
-"3469","Jones, Susan Elan","motoring",11.6009443502442
-"3470","Jones, Susan Elan","penalties",9.366680176686
-"3471","Jones, Susan Elan","review",6.37905526129941
-"3472","Jones, Susan Elan","volunteering",5.42821276431277
-"3473","Jones, Susan Elan","offences",5.23185654071961
-"3474","Jones, Susan Elan","sentencing",5.03336025486512
-"3475","Jones, Susan Elan","gcse",3.95214184287518
-"3476","Jones, Susan Elan","transport",3.54624899033599
-"3477","Jones, Susan Elan","introduce",3.13573151395219
-"3478","Jones, Susan Elan","programme",2.96878114567547
-"3479","Jones, Susan Elan","english",2.89550017572774
-"3480","Jones, Susan Elan","purpose",2.82116768671028
-"3481","Kane, Mike","bilateral",4.54543283655548
-"3482","Kane, Mike","indonesia",4.54543283655548
-"3483","Kane, Mike","bribery",4.19330722170474
-"3484","Kane, Mike","corporate",3.83630669925203
-"3485","Kane, Mike","sanctioned",3.54624899033599
-"3486","Kane, Mike","benefits",2.86734636679085
-"3487","Kane, Mike","bodies",2.70570916153304
-"3488","Kane, Mike","length",2.49094246850339
-"3489","Kane, Mike","agreement",2.3432128691399
-"3490","Kane, Mike","progress",2.22263811052184
-"3491","Kane, Mike","prosecuted",2.2202881354221
-"3492","Kane, Mike","establishing",2.17646965574086
-"3493","Kaufman, Sir Gerald","gorton",9.39235769033044
-"3494","Kaufman, Sir Gerald","reply",7.54046814433311
-"3495","Kaufman, Sir Gerald","manchester",6.94366250987381
-"3496","Kaufman, Sir Gerald","dated",6.58482072690408
-"3497","Kaufman, Sir Gerald","intends",6.08452174278384
-"3498","Kaufman, Sir Gerald","regard",6.08452174278384
-"3499","Kaufman, Sir Gerald","letter",5.83170917314109
-"3500","Kaufman, Sir Gerald","member",4.35564582339727
-"3501","Kaufman, Sir Gerald","right",4.33160145660552
-"3502","Kaufman, Sir Gerald","sherratt",3.71133036988416
-"3503","Kaufman, Sir Gerald","lawson",3.56573088174181
-"3504","Kaufman, Sir Gerald","hussain",3.43602425333506
-"3505","Kawczynski, Daniel","crematorium",18.9245892315239
-"3506","Kawczynski, Daniel","cremation",15.1180779588791
-"3507","Kawczynski, Daniel","infant",10.6978758174996
-"3508","Kawczynski, Daniel","emstrey",8.28402110458559
-"3509","Kawczynski, Daniel","shrewsbury",8.03837311251176
-"3510","Kawczynski, Daniel","amending",5.91659609790616
-"3511","Kawczynski, Daniel","practice",5.90321526007258
-"3512","Kawczynski, Daniel","sexual",5.22731819795107
-"3513","Kawczynski, Daniel","baby",5.18254874628667
-"3514","Kawczynski, Daniel","regulations",5.05232182566931
-"3515","Kawczynski, Daniel","appoint",4.8349049269335
-"3516","Kawczynski, Daniel","national",4.80671023858619
-"3517","Kendall, Liz","gender",4.10007489123824
-"3518","Kendall, Liz","diagnosis",2.84879127854937
-"3519","Kendall, Liz","work",2.56261132430039
-"3520","Kendall, Liz","contesting",2.48215439173454
-"3521","Kendall, Liz","terminal",2.36704370058914
-"3522","Kendall, Liz","dismissal",2.34752121359238
-"3523","Kendall, Liz","appellant",2.26206346474295
-"3524","Kendall, Liz","occurred",2.15472256357675
-"3525","Kendall, Liz","people",2.01123457423429
-"3526","Kendall, Liz","took",1.89542657792812
-"3527","Kendall, Liz","condition",1.77877987103414
-"3528","Kendall, Liz","place",1.36943338594333
-"3529","Kennedy, Seema","enforcement",2.40418977961694
-"3530","Kennedy, Seema","powers",2.34117850482026
-"3531","Kennedy, Seema","effectiveness",2.06133339555135
-"3532","Kennedy, Seema","child",1.93011211272259
-"3533","Kennedy, Seema","orders",1.63797034109543
-"3534","Kennedy, Seema","custody",1.52987966264354
-"3535","Kennedy, Seema","relating",1.49962450800248
-"3536","Kennedy, Seema","made",0.954024030588891
-"3537","Kennedy, Seema","court",0.949332302184983
-"3538","Kennedy, Seema","convict",0
-"3539","Kennedy, Seema","five",0
-"3540","Kennedy, Seema","person",0
-"3541","Khan, Sadiq","prison",145.35198929405
-"3542","Khan, Sadiq","2010",138.31319916815
-"3543","Khan, Sadiq","2014",117.416850001657
-"3544","Khan, Sadiq","2013",105.129796539413
-"3545","Khan, Sadiq","month",98.9691116276669
-"3546","Khan, Sadiq","staff",95.8993411207792
-"3547","Khan, Sadiq","four",84.264665122525
-"3548","Khan, Sadiq","year",75.641753466885
-"3549","Khan, Sadiq","january",70.4585006340798
-"3550","Khan, Sadiq","2011",67.9529730949574
-"3551","Khan, Sadiq","2012",60.4932784465388
-"3552","Khan, Sadiq","may",59.2639736525723
-"3553","Kinahan, Danny","maghaberry",5.24861374353734
-"3554","Kinahan, Danny","accurate",3.74933095786226
-"3555","Kinahan, Danny","reflection",3.33130058958113
-"3556","Kinahan, Danny","made",3.1552642722856
-"3557","Kinahan, Danny","motion",3.03028855770365
-"3558","Kinahan, Danny","policies",2.96856235031315
-"3559","Kinahan, Danny","staff",2.85891499306614
-"3560","Kinahan, Danny","inspections",2.80064765981174
-"3561","Kinahan, Danny","inspectorate",2.73798999521449
-"3562","Kinahan, Danny","bisexual",2.55888403691262
-"3563","Kinahan, Danny","gay",2.48300485726285
-"3564","Kinahan, Danny","assembly",2.42100705324603
-"3565","Kinnock, Stephen","existing",5.68313498747624
-"3566","Kinnock, Stephen","steel",4.26021258338486
-"3567","Kinnock, Stephen","changing",3.98506397046232
-"3568","Kinnock, Stephen","category",3.93590077532276
-"3569","Kinnock, Stephen","consistency",3.66115306706041
-"3570","Kinnock, Stephen","incarcerated",3.370953895301
-"3571","Kinnock, Stephen","public",3.20922130025133
-"3572","Kinnock, Stephen","procurement",3.10405944221048
-"3573","Kinnock, Stephen","land",3.01635686885598
-"3574","Kinnock, Stephen","port",2.95214184287518
-"3575","Kinnock, Stephen","talbot",2.95214184287518
-"3576","Kinnock, Stephen","disturbances",2.79625184343734
-"3577","Kirby, Simon","will",17.2393185385445
-"3578","Kirby, Simon","energy",14.2498005264186
-"3579","Kirby, Simon","departmental",8.75937666929366
-"3580","Kirby, Simon","replies",8.65838526935974
-"3581","Kirby, Simon","letter",6.79928515841002
-"3582","Kirby, Simon","finance",6.64467811652137
-"3583","Kirby, Simon","member",6.451123069471
-"3584","Kirby, Simon","email",5.96490586713265
-"3585","Kirby, Simon","water",5.92821276431277
-"3586","Kirby, Simon","cost",5.62802931831525
-"3587","Kirby, Simon","initiative",5.55533176717822
-"3588","Kirby, Simon","usage",5.42821276431277
-"3589","Knight, Julian","landowner",6.33752602284526
-"3590","Knight, Julian","evict",5.37145418075397
-"3591","Knight, Julian","potential",4.48281923594249
-"3592","Knight, Julian","travellers",3.84000962356849
-"3593","Knight, Julian","faster",3.43602425333506
-"3594","Knight, Julian","substantially",3.16876301142263
-"3595","Knight, Julian","whereabouts",3.11814120131826
-"3596","Knight, Julian","easier",3.0124252070077
-"3597","Knight, Julian","get",2.74516396509527
-"3598","Knight, Julian","order",2.62659592546129
-"3599","Knight, Julian","deny",2.55499091953533
-"3600","Knight, Julian","disclose",2.49119570551037
-"3601","Knight, Sir Greg","whiplash",4.7456018079812
-"3602","Knight, Sir Greg","pedal",4.4813076267001
-"3603","Knight, Sir Greg","progress",4.11968087114532
-"3604","Knight, Sir Greg","cyclists",3.66115306706041
-"3605","Knight, Sir Greg","traffic",3.31435636097134
-"3606","Knight, Sir Greg","bailiffs",3.11687542582858
-"3607","Knight, Sir Greg","methods",3.06314042223207
-"3608","Knight, Sir Greg","tackling",3.01103068551658
-"3609","Knight, Sir Greg","road",3.00464178162622
-"3610","Knight, Sir Greg","made",2.78062420909438
-"3611","Knight, Sir Greg","recommendations",2.59148526165396
-"3612","Knight, Sir Greg","scheduled",2.57144118043676
-"3613","Kwarteng, Kwasi","intimidating",3.34969020218931
-"3614","Kwarteng, Kwasi","bailiffs",3.28547517620851
-"3615","Kwarteng, Kwasi","threatening",3.22883350906107
-"3616","Kwarteng, Kwasi","sutton",3.12614137666199
-"3617","Kwarteng, Kwasi","behaviour",2.82136936861559
-"3618","Kwarteng, Kwasi","exercise",2.73368058740397
-"3619","Kwarteng, Kwasi","put",2.68302353552264
-"3620","Kwarteng, Kwasi","restrictions",2.66614817783265
-"3621","Kwarteng, Kwasi","half",2.60625718289888
-"3622","Kwarteng, Kwasi","highdown",2.57144118043676
-"3623","Kwarteng, Kwasi","permitted",2.45633048929136
-"3624","Kwarteng, Kwasi","prevent",2.27801923853236
-"3625","Lady Hermon","comfort",4.28547517620851
-"3626","Lady Hermon","became",3.51149914457939
-"3627","Lady Hermon","irish",3.43310319184542
-"3628","Lady Hermon","republic",3.24812180703875
-"3629","Lady Hermon","citizens",2.69884505754746
-"3630","Lady Hermon","aware",2.60401046975569
-"3631","Lady Hermon","called",2.47672025797448
-"3632","Lady Hermon","ireland",2.39416778770785
-"3633","Lady Hermon","letters",2.33281484449932
-"3634","Lady Hermon","requested",2.23733225713145
-"3635","Lady Hermon","runs",2.17219184191364
-"3636","Lady Hermon","within",1.93800346859359
-"3637","Lamb, Norman","discount",4.33193472857385
-"3638","Lamb, Norman","nhs",3.96071390393424
-"3639","Lamb, Norman","impact",3.14102057054366
-"3640","Lamb, Norman","carried",3.04643305919697
-"3641","Lamb, Norman","lost",2.96878566766741
-"3642","Lamb, Norman","illness",2.94611216943278
-"3643","Lamb, Norman","rate",2.62413347934719
-"3644","Lamb, Norman","due",2.49222281348348
-"3645","Lamb, Norman","mental",2.24457997622849
-"3646","Lamb, Norman","days",2.15251832037035
-"3647","Lamb, Norman","working",1.56927253840345
-"3648","Lamb, Norman","three",1.56040153701073
-"3649","Lammy, David","unsuccessful",5.71684164164157
-"3650","Lammy, David","claim",3.83413531623385
-"3651","Lammy, David","independence",3.44318198245784
-"3652","Lammy, David","appeal",3.01085876620266
-"3653","Lammy, David","overturned",2.72839744576541
-"3654","Lammy, David","personal",2.64229270136729
-"3655","Lammy, David","payment",2.55183897591465
-"3656","Lammy, David","whose",2.46369719538345
-"3657","Lammy, David","2013",2.44872288842994
-"3658","Lammy, David","died",2.42400334715768
-"3659","Lammy, David","heard",2.38776570287631
-"3660","Lammy, David","nicolson",2.34725142363783
-"3661","Latham, Pauline","vulnerable",3.72029485792731
-"3662","Latham, Pauline","traumatisation",3.2883807836292
-"3663","Latham, Pauline","exploitation",2.84879127854937
-"3664","Latham, Pauline","criminal",2.33661689732089
-"3665","Latham, Pauline","old",2.14312373374476
-"3666","Latham, Pauline","1999",2.12678584630282
-"3667","Latham, Pauline","roll",2.12678584630282
-"3668","Latham, Pauline","limit",2.11021767100035
-"3669","Latham, Pauline","crossexamination",2.06991966946267
-"3670","Latham, Pauline","start",2.0210162749154
-"3671","Latham, Pauline","pre",1.9649115890036
-"3672","Latham, Pauline","pilot",1.95218637052553
-"3673","Lavery, Ian","oakwood",17.7913544721109
-"3674","Lavery, Ian","prison",17.6653223356805
-"3675","Lavery, Ian","noms",14.7464382843788
-"3676","Lavery, Ian","office",11.8866636148907
-"3677","Lavery, Ian","hour",11.1429286858672
-"3678","Lavery, Ian","staff",10.6492903366464
-"3679","Lavery, Ian","service",10.5751004648266
-"3680","Lavery, Ian","per",10.5028169264579
-"3681","Lavery, Ian","three",10.1202587224876
-"3682","Lavery, Ian","retired",9.63591366656073
-"3683","Lavery, Ian","cells",9.60641749523468
-"3684","Lavery, Ian","increase",9.17296884914669
-"3685","Law, Chris","2952",3.71133036988416
-"3686","Law, Chris","foundation",2.84530496609973
-"3687","Law, Chris","election",2.83009143875762
-"3688","Law, Chris","accredited",2.79625184343734
-"3689","Law, Chris","general",2.56193127140856
-"3690","Law, Chris","scotland",2.54533961642677
-"3691","Law, Chris","status",2.38776570287631
-"3692","Law, Chris","wage",2.33871258021393
-"3693","Law, Chris","capacity",2.2900315730418
-"3694","Law, Chris","2015",2.2639600220934
-"3695","Law, Chris","visit",2.24570350539172
-"3696","Law, Chris","live",2.06575516700017
-"3697","Leech, John","evasion",2.68572709037698
-"3698","Leech, John","unpaid",2.54820162515169
-"3699","Leech, John","television",2.11195959474311
-"3700","Leech, John","outstanding",1.96826477440939
-"3701","Leech, John","imprisoned",1.71853275413533
-"3702","Leech, John","licence",1.55333073247474
-"3703","Leech, John","fines",1.53340722113761
-"3704","Leech, John","non",1.45805602395016
-"3705","Leech, John","payment",1.40885775553315
-"3706","Leech, John","2012",1.28900164513632
-"3707","Leech, John","average",1.27314392935718
-"3708","Leech, John","relating",1.20237452523316
-"3709","Lefroy, Jeremy","staffordshire",3.0150728235643
-"3710","Lefroy, Jeremy","monetary",2.97159039142941
-"3711","Lefroy, Jeremy","value",1.93800346859359
-"3712","Lefroy, Jeremy","written",1.89687471440397
-"3713","Lefroy, Jeremy","fines",1.81435189204623
-"3714","Lefroy, Jeremy","total",1.78265719015427
-"3715","Lefroy, Jeremy","2011",1.7118933295973
-"3716","Lefroy, Jeremy","service",1.10366757427426
-"3717","Lefroy, Jeremy","courts",0.900615699382737
-"3718","Lefroy, Jeremy","year",0.591980613658294
-"3719","Lefroy, Jeremy","convict",0
-"3720","Lefroy, Jeremy","five",0
-"3721","Leslie, Charlotte","grandparents",11.0675681174319
-"3722","Leslie, Charlotte","premises",8.92560142599415
-"3723","Leslie, Charlotte","grandchildren",8.58512287696761
-"3724","Leslie, Charlotte","appeal",8.37506565118118
-"3725","Leslie, Charlotte","approved",8.27062588197492
-"3726","Leslie, Charlotte","cafcass",6.72847320819328
-"3727","Leslie, Charlotte","parental",6.36193458114751
-"3728","Leslie, Charlotte","shorten",5.74956828593407
-"3729","Leslie, Charlotte","immigration",5.5900134984914
-"3730","Leslie, Charlotte","involving",5.22264829289251
-"3731","Leslie, Charlotte","process",5.19698725954053
-"3732","Leslie, Charlotte","breakdown",5.13897187627229
-"3733","Leslie, Chris","confiscation",17.0482777341375
-"3734","Leslie, Chris","2012",12.5120375581665
-"3735","Leslie, Chris","2013",11.8775218267537
-"3736","Leslie, Chris","order",11.0105463284163
-"3737","Leslie, Chris","issued",9.67982453084941
-"3738","Leslie, Chris","drug",9.51655860286406
-"3739","Leslie, Chris","financial",7.35699039215245
-"3740","Leslie, Chris","crimes",7.31083897888322
-"3741","Leslie, Chris","related",7.06264026672962
-"3742","Leslie, Chris","collected",6.34005313337635
-"3743","Leslie, Chris","value",5.85481707649483
-"3744","Leslie, Chris","100001",5.17897576133697
-"3745","Lewell-Buck, Emma","remote",7.8333354055907
-"3746","Lewell-Buck, Emma","video",7.42697711204584
-"3747","Lewell-Buck, Emma","conferencing",6.72847320819328
-"3748","Lewell-Buck, Emma","reoffending",6.58302301416319
-"3749","Lewell-Buck, Emma","courtrooms",6.58279177560648
-"3750","Lewell-Buck, Emma","disabled",6.33242600347651
-"3751","Lewell-Buck, Emma","availability",5.63912347253556
-"3752","Lewell-Buck, Emma","survey",5.6271314710979
-"3753","Lewell-Buck, Emma","rate",5.25215150703354
-"3754","Lewell-Buck, Emma","illiterate",5.24861374353734
-"3755","Lewell-Buck, Emma","probability",5.24861374353734
-"3756","Lewell-Buck, Emma","sites",4.95951037938384
-"3757","Lilley, Peter","dickinson",3.11814120131826
-"3758","Lilley, Peter","harpenden",3.11814120131826
-"3759","Lilley, Peter","hitchin",3.11814120131826
-"3760","Lilley, Peter","farm",2.73373133054671
-"3761","Lilley, Peter","hertfordshire",2.73373133054671
-"3762","Lilley, Peter","cross",2.63306995124559
-"3763","Lilley, Peter","william",2.63306995124559
-"3764","Lilley, Peter","rural",2.49119570551037
-"3765","Lilley, Peter","behalf",2.34932145977515
-"3766","Lilley, Peter","reply",2.19472199556186
-"3767","Lilley, Peter","letter",1.69737211921404
-"3768","Lilley, Peter","constituent",1.56777649975397
-"3769","Llwyd, Elfyn","harass",23.0633879893625
-"3770","Llwyd, Elfyn","1997",21.1656705553107
-"3771","Llwyd, Elfyn","victim",18.2899857464706
-"3772","Llwyd, Elfyn","court",17.8837945258232
-"3773","Llwyd, Elfyn","england",14.6168336707781
-"3774","Llwyd, Elfyn","wales",14.5355085517889
-"3775","Llwyd, Elfyn","proceeded",13.8838306214549
-"3776","Llwyd, Elfyn","agenda",13.7300835077693
-"3777","Llwyd, Elfyn","protection",13.6180963432458
-"3778","Llwyd, Elfyn","stalk",13.2166466893802
-"3779","Llwyd, Elfyn","tagging",12.2677043194992
-"3780","Llwyd, Elfyn","act",12.1420928685217
+"229","Baker, Norman","comrcio",2.42963604985466
+"230","Baker, Norman","diligence",2.42963604985466
+"231","Baker, Norman","internacional",2.42963604985466
+"232","Baker, Norman","killarney",2.42963604985466
+"233","Baker, Norman","lda",2.42963604985466
+"234","Baker, Norman","lewes",2.42963604985466
+"235","Baker, Norman","quora",2.42963604985466
+"236","Baker, Norman","whitbread",2.42963604985466
+"237","Baker, Norman","offshore",2.24065381335005
+"238","Baker, Norman","plc",2.24065381335005
+"239","Baker, Norman","fact",1.94112405518782
+"240","Baker, Norman","recently",1.89909583802198
+"241","Baker, Steve","obstacle",4.1918794459622
+"242","Baker, Steve","preparation",3.04356366118304
+"243","Baker, Steve","delays",2.86949933839398
+"244","Baker, Steve","restricted",2.82787718429044
+"245","Baker, Steve","dates",2.63407640607955
+"246","Baker, Steve","books",2.59255877883951
+"247","Baker, Steve","asylum)",2.45485747743195
+"248","Baker, Steve","tier",2.20283267172732
+"249","Baker, Steve","immigr",2.17816581124606
+"250","Baker, Steve","hearings",2.13782734425893
+"251","Baker, Steve","access",1.9567403329279
+"252","Baker, Steve","first",1.9229875624584
+"253","Barclay, Stephen","network rail",6.02398445487787
+"254","Barclay, Stephen","532",4.98893495426658
+"255","Barclay, Stephen","task",4.80523252962503
+"256","Barclay, Stephen","tackling",4.80523252962503
+"257","Barclay, Stephen","publish",4.58155879969684
+"258","Barclay, Stephen","lay",4.52360581122418
+"259","Barclay, Stephen","prime",4.44788395995126
+"260","Barclay, Stephen","radicalisation",4.10370205381423
+"261","Barclay, Stephen","2000",4.08689105599983
+"262","Barclay, Stephen","drive",4.04558544020847
+"263","Barclay, Stephen","freedom",3.98916015497135
+"264","Barclay, Stephen","extremism",3.96121138322711
+"265","Bardell, Hannah","july",2.05101380989086
+"266","Bardell, Hannah","claims",1.75419324822195
+"267","Bardell, Hannah","estimate",1.65339824303596
+"268","Bardell, Hannah","employment",1.51553132933529
+"269","Bardell, Hannah","number",1.47926745223442
+"270","Bardell, Hannah","2013",1.46691649229498
+"271","Bardell, Hannah","tribunal",1.4620586486878
+"272","Bardell, Hannah","made",1.01189529216649
+"273","Bardell, Hannah","convict",0
+"274","Bardell, Hannah","five",0
+"275","Bardell, Hannah","person",0
+"276","Bardell, Hannah","rape",0
+"277","Baroness Afshar","tax",4.53310433109601
+"278","Baroness Afshar","council",3.69515628330937
+"279","Baroness Afshar","rough",3.43602425333506
+"280","Baroness Afshar","groups",3.2533896810499
+"281","Baroness Afshar","non",3.18325117713378
+"282","Baroness Afshar","begging",3.16876301142263
+"283","Baroness Afshar","sleeping",3.16876301142263
+"284","Baroness Afshar","payment",3.07584073248771
+"285","Baroness Afshar","sum",2.68572709037698
+"286","Baroness Afshar","breakdown",2.51145226262694
+"287","Baroness Afshar","committals",2.51145226262694
+"288","Baroness Afshar","specific",2.48215439173454
+"289","Baroness Altmann","county",5.72892131281441
+"290","Baroness Altmann","action",4.89341456969299
+"291","Baroness Altmann","lodge",4.79576848015894
+"292","Baroness Altmann","defence",4.31026736023359
+"293","Baroness Altmann","discovered",3.43602425333506
+"294","Baroness Altmann","penalise",3.43602425333506
+"295","Baroness Altmann","individual",3.34363258668647
+"296","Baroness Altmann","sue",2.96410638215638
+"297","Baroness Altmann","monies",2.81786575697609
+"298","Baroness Altmann","knowing",2.79458629730814
+"299","Baroness Altmann","correct",2.56786575697609
+"300","Baroness Altmann","notification",2.54820162515169
+"301","Baroness Armstrong of Hill Top","chairs",3.22883350906107
+"302","Baroness Armstrong of Hill Top","departmental",2.66614817783265
+"303","Baroness Armstrong of Hill Top","list",2.316511644339
+"304","Baroness Armstrong of Hill Top","appointed",2.27067713642236
+"305","Baroness Armstrong of Hill Top","bodies",2.20920227937655
+"306","Baroness Armstrong of Hill Top","non",1.81851536411445
+"307","Baroness Armstrong of Hill Top","persons",1.49234905385142
+"308","Baroness Armstrong of Hill Top","public",1.41513357710606
+"309","Baroness Armstrong of Hill Top","will",0.89885139728238
+"310","Baroness Armstrong of Hill Top","convict",0
+"311","Baroness Armstrong of Hill Top","five",0
+"312","Baroness Armstrong of Hill Top","rape",0
+"313","Baroness Corston","holloway",14.8285410817851
+"314","Baroness Corston","site",12.8288041368427
+"315","Baroness Corston","carillion",12.4565318785247
+"316","Baroness Corston","women",11.5155471239816
+"317","Baroness Corston","prison",10.7556469660525
+"318","Baroness Corston","rehabilitation",10.4445335441449
+"319","Baroness Corston","programme",9.46066461988412
+"320","Baroness Corston","contract",9.27414725025645
+"321","Baroness Corston","irish",8.95848424862502
+"322","Baroness Corston","republic",8.47578602212964
+"323","Baroness Corston","market",8.25022680605374
+"324","Baroness Corston","community",7.76448943570648
+"325","Baroness Coussins","interpretation",25.9064140061415
+"326","Baroness Coussins","thebigword",9.82000637533273
+"327","Baroness Coussins","translating",7.21685144856835
+"328","Baroness Coussins","court",6.95026856464688
+"329","Baroness Coussins","provision",5.75473981511824
+"330","Baroness Coussins","contract",5.71986682127364
+"331","Baroness Coussins","services",4.39043822264554
+"332","Baroness Coussins","cancellation",4.32492039014931
+"333","Baroness Coussins","current",4.27176491212878
+"334","Baroness Coussins","quality",4.24581812860593
+"335","Baroness Coussins","directive",4.23827106545622
+"336","Baroness Coussins","language",3.81201666310858
+"337","Baroness Deech","nuptial",4.4813076267001
+"338","Baroness Deech","plan",4.36897444397305
+"339","Baroness Deech","binding",4.26021258338486
+"340","Baroness Deech","divorce",3.42022720303473
+"341","Baroness Deech","pre",3.06209355073595
+"342","Baroness Deech","post",2.53488617054572
+"343","Baroness Deech","agreements",2.50499992588602
+"344","Baroness Deech","review",2.44332354494223
+"345","Baroness Deech","britainajourney",2.23801641999213
+"346","Baroness Deech","equalthat",2.23801641999213
+"347","Baroness Deech","theconclusion",2.23801641999213
+"348","Baroness Deech","legislation",2.17250239952996
+"349","Baroness Doocey","section",7.82142165883526
+"350","Baroness Doocey","past",7.578919879091
+"351","Baroness Doocey","coroners",6.25981105085803
+"352","Baroness Doocey","act",6.10678125143013
+"353","Baroness Doocey","2009",5.85182036896875
+"354","Baroness Doocey","modern",5.65946662226605
+"355","Baroness Doocey","slavery",5.50333522145866
+"356","Baroness Doocey","guidance",3.95714676462488
+"357","Baroness Doocey","commission",3.65527403965854
+"358","Baroness Doocey","victim",3.45129399522619
+"359","Baroness Doocey","prosecutions",3.32124643019985
+"360","Baroness Doocey","embedded",3.2883807836292
+"361","Baroness Drake","lower",3.83630669925203
+"362","Baroness Drake","level",2.39549516757162
+"363","Baroness Drake","access",2.25944911590024
+"364","Baroness Drake","fees",2.14596231804009
+"365","Baroness Drake","employment",1.74998484191408
+"366","Baroness Drake","tribunals",1.68823990878185
+"367","Baroness Drake","convict",0
+"368","Baroness Drake","five",0
+"369","Baroness Drake","person",0
+"370","Baroness Drake","rape",0
+"371","Baroness Drake","year",0
+"372","Baroness Drake","offenc",0
+"373","Baroness Gale","53a",3.0124252070077
+"374","Baroness Gale","2003",1.88394336463971
+"375","Baroness Gale","imposed",1.86382176623512
+"376","Baroness Gale","penalty",1.736897009058
+"377","Baroness Gale","sexual",1.51978119303064
+"378","Baroness Gale","prosecutions",1.45351977788345
+"379","Baroness Gale","section",1.41087121425122
+"380","Baroness Gale","act",1.1015749124891
+"381","Baroness Gale","wales",1.08044214622602
+"382","Baroness Gale","convictions",1.07533509847354
+"383","Baroness Gale","case",1.05636173340212
+"384","Baroness Gale","offences",0.970161872294391
+"385","Baroness Golding","thames",2.42018272653674
+"386","Baroness Golding","drawn",2.09665361085237
+"387","Baroness Golding","leeds",1.97724864039993
+"388","Baroness Golding","liverpool",1.89252946562044
+"389","Baroness Golding","formal",1.89252946562044
+"390","Baroness Golding","1999",1.78995701313116
+"391","Baroness Golding","conclusions",1.70093865408485
+"392","Baroness Golding","announcement",1.70093865408485
+"393","Baroness Golding","kingston",1.6648336320889
+"394","Baroness Golding","pilot",1.64300965747714
+"395","Baroness Golding","basis",1.57729636028212
+"396","Baroness Golding","upon",1.46642789744679
+"397","Baroness Gould of Potternewton","genital",2.44704013864261
+"398","Baroness Gould of Potternewton","mutilation",2.44704013864261
+"399","Baroness Gould of Potternewton","abroad",2.41846584846456
+"400","Baroness Gould of Potternewton","sufficient",2.17977889673018
+"401","Baroness Gould of Potternewton","kingdom",2.15120460655214
+"402","Baroness Gould of Potternewton","practice",2.00415825097043
+"403","Baroness Gould of Potternewton","consider",1.91251765481776
+"404","Baroness Gould of Potternewton","carried",1.82059197438716
+"405","Baroness Gould of Potternewton","united",1.7322232976726
+"406","Baroness Gould of Potternewton","female",1.5965605243227
+"407","Baroness Gould of Potternewton","legislation",1.53619117885168
+"408","Baroness Gould of Potternewton","current",1.46729183002864
+"409","Baroness Hamwee","timetabling",3.71133036988416
+"410","Baroness Hamwee","guardianship",2.67644083747113
+"411","Baroness Hamwee","affairs",2.50757670884253
+"412","Baroness Hamwee","decide",2.38776570287631
+"413","Baroness Hamwee","missing",2.32356654071415
+"414","Baroness Hamwee","property",2.28117708317411
+"415","Baroness Hamwee","legislation",1.65927611555321
+"416","Baroness Hamwee","consultation",1.59767179159901
+"417","Baroness Hamwee","response",1.58233986939804
+"418","Baroness Hamwee","proposed",1.382850987175
+"419","Baroness Hamwee","persons",1.292412191949
+"420","Baroness Hamwee","will",0.77842814427368
+"421","Baroness Hayter of Kentish Town","intend",7.68836556647595
+"422","Baroness Hayter of Kentish Town","withdraw",7.53622466752175
+"423","Baroness Hayter of Kentish Town","continued",7.11490175301801
+"424","Baroness Hayter of Kentish Town","choice",6.99748917747002
+"425","Baroness Hayter of Kentish Town","bank",6.91767985244346
+"426","Baroness Hayter of Kentish Town","participation",6.87258900498037
+"427","Baroness Hayter of Kentish Town","brussels",6.79814219616455
+"428","Baroness Hayter of Kentish Town","hague",6.53997015295838
+"429","Baroness Hayter of Kentish Town","signatory",6.53997015295838
+"430","Baroness Hayter of Kentish Town","ombudsman",6.04182856213677
+"431","Baroness Hayter of Kentish Town","will",5.75683163277542
+"432","Baroness Hayter of Kentish Town","become",5.64629281153565
+"433","Baroness Healy of Primrose Hill","immediate",2.07634261619918
+"434","Baroness Healy of Primrose Hill","remanded",1.90517311907292
+"435","Baroness Healy of Primrose Hill","subsequently",1.87041297747788
+"436","Baroness Healy of Primrose Hill","crown",1.52246814793449
+"437","Baroness Healy of Primrose Hill","women",1.51183088109155
+"438","Baroness Healy of Primrose Hill","magistrates",1.23421797132583
+"439","Baroness Healy of Primrose Hill","custodial",1.22663261584402
+"440","Baroness Healy of Primrose Hill","receive",1.17187381445793
+"441","Baroness Healy of Primrose Hill","england",1.08648714188543
+"442","Baroness Healy of Primrose Hill","wales",1.08044214622602
+"443","Baroness Healy of Primrose Hill","convicted",1.07533509847354
+"444","Baroness Healy of Primrose Hill","proportion",1.05636173340212
+"445","Baroness Hodgson of Abinger","identification",4.0655587238791
+"446","Baroness Hodgson of Abinger","gathered",3.74933095786226
+"447","Baroness Hodgson of Abinger","gypsies",2.72224609610137
+"448","Baroness Hodgson of Abinger","enable",2.38261729153062
+"449","Baroness Hodgson of Abinger","can",2.3603582316201
+"450","Baroness Hodgson of Abinger","travellers",2.27178033009015
+"451","Baroness Hodgson of Abinger","youth",1.83106512470491
+"452","Baroness Hodgson of Abinger","system",1.77057117926664
+"453","Baroness Hodgson of Abinger","justice",1.76759904999392
+"454","Baroness Hodgson of Abinger","data",1.75016175949694
+"455","Baroness Hodgson of Abinger","convict",0
+"456","Baroness Hodgson of Abinger","five",0
+"457","Baroness Howe of Idlicote","visiting",12.2624653844511
+"458","Baroness Howe of Idlicote","barnardos",11.8092733361489
+"459","Baroness Howe of Idlicote","locked",10.5267904683264
+"460","Baroness Howe of Idlicote","experiences",9.65416474903672
+"461","Baroness Howe of Idlicote","fathers",9.04328542677841
+"462","Baroness Howe of Idlicote","parent",8.62158067625167
+"463","Baroness Howe of Idlicote","incentive",7.77147348379736
+"464","Baroness Howe of Idlicote","privileges",7.77147348379736
+"465","Baroness Howe of Idlicote","children",7.5272510068545
+"466","Baroness Howe of Idlicote","earned",6.49739728023495
+"467","Baroness Howe of Idlicote","scheme",5.07968713666443
+"468","Baroness Howe of Idlicote","report",4.93709434552974
+"469","Baroness Hussein-Ece","pursue",2.24866008047404
+"470","Baroness Hussein-Ece","sex",1.67972611422613
+"471","Baroness Hussein-Ece","violence",1.40962467057739
+"472","Baroness Hussein-Ece","child",1.40436284294811
+"473","Baroness Hussein-Ece","domestic",1.39917897119383
+"474","Baroness Hussein-Ece","given",1.37917895962982
+"475","Baroness Hussein-Ece","access",1.34231279435367
+"476","Baroness Hussein-Ece","prosecuted",1.31904770519308
+"477","Baroness Hussein-Ece","family",1.24549958361764
+"478","Baroness Hussein-Ece","aid",1.16841695963381
+"479","Baroness Hussein-Ece","legal",1.01908364267726
+"480","Baroness Hussein-Ece","convicted",0.975850700855631
+"481","Baroness Jones of Moulsecoomb","crash",2.36906627436083
+"482","Baroness Jones of Moulsecoomb","laid",2.36906627436083
+"483","Baroness Jones of Moulsecoomb","treated",2.19288698659778
+"484","Baroness Jones of Moulsecoomb","traffic",1.91354453719715
+"485","Baroness Jones of Moulsecoomb","qualify",1.80498121111431
+"486","Baroness Jones of Moulsecoomb","extend",1.7797820163586
+"487","Baroness Jones of Moulsecoomb","code",1.73473074144029
+"488","Baroness Jones of Moulsecoomb","road",1.73473074144029
+"489","Baroness Jones of Moulsecoomb","practice",1.63638835955545
+"490","Baroness Jones of Moulsecoomb","regard",1.59339139449136
+"491","Baroness Jones of Moulsecoomb","include",1.38886356842976
+"492","Baroness Jones of Moulsecoomb","charge",1.31169365828426
+"493","Baroness Kennedy of Cradley","holloway",7.832596889295
+"494","Baroness Kennedy of Cradley","hmp",5.17474934942291
+"495","Baroness Kennedy of Cradley","presently",3.72656987909899
+"496","Baroness Kennedy of Cradley","economic",3.42469510436916
+"497","Baroness Kennedy of Cradley","corporate",3.32233905826068
+"498","Baroness Kennedy of Cradley","liability",3.16413841980111
+"499","Baroness Kennedy of Cradley","assaults",2.64601479405024
+"500","Baroness Kennedy of Cradley","call",2.62695853427377
+"501","Baroness Kennedy of Cradley","held",2.59921946369702
+"502","Baroness Kennedy of Cradley","evidence",2.17646965574086
+"503","Baroness Kennedy of Cradley","response",1.93796263984368
+"504","Baroness Kennedy of Cradley","crime",1.90523557471049
+"505","Baroness Kennedy of The Shaws","unaccompanied",10.4850148932327
+"506","Baroness Kennedy of The Shaws","migrant",10.1741003237417
+"507","Baroness Kennedy of The Shaws","appeared",7.77370276837618
+"508","Baroness Kennedy of The Shaws","deradicalisation",4.92430098544712
+"509","Baroness Kennedy of The Shaws","children",4.69028170103063
+"510","Baroness Kennedy of The Shaws","undergone",4.64386075887713
+"511","Baroness Kennedy of The Shaws","2014",4.3528902404315
+"512","Baroness Kennedy of The Shaws","proceedings",4.02611872964542
+"513","Baroness Kennedy of The Shaws","programme",2.84656078331018
+"514","Baroness Kennedy of The Shaws","healthy",2.72005056373129
+"515","Baroness Kennedy of The Shaws","either",2.63508283207643
+"516","Baroness Kennedy of The Shaws","currently",2.63204190948855
+"517","Baroness King of Bow","explanatory",3.03028855770365
+"518","Baroness King of Bow","pupils",2.79458629730814
+"519","Baroness King of Bow","admission",2.79458629730814
+"520","Baroness King of Bow","academy",2.79458629730814
+"521","Baroness King of Bow","sen",2.65670931364155
+"522","Baroness King of Bow","went",2.3685886568422
+"523","Baroness King of Bow","schools",2.3685886568422
+"524","Baroness King of Bow","memorandum",2.28313006957944
+"525","Baroness King of Bow","instances",2.21489270550712
+"526","Baroness King of Bow","goods",1.92238429128494
+"527","Baroness King of Bow","compliance",1.88525145619363
+"528","Baroness King of Bow","copy",1.80240862399988
+"529","Baroness Kinnock of Holyhead","eritrean",7.17198619315161
+"530","Baroness Kinnock of Holyhead","asylum",4.45485122606036
+"531","Baroness Kinnock of Holyhead","appeals",3.08593514978754
+"532","Baroness Kinnock of Holyhead","nationals",2.8751867939638
+"533","Baroness Kinnock of Holyhead","lodged",2.67644083747113
+"534","Baroness Kinnock of Holyhead","2013",2.50978229810019
+"535","Baroness Kinnock of Holyhead","outside",2.40549051337143
+"536","Baroness Kinnock of Holyhead","initial",2.2679546969101
+"537","Baroness Kinnock of Holyhead","2015",2.2639600220934
+"538","Baroness Kinnock of Holyhead","2014",2.16573453457835
+"539","Baroness Kinnock of Holyhead","pay",2.05512425612285
+"540","Baroness Kinnock of Holyhead","refusals",1.98583828345695
+"541","Baroness Lawrence of Clarendon","historical",2.96511597206594
+"542","Baroness Lawrence of Clarendon","face",2.84530496609973
+"543","Baroness Lawrence of Clarendon","continue",2.40549051337143
+"544","Baroness Lawrence of Clarendon","problems",2.32356654071415
+"545","Baroness Lawrence of Clarendon","met",2.20749071839583
+"546","Baroness Lawrence of Clarendon","discuss",2.02752005996842
+"547","Baroness Lawrence of Clarendon","commissioner",2.01315759583639
+"548","Baroness Lawrence of Clarendon","financial",1.61903391940739
+"549","Baroness Lawrence of Clarendon","crime",1.55561833261298
+"550","Baroness Lawrence of Clarendon","families",1.48244102236422
+"551","Baroness Lawrence of Clarendon","victims",1.280089689943
+"552","Baroness Lawrence of Clarendon","legal",1.21295214947974
+"553","Baroness Lister of Burtersett","pursuing",4.6425415406108
+"554","Baroness Lister of Burtersett","upper",4.53118197942137
+"555","Baroness Lister of Burtersett","chamber)",4.14180702582731
+"556","Baroness Lister of Burtersett","representation",3.98060651743871
+"557","Baroness Lister of Burtersett","appeals",3.96942824049451
+"558","Baroness Lister of Burtersett","asylum",3.68769560347356
+"559","Baroness Lister of Burtersett","hl2645",3.56573088174181
+"560","Baroness Lister of Burtersett","litigants",3.51908706169429
+"561","Baroness Lister of Burtersett","200203",3.31951479760817
+"562","Baroness Lister of Burtersett","forcible",3.31951479760817
+"563","Baroness Lister of Burtersett","meters",3.31951479760817
+"564","Baroness Lister of Burtersett","prepayment",3.31951479760817
+"565","Baroness Ludford","rental",10.6797352150481
+"566","Baroness Ludford","buildings",10.3271882946916
+"567","Baroness Ludford","raised",9.87824869103113
+"568","Baroness Ludford","disposed",9.14366566627923
+"569","Baroness Ludford","money",8.16568323286223
+"570","Baroness Ludford","sale",8.10871807481138
+"571","Baroness Ludford","estate",7.79932991909789
+"572","Baroness Ludford","may",6.83874630057567
+"573","Baroness Ludford","third",6.28511776787567
+"574","Baroness Ludford","amp",5.67019187359006
+"575","Baroness Ludford","parties",5.4968437030573
+"576","Baroness Ludford","2010",4.62088948203288
+"577","Baroness Masham of Ilton","training",6.69170822148218
+"578","Baroness Masham of Ilton","officer",6.09576342693685
+"579","Baroness Masham of Ilton","role",4.82579733469774
+"580","Baroness Masham of Ilton","suggestion",3.42265523528935
+"581","Baroness Masham of Ilton","fulfil",3.27333545844424
+"582","Baroness Masham of Ilton","vocational",3.13398010069454
+"583","Baroness Masham of Ilton","degree",3.04104746457308
+"584","Baroness Masham of Ilton","league",3.04104746457308
+"585","Baroness Masham of Ilton","howard",3.04104746457308
+"586","Baroness Masham of Ilton","penal",3.04104746457308
+"587","Baroness Masham of Ilton","receive",2.70863175929399
+"588","Baroness Masham of Ilton","england",2.51127172761062
+"589","Baroness Meacher","havemade",3.71133036988416
+"590","Baroness Meacher","law",3.46522367369785
+"591","Baroness Meacher","terminal",2.84483247791272
+"592","Baroness Meacher","die",2.79899796999608
+"593","Baroness Meacher","illness",2.77762119085617
+"594","Baroness Meacher","burials",2.64310543618979
+"595","Baroness Meacher","possible",2.46369719538345
+"596","Baroness Meacher","assisted",2.45485747743195
+"597","Baroness Meacher","cremations",2.33871258021393
+"598","Baroness Meacher","scotland",2.32356654071415
+"599","Baroness Meacher","basis",2.23063390459269
+"600","Baroness Meacher","level",1.95591361395112
+"601","Baroness Miller of Chilthorne Domer","800th",7.11120534712431
+"602","Baroness Miller of Chilthorne Domer","anniversary",7.11120534712431
+"603","Baroness Miller of Chilthorne Domer","forest",6.84935674088551
+"604","Baroness Miller of Chilthorne Domer","charter",6.64625118270864
+"605","Baroness Miller of Chilthorne Domer","mark",6.01534769400275
+"606","Baroness Miller of Chilthorne Domer","celebrate",3.98506397046232
+"607","Baroness Miller of Chilthorne Domer","granting",3.94725568100664
+"608","Baroness Miller of Chilthorne Domer","2017",3.9015072919179
+"609","Baroness Miller of Chilthorne Domer","carta",3.12614137666199
+"610","Baroness Miller of Chilthorne Domer","magna",3.12614137666199
+"611","Baroness Miller of Chilthorne Domer","similar",2.53941356285557
+"612","Baroness Miller of Chilthorne Domer","way",2.24696236650233
+"613","Baroness Morgan of Huyton","literacy",6.1579870339585
+"614","Baroness Morgan of Huyton","light",4.28404688523641
+"615","Baroness Morgan of Huyton","parcels",3.72450728589427
+"616","Baroness Morgan of Huyton","skills",3.28318859405118
+"617","Baroness Morgan of Huyton","improvement",3.17376537805039
+"618","Baroness Morgan of Huyton","stop",3.16413841980111
+"619","Baroness Morgan of Huyton","showing",3.12614137666199
+"620","Baroness Morgan of Huyton","targets",3.04226273002551
+"621","Baroness Morgan of Huyton","governors",2.96944973466319
+"622","Baroness Morgan of Huyton","monitored",2.54262087428531
+"623","Baroness Morgan of Huyton","sent",2.45703163861456
+"624","Baroness Morgan of Huyton","libraries",2.38574330333962
+"625","Baroness Pinnock","foster",4.54543283655548
+"626","Baroness Pinnock","abused",3.5273201588906
+"627","Baroness Pinnock","compensation",3.49874213327648
+"628","Baroness Pinnock","injuries",3.31045049746779
+"629","Baroness Pinnock","children",2.86167618634881
+"630","Baroness Pinnock","parents",2.65125216004296
+"631","Baroness Pinnock","criminal",2.64839877233512
+"632","Baroness Pinnock","indefinitely",2.55888403691262
+"633","Baroness Pinnock","keeping",2.24730259686733
+"634","Baroness Pinnock","best",2.21489270550712
+"635","Baroness Pinnock","allege",1.79334018039318
+"636","Baroness Pinnock","claimants",1.79334018039318
+"637","Baroness Rebuck","least",2.90091680990377
+"638","Baroness Rebuck","literacy",2.71267848175249
+"639","Baroness Rebuck","studies",2.63362435843454
+"640","Baroness Rebuck","entry",2.55662983150491
+"641","Baroness Rebuck","skills",2.50757670884253
+"642","Baroness Rebuck","cent",2.50757670884253
+"643","Baroness Rebuck","recognised",2.46410638215638
+"644","Baroness Rebuck","qualifications",2.34924847749706
+"645","Baroness Rebuck","towards",2.31786575697609
+"646","Baroness Rebuck","materials",2.26226765164198
+"647","Baroness Rebuck","specific",2.23738373325425
+"648","Baroness Rebuck","higher",2.23738373325425
+"649","Baroness Redfern","sanctions",3.28318859405118
+"650","Baroness Redfern","targets",3.04226273002551
+"651","Baroness Redfern","met",2.89028380370323
+"652","Baroness Redfern","lasting",2.83330026878961
+"653","Baroness Redfern","imposed",2.63584201965588
+"654","Baroness Redfern","percentage",2.42688610118765
+"655","Baroness Redfern","education",2.34270470544706
+"656","Baroness Redfern","less",2.23027757963408
+"657","Baroness Redfern","upon",2.16605755572496
+"658","Baroness Redfern","accommodation",2.12537475660989
+"659","Baroness Redfern","allocated",2.05390474951407
+"660","Baroness Redfern","providers",1.80249846893443
+"661","Baroness Seccombe","bears",3.03028855770365
+"662","Baroness Seccombe","kingdom",1.89718413605117
+"663","Baroness Seccombe","aware",1.84131346144502
+"664","Baroness Seccombe","concerns",1.75130568951585
+"665","Baroness Seccombe","incurred",1.74348818471609
+"666","Baroness Seccombe","united",1.52767735362464
+"667","Baroness Seccombe","purse",1.51958062629746
+"668","Baroness Seccombe","european",1.50778592432058
+"669","Baroness Seccombe","private",1.39392219596654
+"670","Baroness Seccombe","human",1.39116876811131
+"671","Baroness Seccombe","rights",1.22523080063216
+"672","Baroness Seccombe","average",1.12280740675689
+"673","Baroness Sharples","delays",3.51440459815959
+"674","Baroness Sharples","inquests",3.35276739290178
+"675","Baroness Sharples","london",2.84703477522624
+"676","Baroness Sharples","six",2.6902088515967
+"677","Baroness Sharples","holding",2.6902088515967
+"678","Baroness Sharples","months",1.65040263970043
+"679","Baroness Sharples","convict",0
+"680","Baroness Sharples","five",0
+"681","Baroness Sharples","person",0
+"682","Baroness Sharples","rape",0
+"683","Baroness Sharples","year",0
+"684","Baroness Sharples","offenc",0
+"685","Baroness Smith of Basildon","genital",8.93223053387195
+"686","Baroness Smith of Basildon","mutilation",8.93223053387195
+"687","Baroness Smith of Basildon","phone",8.23289538544681
+"688","Baroness Smith of Basildon","whilst",7.76473381568405
+"689","Baroness Smith of Basildon","mobile",7.14782017876855
+"690","Baroness Smith of Basildon","cautioned",6.85492818553776
+"691","Baroness Smith of Basildon","prosecuted",6.76090201910854
+"692","Baroness Smith of Basildon","drug",6.5148143272348
+"693","Baroness Smith of Basildon","use",6.3139215915633
+"694","Baroness Smith of Basildon","drive",5.9288171025926
+"695","Baroness Smith of Basildon","female",5.82779433787318
+"696","Baroness Smith of Basildon","770)",5.10622671596857
+"697","Baroness Stern","inspector",40.8954673441832
+"698","Baroness Stern","chief",34.1526466617138
+"699","Baroness Stern","report",23.2568861469912
+"700","Baroness Stern","action",20.685449522607
+"701","Baroness Stern","hmp",19.0719061226577
+"702","Baroness Stern","conclusion",16.4447919437234
+"703","Baroness Stern","respect",12.8957207677207
+"704","Baroness Stern","response",12.2540866901423
+"705","Baroness Stern","prison",10.9046742608
+"706","Baroness Stern","young",10.8163542058159
+"707","Baroness Stern","light",10.8077460008117
+"708","Baroness Stern","finding",10.5654003835787
+"709","Baroness Taylor of Bolton","category",3.06425253703117
+"710","Baroness Taylor of Bolton","held",2.90601570463354
+"711","Baroness Taylor of Bolton","currently",2.74505165718986
+"712","Baroness Taylor of Bolton","prisoners",0.894159526383379
+"713","Baroness Taylor of Bolton","convict",0
+"714","Baroness Taylor of Bolton","five",0
+"715","Baroness Taylor of Bolton","person",0
+"716","Baroness Taylor of Bolton","rape",0
+"717","Baroness Taylor of Bolton","year",0
+"718","Baroness Taylor of Bolton","offenc",0
+"719","Baroness Taylor of Bolton","sexual",0
+"720","Baroness Taylor of Bolton","agreement",0
+"721","Baroness Thomas of Winchester","relevance",3.96546951770599
+"722","Baroness Thomas of Winchester","disabl",3.46281379188025
+"723","Baroness Thomas of Winchester","transforming",3.43069218890072
+"724","Baroness Thomas of Winchester","referenced",3.21410638215638
+"725","Baroness Thomas of Winchester","independence",2.96486165378729
+"726","Baroness Thomas of Winchester","hl2078",2.94946629760185
+"727","Baroness Thomas of Winchester","cross",2.71410638215638
+"728","Baroness Thomas of Winchester","system",2.68426676117044
+"729","Baroness Thomas of Winchester","payment",2.67895165812421
+"730","Baroness Thomas of Winchester","consultation",2.65332514880032
+"731","Baroness Thomas of Winchester","appeals",2.59259596105094
+"732","Baroness Thomas of Winchester","website",2.31786575697609
+"733","Baroness Thornton","conducted",4.28106789775998
+"734","Baroness Thornton","celebrant",3.56434957305558
+"735","Baroness Thornton","humanist",3.24812180703875
+"736","Baroness Thornton","workplace",3.06314042223207
+"737","Baroness Thornton","recognition",2.77298948091366
+"738","Baroness Thornton","marriages",2.57914917251452
+"739","Baroness Thornton","harassment",2.51386367274078
+"740","Baroness Thornton","enable",2.38261729153062
+"741","Baroness Thornton","concerning",2.34962314268375
+"742","Baroness Thornton","intend",2.30904350017104
+"743","Baroness Thornton","brought",2.21310248042081
+"744","Baroness Thornton","monitoring",2.12730924814564
+"745","Baroness Tonge","girls",3.04104746457308
+"746","Baroness Tonge","genital",2.64310543618979
+"747","Baroness Tonge","mutilation",2.64310543618979
+"748","Baroness Tonge","contain",2.37076455926199
+"749","Baroness Tonge","origin",2.25513921852908
+"750","Baroness Tonge","country",1.83729380353144
+"751","Baroness Tonge","female",1.72448246124158
+"752","Baroness Tonge","current",1.58485631321799
+"753","Baroness Tonge","protection",1.50473915547755
+"754","Baroness Tonge","orders",1.4185239260341
+"755","Baroness Tonge","information",1.41515167938967
+"756","Baroness Tonge","nationality",1.37211267113032
+"757","Baroness Uddin","spectrum",3.57484680302201
+"758","Baroness Uddin","autism",3.27333545844424
+"759","Baroness Uddin","disorder",2.61907845362646
+"760","Baroness Uddin","system",1.68817338102719
+"761","Baroness Uddin","justice",1.68533956695525
+"762","Baroness Uddin","currently",1.65532843218946
+"763","Baroness Uddin","training",1.49053224433803
+"764","Baroness Uddin","provide",1.43789635211168
+"765","Baroness Uddin","criminal",1.3551372370972
+"766","Baroness Uddin","staff",1.24172420135705
+"767","Baroness Uddin","people",1.05033300077928
+"768","Baroness Uddin","convict",0
+"769","Baroness Wheatcroft","women",8.32567242029279
+"770","Baroness Wheatcroft","current",8.08039528400836
+"771","Baroness Wheatcroft","proportion",5.81739787143962
+"772","Baroness Wheatcroft","jailed",5.71299783758061
+"773","Baroness Wheatcroft","woman",3.56434957305558
+"774","Baroness Wheatcroft","crime",3.53137225309141
+"775","Baroness Wheatcroft","children",3.51836401557083
+"776","Baroness Wheatcroft","prison",3.19758406426661
+"777","Baroness Wheatcroft","addiction",3.12614137666199
+"778","Baroness Wheatcroft","combined",3.06314042223207
+"779","Baroness Wheatcroft","keeping",3.0150728235643
+"780","Baroness Wheatcroft","violent",2.93639188796211
+"781","Baroness Whitaker","romany",5.27732913387793
+"782","Baroness Whitaker","gypsies",4.31248644372485
+"783","Baroness Whitaker","traveller",3.5988744333825
+"784","Baroness Whitaker","recommendations",3.43477364953329
+"785","Baroness Whitaker","inspectorate",3.35975679738186
+"786","Baroness Whitaker","humanist",3.24812180703875
+"787","Baroness Whitaker","response",2.74593816431707
+"788","Baroness Whitaker","marriages",2.57914917251452
+"789","Baroness Whitaker","now",2.57914917251452
+"790","Baroness Whitaker","report",2.15120063824805
+"791","Baroness Whitaker","closed",2.0387313466157
+"792","Baroness Whitaker","allow",1.94232786333897
+"793","Baroness Young of Hornsey","ago",3.42265523528935
+"794","Baroness Young of Hornsey","ten",3.13398010069454
+"795","Baroness Young of Hornsey","race",2.75237232997826
+"796","Baroness Young of Hornsey","senior",2.40549051337143
+"797","Baroness Young of Hornsey","posts",1.93605129243709
+"798","Baroness Young of Hornsey","level",1.6938708772895
+"799","Baroness Young of Hornsey","currently",1.58485631321799
+"800","Baroness Young of Hornsey","relations",1.29871292006789
+"801","Baroness Young of Hornsey","numbers",1.20781681702708
+"802","Baroness Young of Hornsey","five",1.07593336621344
+"803","Baroness Young of Hornsey","years",0.540401892843998
+"804","Baroness Young of Hornsey","prisons",0.516243243255912
+"805","Bayley, Sir Hugh","york",13.0371547541972
+"806","Bayley, Sir Hugh","1995",5.96279136138744
+"807","Bayley, Sir Hugh","crown",5.08727107884578
+"808","Bayley, Sir Hugh","cathedral",4.54543283655548
+"809","Bayley, Sir Hugh","reburial",4.54543283655548
+"810","Bayley, Sir Hugh","2004",4.53451374718337
+"811","Bayley, Sir Hugh","magristrates",4.28547517620851
+"812","Bayley, Sir Hugh","king",4.1918794459622
+"813","Bayley, Sir Hugh","richard",3.98506397046232
+"814","Bayley, Sir Hugh","magistrages",3.87635814759977
+"815","Bayley, Sir Hugh","leicester",3.83832605536893
+"816","Bayley, Sir Hugh","witness",3.62769813125812
+"817","Bebb, Guto","violent",2.07634261619918
+"818","Bebb, Guto","murdered",1.95149793852278
+"819","Bebb, Guto","subject",1.87041297747788
+"820","Bebb, Guto","assaulted",1.7322232976726
+"821","Bebb, Guto","licence",1.55333073247474
+"822","Bebb, Guto","committed",1.49893414480089
+"823","Bebb, Guto","crime",1.44022271990776
+"824","Bebb, Guto","released",1.31486854114797
+"825","Bebb, Guto","england",1.08648714188543
+"826","Bebb, Guto","wales",1.08044214622602
+"827","Bebb, Guto","five",0.99612073645634
+"828","Bebb, Guto","people",0.931020697091796
+"829","Beckett, Margaret","eastern",3.87635814759977
+"830","Beckett, Margaret","europe",2.83330026878961
+"831","Beckett, Margaret","care",2.02213962478468
+"832","Beckett, Margaret","countries",1.91899079172409
+"833","Beckett, Margaret","proceedings",1.86883185095217
+"834","Beckett, Margaret","involving",1.8560995589208
+"835","Beckett, Margaret","families",1.54835914959439
+"836","Beckett, Margaret","children",1.46426739097766
+"837","Beckett, Margaret","estimate",1.4100227593455
+"838","Beckett, Margaret","number",1.26152352199167
+"839","Beckett, Margaret","will",0.813041680110636
+"840","Beckett, Margaret","convict",0
+"841","Beith, Sir Alan","archives",8.97425786613916
+"842","Beith, Sir Alan","targets",7.18817073082264
+"843","Beith, Sir Alan","meet",5.48523435018643
+"844","Beith, Sir Alan","records",5.34581310112626
+"845","Beith, Sir Alan","departments",4.55589571969595
+"846","Beith, Sir Alan","national",4.24475906723051
+"847","Beith, Sir Alan","clearing",3.61880850954184
+"848","Beith, Sir Alan","release",2.75365546461672
+"849","Beith, Sir Alan","encourage",2.69838631099963
+"850","Beith, Sir Alan","obligations",2.57324779654187
+"851","Beith, Sir Alan","material",2.33645998385951
+"852","Beith, Sir Alan","engaged",2.12047628526286
+"853","Bellingham, Sir Henry","beachy",6.91809396928489
+"854","Bellingham, Sir Henry","head",5.86352223883743
+"855","Bellingham, Sir Henry","northmoor",3.21410638215638
+"856","Bellingham, Sir Henry","paid",3.14729788248713
+"857","Bellingham, Sir Henry","iraq",2.71410638215638
+"858","Bellingham, Sir Henry","leigh",2.71410638215638
+"859","Bellingham, Sir Henry","verdicts",2.68572709037698
+"860","Bellingham, Sir Henry","died",2.65536262541257
+"861","Bellingham, Sir Henry","historic",2.56786575697609
+"862","Bellingham, Sir Henry","detailed",2.41846584846456
+"863","Bellingham, Sir Henry","related",2.32709290623502
+"864","Bellingham, Sir Henry","inquests",2.19490148079316
+"865","Benn, Hilary","contesting",21.0426400661948
+"866","Benn, Hilary","levied",20.8412623786122
+"867","Benn, Hilary","notice",20.0981431556632
+"868","Benn, Hilary","fixed",19.6448711179794
+"869","Benn, Hilary","local",18.7119406571172
+"870","Benn, Hilary","consequent",18.6913849201242
+"871","Benn, Hilary","authorities",18.073354555465
+"872","Benn, Hilary","penalty",17.3356340731073
+"873","Benn, Hilary","upon",16.8914174082424
+"874","Benn, Hilary","guilty",16.4551287238767
+"875","Benn, Hilary","area",15.6825204393465
+"876","Benn, Hilary","found",15.1586232624822
+"877","Benton, Joe","shared",10.1914359958947
+"878","Benton, Joe","privatisation",5.45436059540865
+"879","Benton, Joe","services",4.47437049428268
+"880","Benton, Joe","bootle",4.28547517620851
+"881","Benton, Joe","robust",4.0655587238791
+"882","Benton, Joe","shored",3.56434957305558
+"883","Benton, Joe","steria",3.43310319184542
+"884","Benton, Joe","commercial",2.72224609610137
+"885","Benton, Joe","jobs",2.66614817783265
+"886","Benton, Joe","union",2.59704245528317
+"887","Benton, Joe","bid",2.4306848901984
+"888","Benton, Joe","house",2.3603582316201
+"889","Benyon, Richard","upheld",5.45679489153083
+"890","Benyon, Richard","advisory",5.0249057998964
+"891","Benyon, Richard","complaints",4.82324353165127
+"892","Benyon, Richard","family",3.09671829918877
+"893","Benyon, Richard","support",2.98831434599134
+"894","Benyon, Richard","children",2.92853478195532
+"895","Benyon, Richard","three",2.66142980394467
+"896","Benyon, Richard","service",2.10461148606787
+"897","Benyon, Richard","made",1.72589440933412
+"898","Benyon, Richard","court",1.71740675329739
+"899","Benyon, Richard","years",1.12886273736366
+"900","Benyon, Richard","convict",0
+"901","Berger, Luciana","health",30.9110698986386
+"902","Berger, Luciana","mental",30.2156725114019
+"903","Berger, Luciana","2010",28.2972756186629
+"904","Berger, Luciana","prison",25.0375804490613
+"905","Berger, Luciana","self",24.5492366707352
+"906","Berger, Luciana","year",20.7304385610648
+"907","Berger, Luciana","harm",19.0113170518428
+"908","Berger, Luciana","death",17.258932594008
+"909","Berger, Luciana","suicide",16.699586561703
+"910","Berger, Luciana","bill",16.2904025805833
+"911","Berger, Luciana","inflicted",14.4291129339406
+"912","Berger, Luciana","include",13.8098012298951
+"913","Berry, Jake","grandchildren",15.5088809566374
+"914","Berry, Jake","grandparents",15.1469266297984
+"915","Berry, Jake","gap",11.8892517275204
+"916","Berry, Jake","see",10.2320783611728
+"917","Berry, Jake","applications",8.80125006000612
+"918","Berry, Jake","contact",7.31820085760917
+"919","Berry, Jake","order",6.25444484818896
+"920","Berry, Jake","employee",5.53941275840237
+"921","Berry, Jake","percentage",5.52879973959939
+"922","Berry, Jake","earnings",5.39647439313095
+"923","Berry, Jake","final",5.36689246418323
+"924","Berry, Jake","permission",5.34062553857743
+"925","Berry, James","occurrence",3.42265523528935
+"926","Berry, James","dropped",3.04104746457308
+"927","Berry, James","delayed",2.48505932319183
+"928","Berry, James","caused",2.06575516700017
+"929","Berry, James","london",2.01315759583639
+"930","Berry, James","two",1.91322529603858
+"931","Berry, James","crown",1.64445354805812
+"932","Berry, James","data",1.59767179159901
+"933","Berry, James","magistrates",1.33310777291295
+"934","Berry, James","cases",1.14100107964996
+"935","Berry, James","courts",0.822145890325361
+"936","Berry, James","years",0.540401892843998
+"937","Bingham, Andrew","drake",7.53644634553629
+"938","Bingham, Andrew","books",7.08199798964202
+"939","Bingham, Andrew","manchester",5.4127040229326
+"940","Bingham, Andrew","delivered",5.27016566415286
+"941","Bingham, Andrew","contain",5.19408491056634
+"942","Bingham, Andrew","packages",5.15829834502905
+"943","Bingham, Andrew","library",4.79976722982164
+"944","Bingham, Andrew","users",4.49124084452485
+"945","Bingham, Andrew","judiciary",4.37414155051009
+"946","Bingham, Andrew","found",4.0774626932314
+"947","Bingham, Andrew","identify",3.99318480861032
+"948","Bingham, Andrew","access",3.93667588382649
+"949","Blackford, Ian","devolved",3.81674328312721
+"950","Blackford, Ian","administrations",3.53398434115333
+"951","Blackford, Ian","policies",3.25189712525413
+"952","Blackford, Ian","discuss",3.14102057054366
+"953","Blackford, Ian","leaving",3.08677074565337
+"954","Blackford, Ian","convict",0
+"955","Blackford, Ian","five",0
+"956","Blackford, Ian","person",0
+"957","Blackford, Ian","rape",0
+"958","Blackford, Ian","year",0
+"959","Blackford, Ian","offenc",0
+"960","Blackford, Ian","sexual",0
+"961","Blackman-Woods, Dr Roberta","organ",5.99502952955874
+"962","Blackman-Woods, Dr Roberta","durham",5.88983196468393
+"963","Blackman-Woods, Dr Roberta","donors",5.6992517289863
+"964","Blackman-Woods, Dr Roberta","staffing",3.99922226674898
+"965","Blackman-Woods, Dr Roberta","donation",3.87635814759977
+"966","Blackman-Woods, Dr Roberta","frankland",3.398473972902
+"967","Blackman-Woods, Dr Roberta","newton",3.398473972902
+"968","Blackman-Woods, Dr Roberta","register",3.38093196917507
+"969","Blackman-Woods, Dr Roberta","prison",3.31338025556582
+"970","Blackman-Woods, Dr Roberta","occupation",3.02990879034318
+"971","Blackman-Woods, Dr Roberta","record",3.02676478921064
+"972","Blackman-Woods, Dr Roberta","contraband",3.0150728235643
+"973","Blackman, Bob","sex",2.61766408736122
+"974","Blackman, Bob","light",2.56650589561098
+"975","Blackman, Bob","abuse",2.2625183190908
+"976","Blackman, Bob","supporting",1.87302514031479
+"977","Blackman, Bob","victims",1.67603082871324
+"978","Blackman, Bob","cases",1.49392109014922
+"979","Blackman, Bob","2014",1.35322662730182
+"980","Blackman, Bob","convict",0
+"981","Blackman, Bob","five",0
+"982","Blackman, Bob","person",0
+"983","Blackman, Bob","rape",0
+"984","Blackman, Bob","year",0
+"985","Blackman, Kirsty","scotland",15.3882107340866
+"986","Blackman, Kirsty","24107",11.2140153591914
+"987","Blackman, Kirsty","breach",10.3544129883203
+"988","Blackman, Kirsty","tribunal",10.257975895473
+"989","Blackman, Kirsty","devolved",9.51224252378059
+"990","Blackman, Kirsty","data",8.91213674533955
+"991","Blackman, Kirsty","whose",8.81560740711276
+"992","Blackman, Kirsty","waiting",7.57242385821303
+"993","Blackman, Kirsty","february",6.09663732618779
+"994","Blackman, Kirsty","non",6.0805545883565
+"995","Blackman, Kirsty","service",5.0523929203284
+"996","Blackman, Kirsty","appeal",4.70367643537603
+"997","Blackwood, Nicola","modernise",5.26724871686908
+"998","Blackwood, Nicola","2020",2.87475914111963
+"999","Blackwood, Nicola","system",2.79951884296644
+"1000","Blackwood, Nicola","expenditure",2.45912224807632
+"1001","Blackwood, Nicola","research",2.39687496642186
+"1002","Blackwood, Nicola","development",2.19242859459094
+"1003","Blackwood, Nicola","spending",2.10267453211564
+"1004","Blackwood, Nicola","tribunals",2.06766316995917
+"1005","Blackwood, Nicola","allocated",2.05390474951407
+"1006","Blackwood, Nicola","funding",1.60556119691145
+"1007","Blackwood, Nicola","departments",1.53817158977317
+"1008","Blackwood, Nicola","courts",1.42399845327747
+"1009","Blenkinsop, Tom","illegal",4.9876099342528
+"1010","Blenkinsop, Tom","gender",4.87795218983675
+"1011","Blenkinsop, Tom","ethnic",4.62078488123567
+"1012","Blenkinsop, Tom","high",4.59736466125669
+"1013","Blenkinsop, Tom","made",3.95987599066207
+"1014","Blenkinsop, Tom","border",3.87635814759977
+"1015","Blenkinsop, Tom","availability",3.84983734922377
+"1016","Blenkinsop, Tom","drugs",3.8484345715412
+"1017","Blenkinsop, Tom","teesside",3.75715434263479
+"1018","Blenkinsop, Tom","safety",3.73205405292339
+"1019","Blenkinsop, Tom","movement",3.398473972902
+"1020","Blenkinsop, Tom","staff",3.30089083585957
+"1021","Blomfield, Paul","traffickers",22.3262759383296
+"1022","Blomfield, Paul","tribunal",21.1121874140795
+"1023","Blomfield, Paul","tier",16.5799689019821
+"1024","Blomfield, Paul","fee",14.1435460179117
+"1025","Blomfield, Paul","chamber",13.928982377861
+"1026","Blomfield, Paul","damages",13.5517667606982
+"1027","Blomfield, Paul","awarded",13.3090020289332
+"1028","Blomfield, Paul","brought",12.5958207734721
+"1029","Blomfield, Paul","slavery",12.546503851481
+"1030","Blomfield, Paul","tort",12.2898452765362
+"1031","Blomfield, Paul","victims",11.5917083345421
+"1032","Blomfield, Paul","first",11.539126806482
+"1033","Blunkett, David","books",7.19344502659529
+"1034","Blunkett, David","withheld",4.85927209970932
+"1035","Blunkett, David","withhold",4.85927209970932
+"1036","Blunkett, David","first",3.9198706386331
+"1037","Blunkett, David","arrive",3.72537868068164
+"1038","Blunkett, David","borrowed",3.57484680302201
+"1039","Blunkett, David","reasons",3.3994743918576
+"1040","Blunkett, David","brixton",2.79545128374647
+"1041","Blunkett, David","belmarsh",2.47618282379502
+"1042","Blunkett, David","restrictions",2.41162176582563
+"1043","Blunkett, David","yet",2.23738373325425
+"1044","Blunkett, David","population",2.19242859459094
+"1045","Blunt, Crispin","1617",3.21410638215638
+"1046","Blunt, Crispin","102",2.81786575697609
+"1047","Blunt, Crispin","states",2.11602702646169
+"1048","Blunt, Crispin","directive",2.11602702646169
+"1049","Blunt, Crispin","oral",1.96410638215638
+"1050","Blunt, Crispin","agreement",1.65690170953241
+"1051","Blunt, Crispin","transfer",1.50273386942029
+"1052","Blunt, Crispin","june",1.49344561981592
+"1053","Blunt, Crispin","member",1.30676722713648
+"1054","Blunt, Crispin","official",1.29248125036058
+"1055","Blunt, Crispin","2016",1.1171020608201
+"1056","Blunt, Crispin","report",1.07354577610111
+"1057","Bone, Peter","wellingborough",21.3325576492367
+"1058","Bone, Peter","open",10.6292516600387
+"1059","Bone, Peter","new",7.60021064150482
+"1060","Bone, Peter","hmp",7.46108313342997
+"1061","Bone, Peter","site",6.46227261630916
+"1062","Bone, Peter","prison",6.41660861946399
+"1063","Bone, Peter","completed",5.36890327360954
+"1064","Bone, Peter","will",5.18274828435496
+"1065","Bone, Peter","victorian",4.85927209970932
+"1066","Bone, Peter","encroaching",4.54543283655548
+"1067","Bone, Peter","investment",4.47476746650851
+"1068","Bone, Peter","build",4.19204332059297
+"1069","Boswell, Phil","reconsideration",2.84879127854937
+"1070","Boswell, Phil","accepted",2.53941356285557
+"1071","Boswell, Phil","stage",2.38756776911296
+"1072","Boswell, Phil","mandatory",2.14312373374476
+"1073","Boswell, Phil","april",1.69974148357484
+"1074","Boswell, Phil","october",1.67062816592052
+"1075","Boswell, Phil","independence",1.61807647981551
+"1076","Boswell, Phil","decisions",1.59709098712623
+"1077","Boswell, Phil","payment",1.4620407879863
+"1078","Boswell, Phil","appealed",1.41491207216449
+"1079","Boswell, Phil","personal",1.24170946951188
+"1080","Boswell, Phil","2016",1.23931346468103
+"1081","Bottomley, Sir Peter","mire",16.5902100055016
+"1082","Bottomley, Sir Peter","benjamin",15.5223512514028
+"1083","Bottomley, Sir Peter","judicial",11.2695748552856
+"1084","Bottomley, Sir Peter","investigation",8.26688337091185
+"1085","Bottomley, Sir Peter","conduct",8.26688337091185
+"1086","Bottomley, Sir Peter","office",5.49982051088861
+"1087","Bottomley, Sir Peter","property",4.76941723791318
+"1088","Bottomley, Sir Peter","appointment",4.11142465389102
+"1089","Bottomley, Sir Peter","shown",3.98506397046232
+"1090","Bottomley, Sir Peter","report",3.88651369416376
+"1091","Bottomley, Sir Peter","councillor",3.87635814759977
+"1092","Bottomley, Sir Peter","gurpai",3.87635814759977
+"1093","Brabin, Tracy","code",5.29947484838107
+"1094","Brabin, Tracy","seconded",4.34325026359161
+"1095","Brabin, Tracy","exit",3.63151057986905
+"1096","Brabin, Tracy","crime",3.59240083594441
+"1097","Brabin, Tracy","takes",3.55172985105962
+"1098","Brabin, Tracy","organisations",3.30424900759097
+"1099","Brabin, Tracy","trade",3.13121927418238
+"1100","Brabin, Tracy","victims",2.95612051865623
+"1101","Brabin, Tracy","aware",2.95267033473516
+"1102","Brabin, Tracy","existence",2.93639188796211
+"1103","Brabin, Tracy","union",2.90358173523306
+"1104","Brabin, Tracy","committee",2.58158911469325
+"1105","Bradshaw, Ben","mediation",49.8582967313865
+"1106","Bradshaw, Ben","families",23.3006145453217
+"1107","Bradshaw, Ben","television",12.2243116731461
+"1108","Bradshaw, Ben","inform",12.1469948473432
+"1109","Bradshaw, Ben","221",11.1234574364979
+"1110","Bradshaw, Ben","4460",11.1234574364979
+"1111","Bradshaw, Ben","service",10.5028660965404
+"1112","Bradshaw, Ben","profit",10.0362574393813
+"1113","Bradshaw, Ben","devon",9.9797741087339
+"1114","Bradshaw, Ben","england",9.69125035800428
+"1115","Bradshaw, Ben","wales",9.63733019264764
+"1116","Bradshaw, Ben","curfew",9.2376127291468
+"1117","Brady, Graham","212354",6.23007891928364
+"1118","Brady, Graham","open",5.2285417591658
+"1119","Brady, Graham","serving",3.11824024378291
+"1120","Brady, Graham","offence",3.11743173065374
+"1121","Brady, Graham","broken",2.73752311295027
+"1122","Brady, Graham","robbery",2.51145226262694
+"1123","Brady, Graham","specific",2.39186382073675
+"1124","Brady, Graham","indeterminate",2.18542331562958
+"1125","Brady, Graham","serious",2.17219184191364
+"1126","Brady, Graham","imprisoned",2.14338692464114
+"1127","Brady, Graham","sentenced",2.06580258411467
+"1128","Brady, Graham","answer",2.06434766755989
+"1129","Brake, Tom","referendum",7.14788187823327
+"1130","Brake, Tom","outcome",5.30920372199253
+"1131","Brake, Tom","pool",5.30235469043411
+"1132","Brake, Tom","redeployment",4.85514109493415
+"1133","Brake, Tom","states",4.55940457314206
+"1134","Brake, Tom","civil",4.35198047281962
+"1135","Brake, Tom","exceeded",3.83630669925203
+"1136","Brake, Tom","legislation",3.83177851508317
+"1137","Brake, Tom","servants",3.81674328312721
+"1138","Brake, Tom","potential",3.62270361378746
+"1139","Brake, Tom","pan",3.21410638215638
+"1140","Brake, Tom","departments",3.17319985191685
+"1141","Brennan, Kevin","blind",8.5936040377554
+"1142","Brennan, Kevin","guide",7.66162595986859
+"1143","Brennan, Kevin","taxi",7.06876134138484
+"1144","Brennan, Kevin","licensed",6.98071904559484
+"1145","Brennan, Kevin","dogs",6.3531530792417
+"1146","Brennan, Kevin","occupancy",4.49408099739619
+"1147","Brennan, Kevin","readmission",4.0655587238791
+"1148","Brennan, Kevin","guitars",3.87635814759977
+"1149","Brennan, Kevin","strung",3.87635814759977
+"1150","Brennan, Kevin","equality",3.48475195106254
+"1151","Brennan, Kevin","steel",3.398473972902
+"1152","Brennan, Kevin","partially",3.33130058958113
+"1153","Bridgen, Andrew","gastric",6.13286939357901
+"1154","Bridgen, Andrew","holiday",5.83029096398379
+"1155","Bridgen, Andrew","customers",4.4145647416738
+"1156","Bridgen, Andrew","illegitimate",4.31026736023359
+"1157","Bridgen, Andrew","package",4.21877534935129
+"1158","Bridgen, Andrew","declined",3.42382100930146
+"1159","Bridgen, Andrew","illegitimate",3.16876301142263
+"1160","Bridgen, Andrew","molestation",3.09048767596813
+"1161","Bridgen, Andrew","non",2.83158484067264
+"1162","Bridgen, Andrew","claims",2.5664473945705
+"1163","Bridgen, Andrew","handling",2.51145226262694
+"1164","Bridgen, Andrew","fraudulent",2.47790272318285
+"1165","Brock, Deidre","media",5.88347350699198
+"1166","Brock, Deidre","leaves",4.62298306897999
+"1167","Brock, Deidre","portfolio",4.0655587238791
+"1168","Brock, Deidre","schengen",4.0655587238791
+"1169","Brock, Deidre","advertising",3.46063735173971
+"1170","Brock, Deidre","partners",3.24812180703875
+"1171","Brock, Deidre","matters",3.07114171377589
+"1172","Brock, Deidre","month",2.87552404902184
+"1173","Brock, Deidre","international",2.81058502920784
+"1174","Brock, Deidre","engagements",2.73752311295027
+"1175","Brock, Deidre","departmental",2.66614817783265
+"1176","Brock, Deidre","continue",2.63508283207643
+"1177","Brooke, Annette","guidelines",3.10615630769572
+"1178","Brooke, Annette","violence",2.37275188695556
+"1179","Brooke, Annette","domestic",2.35516915487073
+"1180","Brooke, Annette","review",1.80689590148317
+"1181","Brooke, Annette","sentencing",1.42572177895689
+"1182","Brooke, Annette","will",1.10086363896476
+"1183","Brooke, Annette","convict",0
+"1184","Brooke, Annette","five",0
+"1185","Brooke, Annette","person",0
+"1186","Brooke, Annette","rape",0
+"1187","Brooke, Annette","year",0
+"1188","Brooke, Annette","offenc",0
+"1189","Brown, Lyn","red",4.28547517620851
+"1190","Brown, Lyn","box",3.75715434263479
+"1191","Brown, Lyn","gateway",3.61880850954184
+"1192","Brown, Lyn","ict",3.61880850954184
+"1193","Brown, Lyn","journeys",3.28547517620851
+"1194","Brown, Lyn","transportation",2.89550017572774
+"1195","Brown, Lyn","car",2.84483247791272
+"1196","Brown, Lyn","ministers",2.32459415975456
+"1197","Brown, Lyn","progress",2.09552330676486
+"1198","Brown, Lyn","made",1.90804806117778
+"1199","Brown, Lyn","management",1.86634589531096
+"1200","Brown, Lyn","system",1.86634589531096
+"1201","Brown, Nicholas","subscriptions",7.1579362566573
+"1202","Brown, Nicholas","organisations",7.03706702141458
+"1203","Brown, Nicholas","rehabilitation",6.65887487046704
+"1204","Brown, Nicholas","probation",5.17644270875136
+"1205","Brown, Nicholas","transforming",4.86231930921982
+"1206","Brown, Nicholas","publish",4.38691593920083
+"1207","Brown, Nicholas","agencies",4.24913837306788
+"1208","Brown, Nicholas","rights",4.24292663794087
+"1209","Brown, Nicholas","report",4.08407921977999
+"1210","Brown, Nicholas","northumbria",3.83832605536893
+"1211","Brown, Nicholas","implement",3.82009877522051
+"1212","Brown, Nicholas","classified",3.72450728589427
+"1213","Bruce, Fiona","abortions",13.5194772043894
+"1214","Bruce, Fiona","1986",12.4733259387359
+"1215","Bruce, Fiona","1861",9.16946197089928
+"1216","Bruce, Fiona","act",8.1672187698088
+"1217","Bruce, Fiona","section",7.81700567341495
+"1218","Bruce, Fiona","performing",7.36899294803125
+"1219","Bruce, Fiona","vulnerable",6.2987513618085
+"1220","Bruce, Fiona","offence",6.16702753806337
+"1221","Bruce, Fiona","people",6.00325632892314
+"1222","Bruce, Fiona","1929",5.93692148414294
+"1223","Bruce, Fiona","miscarriage",5.7461565375544
+"1224","Bruce, Fiona","recorded",5.65733995320207
+"1225","Bryant, Chris","waive",4.26021258338486
+"1226","Bryant, Chris","universal",2.51226765164198
+"1227","Bryant, Chris","local",2.29615904930097
+"1228","Bryant, Chris","fully",2.23738373325425
+"1229","Bryant, Chris","authorities",2.21779757504583
+"1230","Bryant, Chris","rolled",2.1922406718438
+"1231","Bryant, Chris","age",2.18854142260176
+"1232","Bryant, Chris","extending",2.03899645262111
+"1233","Bryant, Chris","credit",1.98738373325425
+"1234","Bryant, Chris","remission",1.98738373325425
+"1235","Bryant, Chris","fees",1.98677504739601
+"1236","Bryant, Chris","claimants",1.90212450379549
+"1237","Buck, Karen","authorities",8.38261088438084
+"1238","Buck, Karen","judicial",7.83765945275594
+"1239","Buck, Karen","local",6.84709253542573
+"1240","Buck, Karen","2004",6.43057861385615
+"1241","Buck, Karen","review",4.84758772015571
+"1242","Buck, Karen","successful",4.79927877224229
+"1243","Buck, Karen","applications",4.57181672849752
+"1244","Buck, Karen","england",4.45251639714015
+"1245","Buck, Karen","five",4.08218720831479
+"1246","Buck, Karen","mortgage",3.95214184287518
+"1247","Buck, Karen","children",3.85477745610266
+"1248","Buck, Karen","landlord",3.42382100930146
+"1249","Buckland, Robert","injury",4.62474133398428
+"1250","Buckland, Robert","fraud",4.09423371253565
+"1251","Buckland, Robert","12th",3.71133036988416
+"1252","Buckland, Robert","personal",3.68549456094398
+"1253","Buckland, Robert","genuine",3.16876301142263
+"1254","Buckland, Robert","elements",3.0124252070077
+"1255","Buckland, Robert","discourage",2.81546286706411
+"1256","Buckland, Robert","adopt",2.75237232997826
+"1257","Buckland, Robert","exaggerating",2.68572709037698
+"1258","Buckland, Robert","treated",2.68572709037698
+"1259","Buckland, Robert","proposal",2.66312222609193
+"1260","Buckland, Robert","fabricating",2.54820162515169
+"1261","Burden, Richard","week",12.8998432553751
+"1262","Burden, Richard","hours",12.6967321740662
+"1263","Burden, Richard","per",12.4374205404108
+"1264","Burden, Richard","unemployed",11.382036212322
+"1265","Burden, Richard","classed",10.5483799831236
+"1266","Burden, Richard","proportion",10.2617087597553
+"1267","Burden, Richard","work",9.71821984016902
+"1268","Burden, Richard","antisemitism",9.50600314642163
+"1269","Burden, Richard","cells",9.33942441116939
+"1270","Burden, Richard","spent",9.02325368125415
+"1271","Burden, Richard","drone",7.63423187131152
+"1272","Burden, Richard","data",7.2453165931031
+"1273","Burgon, Richard","prison",32.4643323206335
+"1274","Burgon, Richard","2010",24.294614074447
+"1275","Burgon, Richard","officer",21.2293760537854
+"1276","Burgon, Richard","2016",19.3559241788484
+"1277","Burgon, Richard","year",17.6589899767865
+"1278","Burgon, Richard","will",17.0093942793185
+"1279","Burgon, Richard","cell",16.7135972339824
+"1280","Burgon, Richard","service",15.7382060515413
+"1281","Burgon, Richard","bedford",14.7947367529322
+"1282","Burgon, Richard","establishment",14.5588176307019
+"1283","Burgon, Richard","month",14.4594603024692
+"1284","Burgon, Richard","incident",14.0434577247085
+"1285","Burley, Aidan","growth",5.63573151395219
+"1286","Burley, Aidan","culture",4.63573151395219
+"1287","Burley, Aidan","address",3.8844813436876
+"1288","Burley, Aidan","compensation",2.96878114567547
+"1289","Burley, Aidan","convict",0
+"1290","Burley, Aidan","five",0
+"1291","Burley, Aidan","person",0
+"1292","Burley, Aidan","rape",0
+"1293","Burley, Aidan","year",0
+"1294","Burley, Aidan","offenc",0
+"1295","Burley, Aidan","sexual",0
+"1296","Burley, Aidan","agreement",0
+"1297","Burnham, Andy","tenants",4.26021258338486
+"1298","Burnham, Andy","evicted",3.79819167604396
+"1299","Burnham, Andy","manchester",3.14952638886365
+"1300","Burnham, Andy","greater",3.12631916435718
+"1301","Burnham, Andy","2010",1.28782961157414
+"1302","Burnham, Andy","courts",1.07644164991795
+"1303","Burnham, Andy","year",0.707552165615724
+"1304","Burnham, Andy","convict",0
+"1305","Burnham, Andy","five",0
+"1306","Burnham, Andy","person",0
+"1307","Burnham, Andy","rape",0
+"1308","Burnham, Andy","offenc",0
+"1309","Burns, Sir Simon","chelmsford",3.60370129795068
+"1310","Burns, Sir Simon","wildlife",3.398473972902
+"1311","Burns, Sir Simon","00156",3.21410638215638
+"1312","Burns, Sir Simon","sc133/14/00156",3.21410638215638
+"1313","Burns, Sir Simon","ref",2.96410638215638
+"1314","Burns, Sir Simon","trade",2.67031276928871
+"1315","Burns, Sir Simon","inspectorate",2.53488617054572
+"1316","Burns, Sir Simon","illegal",2.36880142471095
+"1317","Burns, Sir Simon","hmp",2.28633378400705
+"1318","Burns, Sir Simon","concerning",2.24027776537461
+"1319","Burns, Sir Simon","ely",2.21410638215638
+"1320","Burns, Sir Simon","send",2.13362435843454
+"1321","Burrowes, David","141a",13.7909123584348
+"1322","Burrowes, David","sentence",10.6287299468013
+"1323","Burrowes, David","custodial",10.1470402533738
+"1324","Burrowes, David","knives",9.53923625106614
+"1325","Burrowes, David","criminal",9.42378900207783
+"1326","Burrowes, David","section",9.39935265499191
+"1327","Burrowes, David","implementation",8.45444366859758
+"1328","Burrowes, David","length",7.98764029360404
+"1329","Burrowes, David","1998",7.57983526879287
+"1330","Burrowes, David","convicted",7.39746170621584
+"1331","Burrowes, David","suppliers",7.36403905166654
+"1332","Burrowes, David","act",7.33879249487137
+"1333","Burstow, Paul","stigma",4.54543283655548
+"1334","Burstow, Paul","pledge",3.98506397046232
+"1335","Burstow, Paul","signing",2.81058502920784
+"1336","Burstow, Paul","discrimination",2.73195743460209
+"1337","Burstow, Paul","mental",2.24457997622849
+"1338","Burstow, Paul","health",2.18139790396614
+"1339","Burstow, Paul","result",1.95040398158957
+"1340","Burstow, Paul","time",1.58134575821989
+"1341","Burstow, Paul","convict",0
+"1342","Burstow, Paul","five",0
+"1343","Burstow, Paul","person",0
+"1344","Burstow, Paul","rape",0
+"1345","Butler, Dawn","equal",11.3141222807118
+"1346","Butler, Dawn","tribunal",10.0902200574146
+"1347","Butler, Dawn","pay",8.98440365525128
+"1348","Butler, Dawn","fees",8.8835366775969
+"1349","Butler, Dawn","employers",8.28082518922751
+"1350","Butler, Dawn","men",7.26317703153937
+"1351","Butler, Dawn","answer",6.85868601091917
+"1352","Butler, Dawn","2016",6.68390543352986
+"1353","Butler, Dawn","women",6.03138731006016
+"1354","Butler, Dawn","51088",6.02542229001739
+"1355","Butler, Dawn","33501",5.92821276431277
+"1356","Butler, Dawn","brought",5.71232474716979
+"1357","Byles, Dan","faulty",2.4722356219127
+"1358","Byles, Dan","incorrectly",2.4722356219127
+"1359","Byles, Dan","contributory",2.4722356219127
+"1360","Byles, Dan","seat",2.4722356219127
+"1361","Byles, Dan","passenger",2.35026250882946
+"1362","Byles, Dan","factor",2.14174809477239
+"1363","Byles, Dan","fitted",1.9880801457246
+"1364","Byles, Dan","accident",1.82845511664639
+"1365","Byles, Dan","traffic",1.82845511664639
+"1366","Byles, Dan","car",1.77956573166752
+"1367","Byles, Dan","inquest",1.71243908359357
+"1368","Byles, Dan","road",1.65759261858429
+"1369","Byrne, Liam","birmingham",17.9257052733577
+"1370","Byrne, Liam","human",12.0014231934519
+"1371","Byrne, Liam","rights",10.5698989835732
+"1372","Byrne, Liam","hodge",9.04884582330077
+"1373","Byrne, Liam","european",8.6134533025368
+"1374","Byrne, Liam","mortem",8.29227267344015
+"1375","Byrne, Liam","hill",7.7764217139165
+"1376","Byrne, Liam","signatory",7.63199115780069
+"1377","Byrne, Liam","convention",7.27847834579525
+"1378","Byrne, Liam","city",6.27157873066135
+"1379","Byrne, Liam","midlands",6.1708012543721
+"1380","Byrne, Liam","post",5.5342039357506
+"1381","Cadbury, Ruth","hardship",6.40731555913878
+"1382","Cadbury, Ruth","avoidable",6.07871195836422
+"1383","Cadbury, Ruth","exceptional",4.84694738305701
+"1384","Cadbury, Ruth","legislation",4.60700791659635
+"1385","Cadbury, Ruth","enterprise",4.47476746650851
+"1386","Cadbury, Ruth","joint",4.34325026359161
+"1387","Cadbury, Ruth","unsafe",3.74933095786226
+"1388","Cadbury, Ruth","within",3.61696083225212
+"1389","Cadbury, Ruth","review",3.54746755182806
+"1390","Cadbury, Ruth","forthcoming",3.27333545844424
+"1391","Cadbury, Ruth","disqualification",3.13398010069454
+"1392","Cadbury, Ruth","pleading",2.79545128374647
+"1393","Cameron, Dr Lisa","childhood",6.26796020138908
+"1394","Cameron, Dr Lisa","complainants",4.9273943907669
+"1395","Cameron, Dr Lisa","agreed",4.9273943907669
+"1396","Cameron, Dr Lisa","special",4.37113234593276
+"1397","Cameron, Dr Lisa","measures",4.13151033400033
+"1398","Cameron, Dr Lisa","applied",3.84896386446239
+"1399","Cameron, Dr Lisa","military",3.57484680302201
+"1400","Cameron, Dr Lisa","abuse",3.45605381948594
+"1401","Cameron, Dr Lisa","domestic",3.33071216050097
+"1402","Cameron, Dr Lisa","dependencies",3.28318859405118
+"1403","Cameron, Dr Lisa","five",3.27564248255662
+"1404","Cameron, Dr Lisa","combat",3.27333545844424
+"1405","Campbell, Gregory","campaign",8.92794129211439
+"1406","Campbell, Gregory","reoffending",7.24309660468607
+"1407","Campbell, Gregory","nspccs",6.5767615672584
+"1408","Campbell, Gregory","rate",6.46788357996815
+"1409","Campbell, Gregory","population",6.2446849293019
+"1410","Campbell, Gregory","treats",5.57422143734441
+"1411","Campbell, Gregory","10000",5.28038596398365
+"1412","Campbell, Gregory","way",4.49392473300466
+"1413","Campbell, Gregory","seeking",4.35796078235748
+"1414","Campbell, Gregory","people",4.30296274920612
+"1415","Campbell, Gregory","drug",4.20820006045262
+"1416","Campbell, Gregory","television",4.15230640541991
+"1417","Campbell, Ronnie","northumberland",2.84483247791272
+"1418","Campbell, Ronnie","stalking",2.68302353552264
+"1419","Campbell, Ronnie","harassment",2.64984497767234
+"1420","Campbell, Ronnie","two",2.20920227937655
+"1421","Campbell, Ronnie","received",1.46158343807783
+"1422","Campbell, Ronnie","sentences",1.16409695787249
+"1423","Campbell, Ronnie","people",1.16118682283765
+"1424","Campbell, Ronnie","years",0.624002356608131
+"1425","Campbell, Ronnie","prison",0.596106350922253
+"1426","Campbell, Ronnie","convict",0
+"1427","Campbell, Ronnie","five",0
+"1428","Campbell, Ronnie","person",0
+"1429","Carmichael, Alistair","legal",6.47623325493263
+"1430","Carmichael, Alistair","review",5.67898674468476
+"1431","Carmichael, Alistair","recognition",5.36443292022196
+"1432","Carmichael, Alistair","obtaining",5.31398650568272
+"1433","Carmichael, Alistair","will",5.1095845429594
+"1434","Carmichael, Alistair","punishment",4.97742543720109
+"1435","Carmichael, Alistair","aid",4.93749046037235
+"1436","Carmichael, Alistair","civil",4.73881108420018
+"1437","Carmichael, Alistair","introduced",4.44444817560717
+"1438","Carmichael, Alistair","gender",4.34438208161248
+"1439","Carmichael, Alistair","act",3.98519205504625
+"1440","Carmichael, Alistair","reforms",3.96125444600002
+"1441","Carmichael, Neil","drug",3.49990291034483
+"1442","Carmichael, Neil","reduction",3.4018773081697
+"1443","Carmichael, Neil","need",2.92141897371393
+"1444","Carmichael, Neil","use",2.76570197435
+"1445","Carmichael, Neil","reoffending",2.68260903280906
+"1446","Carmichael, Neil","education",2.53041028815706
+"1447","Carmichael, Neil","receive",1.79006681989671
+"1448","Carmichael, Neil","prisoners",1.76256468260781
+"1449","Carmichael, Neil","convict",0
+"1450","Carmichael, Neil","five",0
+"1451","Carmichael, Neil","person",0
+"1452","Carmichael, Neil","rape",0
+"1453","Carswell, Douglas","2014",7.22717374906449
+"1454","Carswell, Douglas","emergency",7.11040571079568
+"1455","Carswell, Douglas","2015",6.48008198882272
+"1456","Carswell, Douglas","order",6.18881858023803
+"1457","Carswell, Douglas","local",5.89751296765072
+"1458","Carswell, Douglas","president",5.71624556225518
+"1459","Carswell, Douglas","authorities",5.69624737556352
+"1460","Carswell, Douglas","march",5.34672671473729
+"1461","Carswell, Douglas","reasons",5.25526495681517
+"1462","Carswell, Douglas","2011",5.25526495681517
+"1463","Carswell, Douglas","england",5.11998952386202
+"1464","Carswell, Douglas","january",4.920387835732
+"1465","Caulfield, Maria","modernise",5.26724871686908
+"1466","Caulfield, Maria","estate",3.0441206019243
+"1467","Caulfield, Maria","will",1.34827709592357
+"1468","Caulfield, Maria","prison",0.894159526383379
+"1469","Caulfield, Maria","convict",0
+"1470","Caulfield, Maria","five",0
+"1471","Caulfield, Maria","person",0
+"1472","Caulfield, Maria","rape",0
+"1473","Caulfield, Maria","year",0
+"1474","Caulfield, Maria","offenc",0
+"1475","Caulfield, Maria","sexual",0
+"1476","Caulfield, Maria","agreement",0
+"1477","Chalk, Alex","imprisoned",6.22554027007914
+"1478","Chalk, Alex","incentivise",5.92821276431277
+"1479","Chalk, Alex","tariff",5.59799593999216
+"1480","Chalk, Alex","subject",4.66562968899864
+"1481","Chalk, Alex","cruelty",3.66115306706041
+"1482","Chalk, Alex","recruit",3.65091833847395
+"1483","Chalk, Alex","sentence",3.64815579538675
+"1484","Chalk, Alex","psychiatric",3.57484680302201
+"1485","Chalk, Alex","served",3.51430868526958
+"1486","Chalk, Alex","protection",3.47504622590054
+"1487","Chalk, Alex","arabia",3.46063735173971
+"1488","Chalk, Alex","animal",3.42022720303473
+"1489","Champion, Sarah","modern",10.9417926893542
+"1490","Champion, Sarah","traffickers",10.8520650428597
+"1491","Champion, Sarah","slavery",10.6399343104724
+"1492","Champion, Sarah","remote",9.82604768952721
+"1493","Champion, Sarah","probation",9.46257277657383
+"1494","Champion, Sarah","compensate",9.37894939266724
+"1495","Champion, Sarah","force",8.5685946779902
+"1496","Champion, Sarah","england",7.48180960538076
+"1497","Champion, Sarah","wales",7.44018232343197
+"1498","Champion, Sarah","private",6.95895034013313
+"1499","Champion, Sarah","enable",6.94689284832266
+"1500","Champion, Sarah","evidence",6.82995752116492
+"1501","Chapman, Jenny","england",21.9903952421796
+"1502","Chapman, Jenny","wales",21.8680451115035
+"1503","Chapman, Jenny","officer",20.6628927486045
+"1504","Chapman, Jenny","prison",17.5804101875946
+"1505","Chapman, Jenny","month",17.4707908027187
+"1506","Chapman, Jenny","2013",15.5405096513609
+"1507","Chapman, Jenny","institution",13.5365890520457
+"1508","Chapman, Jenny","young",12.4143976535181
+"1509","Chapman, Jenny","staff",11.3395292400826
+"1510","Chapman, Jenny","sick",10.5294938305919
+"1511","Chapman, Jenny","offender",10.378155803036
+"1512","Chapman, Jenny","assault",10.2353569076879
+"1513","Chishti, Rehman","gypsies",10.7350286298976
+"1514","Chishti, Rehman","tobacco",9.93248197779578
+"1515","Chishti, Rehman","traveller",8.9586415127135
+"1516","Chishti, Rehman","install",8.22504849162305
+"1517","Chishti, Rehman","medway",6.79472021199886
+"1518","Chishti, Rehman","kent",6.68776963027678
+"1519","Chishti, Rehman","young",6.56334145615621
+"1520","Chishti, Rehman","selling",6.15563932705029
+"1521","Chishti, Rehman","illicit",5.99776342017476
+"1522","Chishti, Rehman","centre",5.75089812028855
+"1523","Chishti, Rehman","loops",5.74956828593407
+"1524","Chishti, Rehman","induction",5.04075150725396
+"1525","Chope, Christopher","european",7.42274120273764
+"1526","Chope, Christopher","human",6.84864181874805
+"1527","Chope, Christopher","convention",6.48104174970722
+"1528","Chope, Christopher","rights",6.03173898895075
+"1529","Chope, Christopher","accede",5.85590220516915
+"1530","Chope, Christopher","foreign",4.43410875018806
+"1531","Chope, Christopher","governments",4.38661137846893
+"1532","Chope, Christopher","england",4.34484126659009
+"1533","Chope, Christopher","wales",4.32066744475199
+"1534","Chope, Christopher","par",4.28547517620851
+"1535","Chope, Christopher","defendants",4.24572746735505
+"1536","Chope, Christopher","muslim",4.23205405292339
+"1537","Churchill, Jo","edmunds",4.9226688134498
+"1538","Churchill, Jo","suffolk",4.71174721711286
+"1539","Churchill, Jo","bury",4.26734298226969
+"1540","Churchill, Jo","allowance",3.12144906219678
+"1541","Churchill, Jo","successful",2.98197938115395
+"1542","Churchill, Jo","independence",2.96486165378729
+"1543","Churchill, Jo","decisions",2.92640915581428
+"1544","Churchill, Jo","payment",2.67895165812421
+"1545","Churchill, Jo","appealed",2.59259596105094
+"1546","Churchill, Jo","claims",2.52148355769529
+"1547","Churchill, Jo","support",2.51840943990854
+"1548","Churchill, Jo","personal",2.27523039684756
+"1549","Clark, Katy","hardship",6.54667091688848
+"1550","Clark, Katy","compensation",5.22726826401484
+"1551","Clark, Katy","injuries",4.94595262120681
+"1552","Clark, Katy","applications",4.92096605562716
+"1553","Clark, Katy","criminal",3.95681942987857
+"1554","Clark, Katy","successful",3.53838086172213
+"1555","Clark, Katy","authoritys",3.53838086172213
+"1556","Clark, Katy","aimed",3.398473972902
+"1557","Clark, Katy","emotional",3.398473972902
+"1558","Clark, Katy","fund",3.21112239382291
+"1559","Clark, Katy","2012",2.90837995368856
+"1560","Clark, Katy","reached",2.40920177346954
+"1561","Clegg, Nick","cultivation",3.31951479760817
+"1562","Clegg, Nick","cannabis",2.91027923963108
+"1563","Clegg, Nick","mitigation",2.91027923963108
+"1564","Clegg, Nick","cited",2.71999554143551
+"1565","Clegg, Nick","medical",2.31075998345843
+"1566","Clegg, Nick","serious",1.68257256569982
+"1567","Clegg, Nick","purse",1.6646171739419
+"1568","Clegg, Nick","condition",1.65595394027634
+"1569","Clegg, Nick","records",1.54559425485367
+"1570","Clegg, Nick","prosecuted",1.40423351395645
+"1571","Clegg, Nick","cost",1.12900298309909
+"1572","Clegg, Nick","public",1.09615775535814
+"1573","Clwyd, Ann","macur",33.6458038881538
+"1574","Clwyd, Ann","lady",16.7020366676705
+"1575","Clwyd, Ann","review",12.9265720837365
+"1576","Clwyd, Ann","19906",11.1406922859991
+"1577","Clwyd, Ann","updated",10.7247367411583
+"1578","Clwyd, Ann","gordon",9.21043257725263
+"1579","Clwyd, Ann","redactions",9.21043257725263
+"1580","Clwyd, Ann","reinstated",8.93731349170599
+"1581","Clwyd, Ann","report",8.93312828863306
+"1582","Clwyd, Ann","consider",7.28147867806785
+"1583","Clwyd, Ann","publish",6.97445408405933
+"1584","Clwyd, Ann","angelsea",6.63616271088302
+"1585","Coaker, Vernon","nottinghamshire",16.4557875959754
+"1586","Coaker, Vernon","framework",12.4721101140848
+"1587","Coaker, Vernon","true",9.50607385998472
+"1588","Coaker, Vernon","vision",8.88453525820181
+"1589","Coaker, Vernon","northern",8.77206066225221
+"1590","Coaker, Vernon","ireland",8.68493755867733
+"1591","Coaker, Vernon","portal",8.66269852916468
+"1592","Coaker, Vernon","human",8.47444290115201
+"1593","Coaker, Vernon","nottingham",8.31266614090767
+"1594","Coaker, Vernon","reform",8.02562467328355
+"1595","Coaker, Vernon","police",8.00470864889922
+"1596","Coaker, Vernon","rights",7.46361526990464
+"1597","Coffey, Ann","intermediaries",31.3372873894427
+"1598","Coffey, Ann","registered",26.1971921881121
+"1599","Coffey, Ann","greater",17.5207580937869
+"1600","Coffey, Ann","sexual",17.1097414858253
+"1601","Coffey, Ann","manchester",15.6298015297423
+"1602","Coffey, Ann","2014",15.1852194864011
+"1603","Coffey, Ann","complete",13.2403778964692
+"1604","Coffey, Ann","2013",13.2058553101187
+"1605","Coffey, Ann","prosecuted",12.0525847593443
+"1606","Coffey, Ann","requester",11.8839493752224
+"1607","Coffey, Ann","old",11.4866407045231
+"1608","Coffey, Ann","offence",10.9221109660268
+"1609","Coffey, Dr Thérèse","dissolved",4.85927209970932
+"1610","Coffey, Dr Thérèse","partnerships",3.66115306706041
+"1611","Coffey, Dr Thérèse","county",2.8757419427
+"1612","Coffey, Dr Thérèse","can",2.82116768671028
+"1613","Coffey, Dr Thérèse","civil",2.23524826333986
+"1614","Coffey, Dr Thérèse","court",1.07644164991795
+"1615","Coffey, Dr Thérèse","will",1.01920168406233
+"1616","Coffey, Dr Thérèse","convict",0
+"1617","Coffey, Dr Thérèse","five",0
+"1618","Coffey, Dr Thérèse","person",0
+"1619","Coffey, Dr Thérèse","rape",0
+"1620","Coffey, Dr Thérèse","year",0
+"1621","Colvile, Oliver","drugs",6.53090774148254
+"1622","Colvile, Oliver","combat",5.42821276431277
+"1623","Colvile, Oliver","supply",4.42821276431277
+"1624","Colvile, Oliver","covenant",3.43310319184542
+"1625","Colvile, Oliver","level",3.387741754579
+"1626","Colvile, Oliver","clerks",3.33130058958113
+"1627","Colvile, Oliver","armed",3.0150728235643
+"1628","Colvile, Oliver","accordance",2.80064765981174
+"1629","Colvile, Oliver","forces",1.95110159969754
+"1630","Colvile, Oliver","prisons",1.9266460128952
+"1631","Colvile, Oliver","operate",1.90480917926102
+"1632","Colvile, Oliver","given",1.79822935816472
+"1633","Cooper, Julie","lancashire",11.7779083049811
+"1634","Cooper, Julie","burnley",9.78366231713421
+"1635","Cooper, Julie","reduction",5.14753573202463
+"1636","Cooper, Julie","sold",4.593537911754
+"1637","Cooper, Julie","sanctions",4.34325026359161
+"1638","Cooper, Julie","bargaining",4.0655587238791
+"1639","Cooper, Julie","time",4.062341416456
+"1640","Cooper, Julie","benefit",3.51176775723039
+"1641","Cooper, Julie","mothers",3.50428363736641
+"1642","Cooper, Julie","court",3.28750086197651
+"1643","Cooper, Julie","attended",3.04720937404941
+"1644","Cooper, Julie","committee",2.98096234061031
+"1645","Cooper, Rosie","wigan",8.89780167683854
+"1646","Cooper, Rosie","skelmersdale",8.57016707005398
+"1647","Cooper, Rosie","decision",8.21765168918847
+"1648","Cooper, Rosie","lancashire",8.21229239359518
+"1649","Cooper, Rosie","court",7.11133312528218
+"1650","Cooper, Rosie","magistrates",6.59025589306877
+"1651","Cooper, Rosie","ombudsman",5.99946392135142
+"1652","Cooper, Rosie","ormskirk",5.83964206900234
+"1653","Cooper, Rosie","statutory",5.80736782154113
+"1654","Cooper, Rosie","reverse",5.27498646097085
+"1655","Cooper, Rosie","proposal",5.26896677855382
+"1656","Cooper, Rosie","considered",5.1662736801977
+"1657","Corbyn, Jeremy","victims",9.46325072995739
+"1658","Corbyn, Jeremy","will",5.99541773573192
+"1659","Corbyn, Jeremy","romanian",5.74956828593407
+"1660","Corbyn, Jeremy","give",5.46012841528714
+"1661","Corbyn, Jeremy","crown",5.44215634262288
+"1662","Corbyn, Jeremy","mandatory",5.15142834112038
+"1663","Corbyn, Jeremy","trials",4.71420220526257
+"1664","Corbyn, Jeremy","implement",4.55073604426266
+"1665","Corbyn, Jeremy","disappearances",4.54543283655548
+"1666","Corbyn, Jeremy","right",4.16255819458182
+"1667","Corbyn, Jeremy","transcripts",4.10334315369087
+"1668","Corbyn, Jeremy","born",4.04686740189623
+"1669","Costa, Alberto","glen",6.07340847302224
+"1670","Costa, Alberto","parva",6.07340847302224
+"1671","Costa, Alberto","education",4.38279918308302
+"1672","Costa, Alberto","redeveloped",4.1918794459622
+"1673","Costa, Alberto","leicester",3.83832605536893
+"1674","Costa, Alberto","2020",2.87475914111963
+"1675","Costa, Alberto","ratio",2.69838631099963
+"1676","Costa, Alberto","accommodate",2.49222281348348
+"1677","Costa, Alberto","adequacy",2.44270562350646
+"1678","Costa, Alberto","complete",2.30395737218284
+"1679","Costa, Alberto","prison",1.89679879370472
+"1680","Costa, Alberto","hmp",1.82386341203212
+"1681","Cowan, Ronnie","inverclyde",4.28547517620851
+"1682","Cowan, Ronnie","awards",2.11095452418951
+"1683","Cowan, Ronnie","successful",1.95591361395112
+"1684","Cowan, Ronnie","independence",1.94468590519903
+"1685","Cowan, Ronnie","payments",1.75715434263479
+"1686","Cowan, Ronnie","appeals",1.70051267548735
+"1687","Cowan, Ronnie","personal",1.49234905385142
+"1688","Cowan, Ronnie","2016",1.4894694144268
+"1689","Cowan, Ronnie","2015",1.24756112085878
+"1690","Cowan, Ronnie","convict",0
+"1691","Cowan, Ronnie","five",0
+"1692","Cowan, Ronnie","rape",0
+"1693","Cox, Geoffrey","constructor",3.03028855770365
+"1694","Cox, Geoffrey","plymouth",3.03028855770365
+"1695","Cox, Geoffrey","geoamey",2.48300485726285
+"1696","Cox, Geoffrey","transport",2.04742780918392
+"1697","Cox, Geoffrey","deliver",1.96407477962185
+"1698","Cox, Geoffrey","failure",1.92238429128494
+"1699","Cox, Geoffrey","investigate",1.59545980594724
+"1700","Cox, Geoffrey","defendants",1.52767735362464
+"1701","Cox, Geoffrey","purse",1.51958062629746
+"1702","Cox, Geoffrey","october",1.41976093633107
+"1703","Cox, Geoffrey","crown",1.34269069948392
+"1704","Cox, Geoffrey","2016",1.05321392331115
+"1705","Coyle, Neil","psychiatric",5.30235469043411
+"1706","Coyle, Neil","requested",3.1640656215701
+"1707","Coyle, Neil","british",3.09726191723672
+"1708","Coyle, Neil","introduction",2.94697614483916
+"1709","Coyle, Neil","bill",2.93865096047327
+"1710","Coyle, Neil","assessments",2.90638459537085
+"1711","Coyle, Neil","judges",2.84632332126694
+"1712","Coyle, Neil","universal",2.51226765164198
+"1713","Coyle, Neil","rights",2.32471199363358
+"1714","Coyle, Neil","adjourned",2.31786575697609
+"1715","Coyle, Neil","proposals",2.14230353744611
+"1716","Coyle, Neil","sufficient",2.03899645262111
+"1717","Crausby, David","commissioners",4.56827897291929
+"1718","Crausby, David","refusals",4.50800435190759
+"1719","Crausby, David","review",4.23488564654146
+"1720","Crausby, David","devolution",3.72450728589427
+"1721","Crausby, David","police",3.63137924771511
+"1722","Crausby, David","external",3.59200009332702
+"1723","Crausby, David","crime",3.53002593212836
+"1724","Crausby, David","funding",3.48824858225007
+"1725","Crausby, David","fighting",3.398473972902
+"1726","Crausby, David","motor",3.28601931495429
+"1727","Crausby, David","repossession",3.27333545844424
+"1728","Crausby, David","eviction",3.02990879034318
+"1729","Crausby, Sir David","capabl",5.87530699098492
+"1730","Crausby, Sir David","bolton",4.26021258338486
+"1731","Crausby, Sir David","repossessions",4.10334315369087
+"1732","Crausby, Sir David","five",3.63043616615656
+"1733","Crausby, Sir David","appeals",3.04097078039078
+"1734","Crausby, Sir David","work",2.64578461856019
+"1735","Crausby, Sir David","outcome",2.63896072857686
+"1736","Crausby, Sir David","nine",2.43725762059819
+"1737","Crausby, Sir David","resolved",2.43725762059819
+"1738","Crausby, Sir David","previous",2.3761000869598
+"1739","Crausby, Sir David","assessments",2.29769876944969
+"1740","Crausby, Sir David","financial",2.11981299668154
+"1741","Crawley, Angela","consent",2.87475914111963
+"1742","Crawley, Angela","scottish",2.61907845362646
+"1743","Crawley, Angela","repeal",2.59555981135252
+"1744","Crawley, Angela","parliament",2.42688610118765
+"1745","Crawley, Angela","seek",2.36880142471095
+"1746","Crawley, Angela","1998",2.17467147921726
+"1747","Crawley, Angela","human",1.7795890675973
+"1748","Crawley, Angela","legislative",1.73305738067267
+"1749","Crawley, Angela","rights",1.56732050637441
+"1750","Crawley, Angela","proposed",1.44434075030068
+"1751","Crawley, Angela","act",1.24274410550915
+"1752","Crawley, Angela","convict",0
+"1753","Creagh, Mary","wakefield",6.08869953969506
+"1754","Creagh, Mary","five",5.65443924495947
+"1755","Creagh, Mary","inmates",5.10990963671029
+"1756","Creagh, Mary","rejected",5.00999827684004
+"1757","Creagh, Mary","patients",3.98506397046232
+"1758","Creagh, Mary","granted",3.97191378126868
+"1759","Creagh, Mary","year",3.82368265765316
+"1760","Creagh, Mary","force",3.64140631336009
+"1761","Creagh, Mary","received",3.56977986453754
+"1762","Creagh, Mary","civil",3.56622252868861
+"1763","Creagh, Mary","applications",3.5030330232844
+"1764","Creagh, Mary","discharge",3.27795718927577
+"1765","Creasy, Stella","55a",3.31951479760817
+"1766","Creasy, Stella","parentage",3.31951479760817
+"1767","Creasy, Stella","1986",2.39388146013676
+"1768","Creasy, Stella","declaration",2.33645998385951
+"1769","Creasy, Stella","county",1.96450574016346
+"1770","Creasy, Stella","high",1.86980294960517
+"1771","Creasy, Stella","applications",1.44323858077113
+"1772","Creasy, Stella","law",1.43843203333643
+"1773","Creasy, Stella","section",1.36303108707121
+"1774","Creasy, Stella","family",1.32593555945627
+"1775","Creasy, Stella","magistrates",1.19236784062669
+"1776","Creasy, Stella","act",1.06422247140201
+"1777","Cunningham, Alex","substances",14.2986407757581
+"1778","Cunningham, Alex","psychoactive",10.077318670711
+"1779","Cunningham, Alex","families",8.06138336876923
+"1780","Cunningham, Alex","domestic",7.56651953988717
+"1781","Cunningham, Alex","new",7.56398294457637
+"1782","Cunningham, Alex","jail",6.76052064195506
+"1783","Cunningham, Alex","broken",6.66292494234059
+"1784","Cunningham, Alex","involving",6.39306815348332
+"1785","Cunningham, Alex","abuse",6.354748280114
+"1786","Cunningham, Alex","detect",6.10392169475882
+"1787","Cunningham, Alex","illicit",5.94737220869284
+"1788","Cunningham, Alex","child",5.92302690613325
+"1789","Cunningham, Jim","made",23.9429391999516
+"1790","Cunningham, Jim","prison",21.8877567376359
+"1791","Cunningham, Jim","midlands",20.930897655971
+"1792","Cunningham, Jim","will",18.4316502867953
+"1793","Cunningham, Jim","year",17.5742383923816
+"1794","Cunningham, Jim","west",17.2448461868815
+"1795","Cunningham, Jim","england",16.2102155384907
+"1796","Cunningham, Jim","number",16.115652327131
+"1797","Cunningham, Jim","five",15.1206426031285
+"1798","Cunningham, Jim","claim",15.1019796294686
+"1799","Cunningham, Jim","wales",13.6822189040233
+"1800","Cunningham, Jim","estimate",13.4917921310633
+"1801","Cunningham, Sir Tony","cert",3.11814120131826
+"1802","Cunningham, Sir Tony","gary",3.11814120131826
+"1803","Cunningham, Sir Tony","jbirqk61bb77//e/1",3.11814120131826
+"1804","Cunningham, Sir Tony","owh0080",3.11814120131826
+"1805","Cunningham, Sir Tony","tomlinson",3.11814120131826
+"1806","Cunningham, Sir Tony","workington",3.11814120131826
+"1807","Cunningham, Sir Tony","withdrawn",2.24866008047404
+"1808","Cunningham, Sir Tony","constituent",1.56777649975397
+"1809","Cunningham, Sir Tony","reasons",1.31296224844248
+"1810","Cunningham, Sir Tony","funding",1.29151289140489
+"1811","Cunningham, Sir Tony","member",1.26775042484217
+"1812","Cunningham, Sir Tony","claim",1.20336664054642
+"1813","Curran, Margaret","scotland",2.84577620407675
+"1814","Curran, Margaret","processed",2.1478601170062
+"1815","Curran, Margaret","employment",1.51553132933529
+"1816","Curran, Margaret","tribunals",1.4620586486878
+"1817","Curran, Margaret","service",1.23393786031977
+"1818","Curran, Margaret","2010",1.20465429476315
+"1819","Curran, Margaret","courts",1.00691896271166
+"1820","Curran, Margaret","year",0.661854446750993
+"1821","Curran, Margaret","convict",0
+"1822","Curran, Margaret","five",0
+"1823","Curran, Margaret","person",0
+"1824","Curran, Margaret","rape",0
+"1825","Dakin, Nic","embed",6.42821276431277
+"1826","Dakin, Nic","component",5.63573151395219
+"1827","Dakin, Nic","nothing",5.63573151395219
+"1828","Dakin, Nic","independence",4.47624636825777
+"1829","Dakin, Nic","decision",4.4181921065413
+"1830","Dakin, Nic","enhanced",4.13573151395219
+"1831","Dakin, Nic","standard",4.05076901323103
+"1832","Dakin, Nic","payments",4.04458926948534
+"1833","Dakin, Nic","mobility",3.92821276431277
+"1834","Dakin, Nic","appeal",3.91421240184674
+"1835","Dakin, Nic","quarter",3.82348608149829
+"1836","Dakin, Nic","beef",3.71133036988416
+"1837","Danczuk, Simon","albany",2.94946629760185
+"1838","Danczuk, Simon","ashwell",2.94946629760185
+"1839","Danczuk, Simon","askham",2.94946629760185
+"1840","Danczuk, Simon","buckley",2.94946629760185
+"1841","Danczuk, Simon","grange",2.41677945971859
+"1842","Danczuk, Simon","ashfield",2.30541490792287
+"1843","Danczuk, Simon","unemployed",1.52047728657507
+"1844","Danczuk, Simon","classed",1.40911273477935
+"1845","Danczuk, Simon","week",1.36768662052877
+"1846","Danczuk, Simon","hours",1.34615207139606
+"1847","Danczuk, Simon","cells",1.34098045146564
+"1848","Danczuk, Simon","per",1.31865894261325
+"1849","David, Wayne","spent",8.65392736021658
+"1850","David, Wayne","per",8.1857993858467
+"1851","David, Wayne","number",7.75222003225956
+"1852","David, Wayne","unemployed",7.72738031142994
+"1853","David, Wayne","classed",7.16140260657656
+"1854","David, Wayne","week",6.95086651868799
+"1855","David, Wayne","hours",6.84142348231189
+"1856","David, Wayne","cells",6.81514023929251
+"1857","David, Wayne","2011",6.31178576189719
+"1858","David, Wayne","christmas",5.66018287751524
+"1859","David, Wayne","2012",5.62332312100681
+"1860","David, Wayne","five",5.60232191539126
+"1861","Davidson, Ian","development",2.74835469134796
+"1862","Davidson, Ian","foreign",2.55842741495289
+"1863","Davidson, Ian","action",2.45634330665509
+"1864","Davidson, Ian","home",2.40558226530176
+"1865","Davidson, Ian","plan",2.18448722198653
+"1866","Davidson, Ian","national",1.79651719356078
+"1867","Davidson, Ian","offenders",1.31420029804509
+"1868","Davidson, Ian","convict",0
+"1869","Davidson, Ian","five",0
+"1870","Davidson, Ian","person",0
+"1871","Davidson, Ian","rape",0
+"1872","Davidson, Ian","year",0
+"1873","Davies, Byron","anticorruption",3.74933095786226
+"1874","Davies, Byron","corporate",2.97159039142941
+"1875","Davies, Byron","liability",2.83009143875762
+"1876","Davies, Byron","action",2.05512425612285
+"1877","Davies, Byron","expects",2.03339537666691
+"1878","Davies, Byron","progress",1.98798796180341
+"1879","Davies, Byron","introduced",1.98321074297139
+"1880","Davies, Byron","plan",1.8276731371106
+"1881","Davies, Byron","criminal",1.42127992475239
+"1882","Davies, Byron","made",0.905066663758513
+"1883","Davies, Byron","convict",0
+"1884","Davies, Byron","five",0
+"1885","Davies, David T. C.","seekers",5.66913452064925
+"1886","Davies, David T. C.","wish",5.05431574721918
+"1887","Davies, David T. C.","gwent",4.84036545307348
+"1888","Davies, David T. C.","served",4.50953570363963
+"1889","Davies, David T. C.","spent",4.23905308652826
+"1890","Davies, David T. C.","five",4.18454909875453
+"1891","Davies, David T. C.","magistrates",3.9505407738351
+"1892","Davies, David T. C.","asylum",3.70411114354803
+"1893","Davies, David T. C.","translators",3.55172985105962
+"1894","Davies, David T. C.","district",3.35276739290178
+"1895","Davies, David T. C.","sufficient",3.3296672641778
+"1896","Davies, David T. C.","immigration",3.2866137150952
+"1897","Davies, Mims","vulnerable",6.80586091349106
+"1898","Davies, Mims","intimidated",6.37959899253249
+"1899","Davies, Mims","witness",4.1146734693443
+"1900","Davies, Mims","screens",3.87635814759977
+"1901","Davies, Mims","defines",2.98317831100567
+"1902","Davies, Mims","safeguard",2.72224609610137
+"1903","Davies, Mims","appropriate",2.65536262541257
+"1904","Davies, Mims","participate",2.54533961642677
+"1905","Davies, Mims","give",2.48803603528226
+"1906","Davies, Mims","adequacy",2.44270562350646
+"1907","Davies, Mims","special",2.28274941795632
+"1908","Davies, Mims","arrangements",2.19009490478894
+"1909","Davies, Philip","offence",226.167240895477
+"1910","Davies, Philip","sentence",202.112881655131
+"1911","Davies, Philip","prison",150.468404951876
+"1912","Davies, Philip","year",140.391224753454
+"1913","Davies, Philip","offender",132.671904894463
+"1914","Davies, Philip","release",125.571717682777
+"1915","Davies, Philip","proportion",121.303317533407
+"1916","Davies, Philip","convicted",119.867110755519
+"1917","Davies, Philip","commit",110.539975867394
+"1918","Davies, Philip","court",97.8007856436498
+"1919","Davies, Philip","serve",90.2140559329498
+"1920","Davies, Philip","licence",89.7376957747472
+"1921","Day, Martyn","visa",7.67665211073786
+"1922","Day, Martyn","appeals",6.83382807970845
+"1923","Day, Martyn","pension",6.49568134305895
+"1924","Day, Martyn","alpha",6.0248504140154
+"1925","Day, Martyn","scotland",5.09067923285354
+"1926","Day, Martyn","carries",4.93515365200848
+"1927","Day, Martyn","retirement",4.92822646902415
+"1928","Day, Martyn","potential",4.90794644761181
+"1929","Day, Martyn","officers",4.85964036676769
+"1930","Day, Martyn","age",4.70101531315458
+"1931","Day, Martyn","manual",4.6015555121686
+"1932","Day, Martyn","country",4.50043232622936
+"1933","de Bois, Nick","born",17.9051819848046
+"1934","de Bois, Nick","blade",16.2868426924527
+"1935","de Bois, Nick","point",15.3129609299975
+"1936","de Bois, Nick","article",13.8961908968381
+"1937","de Bois, Nick","offensive",12.2284450547241
+"1938","de Bois, Nick","self",10.8021470624191
+"1939","de Bois, Nick","weapon",10.7741317563836
+"1940","de Bois, Nick","inception",10.1181229249729
+"1941","de Bois, Nick","threatening",9.54189318314191
+"1942","de Bois, Nick","aged",8.69401068253521
+"1943","de Bois, Nick","certificated",8.59047764488263
+"1944","de Bois, Nick","economy",8.4185138288612
+"1945","De Piero, Gloria","ashfield",16.618915809276
+"1946","De Piero, Gloria","constituency",12.975596769324
+"1947","De Piero, Gloria","nottinghamshire",12.5689139940735
+"1948","De Piero, Gloria","five",8.94425067784536
+"1949","De Piero, Gloria","tribunal",8.24697192335756
+"1950","De Piero, Gloria","year",8.24513867300299
+"1951","De Piero, Gloria","pay",7.90850290013461
+"1952","De Piero, Gloria","discrimination",7.08321396904052
+"1953","De Piero, Gloria","men",6.83324741258567
+"1954","De Piero, Gloria","convicted",6.51531732405714
+"1955","De Piero, Gloria","successful",5.98638689766213
+"1956","De Piero, Gloria","people",5.90190567445936
+"1957","Debbonaire, Thangam","bristol",5.93023194413188
+"1958","Debbonaire, Thangam","synnex",5.04075150725396
+"1959","Debbonaire, Thangam","concentrix",4.85514109493415
+"1960","Debbonaire, Thangam","private",4.61608508661946
+"1961","Debbonaire, Thangam","genital",4.09468133465334
+"1962","Debbonaire, Thangam","mutilation",4.09468133465334
+"1963","Debbonaire, Thangam","representation",3.9652435409037
+"1964","Debbonaire, Thangam","close",3.72219715744768
+"1965","Debbonaire, Thangam","intimate",3.56573088174181
+"1966","Debbonaire, Thangam","regardless",3.56434957305558
+"1967","Debbonaire, Thangam","business",3.43750753757393
+"1968","Debbonaire, Thangam","labour",3.42382100930146
+"1969","Djanogly, Jonathan","merger",5.40371671931768
+"1970","Djanogly, Jonathan","marital",5.24861374353734
+"1971","Djanogly, Jonathan","peterborough",5.20474121201711
+"1972","Djanogly, Jonathan","cambridgeshire",4.92430098544712
+"1973","Djanogly, Jonathan","law",3.8194846038957
+"1974","Djanogly, Jonathan","east",3.81113212384202
+"1975","Djanogly, Jonathan","south",3.78845301987528
+"1976","Djanogly, Jonathan","anticorruption",3.42265523528935
+"1977","Djanogly, Jonathan","coroner",3.37943535795317
+"1978","Djanogly, Jonathan","matrimonial",3.2883807836292
+"1979","Djanogly, Jonathan","relating",3.13537034525707
+"1980","Djanogly, Jonathan","north",3.06681952992252
+"1981","Dobbin, Jim","tranquilisers",5.74956828593407
+"1982","Dobbin, Jim","prescription",5.30235469043411
+"1983","Dobbin, Jim","danny",4.54543283655548
+"1984","Dobbin, Jim","fitzsimons",4.54543283655548
+"1985","Dobbin, Jim","illicit",4.09468133465334
+"1986","Dobbin, Jim","trade",3.96071390393424
+"1987","Dobbin, Jim","iraq",3.83832605536893
+"1988","Dobbin, Jim","achieve",3.27795718927577
+"1989","Dobbin, Jim","regard",2.58158911469325
+"1990","Dobbin, Jim","agreement",2.3432128691399
+"1991","Dobbin, Jim","transfer",2.12518661877157
+"1992","Dobbin, Jim","prisoner",1.43202685805714
+"1993","Dobson, Frank","coroners",2.87777102449042
+"1994","Dobson, Frank","progress",2.56648142284181
+"1995","Dobson, Frank","implementation",2.52460750442972
+"1996","Dobson, Frank","hour",2.39549516757162
+"1997","Dobson, Frank","system",2.28579756352484
+"1998","Dobson, Frank","made",1.16843603864808
+"1999","Dobson, Frank","convict",0
+"2000","Dobson, Frank","five",0
+"2001","Dobson, Frank","person",0
+"2002","Dobson, Frank","rape",0
+"2003","Dobson, Frank","year",0
+"2004","Dobson, Frank","offenc",0
+"2005","Docherty-Hughes, Martin","charter",4.30069056821956
+"2006","Docherty-Hughes, Martin","fundamental",4.19330722170474
+"2007","Docherty-Hughes, Martin","party",3.04720937404941
+"2008","Docherty-Hughes, Martin","remaining",3.0198101183243
+"2009","Docherty-Hughes, Martin","governments",2.78100017741942
+"2010","Docherty-Hughes, Martin","rights",2.12216199769319
+"2011","Docherty-Hughes, Martin","convict",0
+"2012","Docherty-Hughes, Martin","five",0
+"2013","Docherty-Hughes, Martin","person",0
+"2014","Docherty-Hughes, Martin","rape",0
+"2015","Docherty-Hughes, Martin","year",0
+"2016","Docherty-Hughes, Martin","offenc",0
+"2017","Dodds, Nigel","topics",4.1918794459622
+"2018","Dodds, Nigel","europe",3.32233905826068
+"2019","Dodds, Nigel","correspondence",3.32233905826068
+"2020","Dodds, Nigel","message",3.25379110666075
+"2021","Dodds, Nigel","origin",2.95267033473516
+"2022","Dodds, Nigel","content",2.84530496609973
+"2023","Dodds, Nigel","arrangements",2.61766408736122
+"2024","Dodds, Nigel","return",2.51231933069401
+"2025","Dodds, Nigel","prohibit",2.50757670884253
+"2026","Dodds, Nigel","commissioner",2.46560444080364
+"2027","Dodds, Nigel","sending",2.46369719538345
+"2028","Dodds, Nigel","countries",2.40558226530176
+"2029","Donaldson, Stuart Blair","band",3.51440459815959
+"2030","Donaldson, Stuart Blair","adviser",3.48419398729183
+"2031","Donaldson, Stuart Blair","name",3.26535130717057
+"2032","Donaldson, Stuart Blair","special",3.09085732327292
+"2033","Donaldson, Stuart Blair","pay",2.6531540061169
+"2034","Donaldson, Stuart Blair","affairs",2.61907845362646
+"2035","Donaldson, Stuart Blair","missing",2.42688610118765
+"2036","Donaldson, Stuart Blair","help",2.39687496642186
+"2037","Donaldson, Stuart Blair","responsibilities",2.23776650358638
+"2038","Donaldson, Stuart Blair","legislative",1.73305738067267
+"2039","Donaldson, Stuart Blair","financial",1.69102577761923
+"2040","Donaldson, Stuart Blair","protect",1.57164879006173
+"2041","Donelan, Michelle","chippenham",3.71133036988416
+"2042","Donelan, Michelle","wiltshire",3.42265523528935
+"2043","Donelan, Michelle","retrospectively",3.31951479760817
+"2044","Donelan, Michelle","abolition",3.06131590786101
+"2045","Donelan, Michelle","225",3.06131590786101
+"2046","Donelan, Michelle","upheld",2.61224167530896
+"2047","Donelan, Michelle","initial",2.2679546969101
+"2048","Donelan, Michelle","assessments",1.87606318925752
+"2049","Donelan, Michelle","constituency",1.86602727749074
+"2050","Donelan, Michelle","2003",1.82006220436519
+"2051","Donelan, Michelle","applied",1.72130896877564
+"2052","Donelan, Michelle","independence",1.68414739628389
+"2053","Dorries, Nadine","stalking",14.5063714627072
+"2054","Dorries, Nadine","attorney",12.3711910377458
+"2055","Dorries, Nadine","elderly",11.3372013120428
+"2056","Dorries, Nadine","power",10.0934564260279
+"2057","Dorries, Nadine","protect",8.8967085389117
+"2058","Dorries, Nadine","abuse",8.60251134421133
+"2059","Dorries, Nadine","vulnerable",7.89847088960762
+"2060","Dorries, Nadine","new",7.32754454444003
+"2061","Dorries, Nadine","people",5.94567096403692
+"2062","Dorries, Nadine","laws",5.79631613040304
+"2063","Dorries, Nadine","better",5.25959366330941
+"2064","Dorries, Nadine","training",5.14345336214922
+"2065","Doughty, Stephen","lessons",12.8737167965578
+"2066","Doughty, Stephen","car",11.3426621569435
+"2067","Doughty, Stephen","tests",9.83087798073373
+"2068","Doughty, Stephen","drive",8.66076944571886
+"2069","Doughty, Stephen","abscond",7.73543749760746
+"2070","Doughty, Stephen","2013",6.58554674890636
+"2071","Doughty, Stephen","missing",6.08452546005101
+"2072","Doughty, Stephen","parking",5.85055601323255
+"2073","Doughty, Stephen","prison",5.66025547149102
+"2074","Doughty, Stephen","ka505a",4.54543283655548
+"2075","Doughty, Stephen","maya",4.54543283655548
+"2076","Doughty, Stephen","202937",4.54543283655548
+"2077","Dowd, Jim","passed",2.40920177346954
+"2078","Dowd, Jim","maximum",2.06075581964016
+"2079","Dowd, Jim","fraud",2.04256488665471
+"2080","Dowd, Jim","length",1.6922621702771
+"2081","Dowd, Jim","increase",1.60002236735152
+"2082","Dowd, Jim","legislative",1.59418092621847
+"2083","Dowd, Jim","proposals",1.32860025338325
+"2084","Dowd, Jim","average",1.32120389470613
+"2085","Dowd, Jim","custodial",1.27293682360404
+"2086","Dowd, Jim","convictions",1.11592796969529
+"2087","Dowd, Jim","five",1.0337233412943
+"2088","Dowd, Jim","sentence",0.968587216435596
+"2089","Dowd, Peter","probate",12.5975480066718
+"2090","Dowd, Peter","registries",12.0032973147448
+"2091","Dowd, Peter","cafcass",10.1235391658366
+"2092","Dowd, Peter","fee",7.82352612785566
+"2093","Dowd, Peter","grant",6.18361892303768
+"2094","Dowd, Peter","proposals",5.89283343753363
+"2095","Dowd, Peter","expended",5.83971195843831
+"2096","Dowd, Peter","liquid",5.7813664715923
+"2097","Dowd, Peter","reflect",5.18861527796988
+"2098","Dowd, Peter","departments",5.00027376515491
+"2099","Dowd, Peter","filed",4.80613722435685
+"2100","Dowd, Peter","actual",4.56652583745013
+"2101","Dowden, Oliver","specialise",4.4813076267001
+"2102","Dowden, Oliver","belief",3.79819167604396
+"2103","Dowden, Oliver","religion",3.72537868068164
+"2104","Dowden, Oliver","characteristic",3.60370129795068
+"2105","Dowden, Oliver","judges",2.40558226530176
+"2106","Dowden, Oliver","protected",1.9701660231828
+"2107","Dowden, Oliver","train",1.86848105176083
+"2108","Dowden, Oliver","convict",0
+"2109","Dowden, Oliver","five",0
+"2110","Dowden, Oliver","person",0
+"2111","Dowden, Oliver","rape",0
+"2112","Dowden, Oliver","year",0
+"2113","Drax, Richard","marine",3.87635814759977
+"2114","Drax, Richard","sergeant",3.57484680302201
+"2115","Drax, Richard","blackman",3.398473972902
+"2116","Drax, Richard","expediting",3.398473972902
+"2117","Drax, Richard","alexander",3.27333545844424
+"2118","Drax, Richard","investigations",2.04091904126721
+"2119","Drax, Richard","commission",1.98685091153302
+"2120","Drax, Richard","criminal",1.3551372370972
+"2121","Drax, Richard","review",1.33448106334806
+"2122","Drax, Richard","case",1.19173676033031
+"2123","Drax, Richard","will",0.813041680110636
+"2124","Drax, Richard","convict",0
+"2125","Drew, Dr David","stroud",3.71133036988416
+"2126","Drew, Dr David","district",2.37076455926199
+"2127","Drew, Dr David","allowance",1.77309464136928
+"2128","Drew, Dr David","successful",1.6938708772895
+"2129","Drew, Dr David","independence",1.68414739628389
+"2130","Drew, Dr David","payment",1.52174029909188
+"2131","Drew, Dr David","appeals",1.47268717642949
+"2132","Drew, Dr David","support",1.43054658067463
+"2133","Drew, Dr David","personal",1.292412191949
+"2134","Drew, Dr David","employment",1.23742614869112
+"2135","Drew, Dr David","2010",0.983596112874016
+"2136","Drew, Dr David","year",0.540401892843998
+"2137","Dromey, Jack","unfairly",4.85927209970932
+"2138","Dromey, Jack","people",4.42635478148887
+"2139","Dromey, Jack","dangerous",4.42414291169228
+"2140","Dromey, Jack","treated",3.79819167604396
+"2141","Dromey, Jack","citizenship",3.71133036988416
+"2142","Dromey, Jack","release",3.6609506899699
+"2143","Dromey, Jack","mappa",3.56573088174181
+"2144","Dromey, Jack","marketing",3.55172985105962
+"2145","Dromey, Jack","press",3.51859493300094
+"2146","Dromey, Jack","knives",3.46063735173971
+"2147","Dromey, Jack","drivers",3.45982640536948
+"2148","Dromey, Jack","unlawful",3.28318859405118
+"2149","Drummond, Flick","electronic",3.78551165488164
+"2150","Drummond, Flick","monitoring",3.36357125584028
+"2151","Drummond, Flick","progress",3.14328496014729
+"2152","Drummond, Flick","made",1.43103604588334
+"2153","Drummond, Flick","convict",0
+"2154","Drummond, Flick","five",0
+"2155","Drummond, Flick","person",0
+"2156","Drummond, Flick","rape",0
+"2157","Drummond, Flick","year",0
+"2158","Drummond, Flick","offenc",0
+"2159","Drummond, Flick","sexual",0
+"2160","Drummond, Flick","agreement",0
+"2161","Duddridge, James","rwanda",4.4813076267001
+"2162","Duddridge, James","entrustment",4.4813076267001
+"2163","Duddridge, James","jersey",3.9816657709599
+"2164","Duddridge, James","facilitate",3.66115306706041
+"2165","Duddridge, James","trade",3.34741420767242
+"2166","Duddridge, James","agreement",2.50499992588602
+"2167","Duddridge, James","decision",2.17646814407056
+"2168","Duddridge, James","convict",0
+"2169","Duddridge, James","five",0
+"2170","Duddridge, James","person",0
+"2171","Duddridge, James","rape",0
+"2172","Duddridge, James","year",0
+"2173","Dugher, Michael","yorkshire",7.94953493301701
+"2174","Dugher, Michael","south",7.90222921823866
+"2175","Dugher, Michael","breathalysed",4.1918794459622
+"2176","Dugher, Michael","influence",3.370953895301
+"2177","Dugher, Michael","probation",3.34062365178744
+"2178","Dugher, Michael","alcohol",2.8835764369274
+"2179","Dugher, Michael","staff",2.74555551267003
+"2180","Dugher, Michael","five",2.56012470945585
+"2181","Dugher, Michael","year",2.53386151657539
+"2182","Dugher, Michael","people",2.39281143781709
+"2183","Dugher, Michael","service",2.32673554291981
+"2184","Dugher, Michael","drive",2.30395737218284
+"2185","Eagle, Maria","remit",4.46934638030619
+"2186","Eagle, Maria","engagement",4.0561974420849
+"2187","Eagle, Maria","resources",3.92628444651649
+"2188","Eagle, Maria","process",3.60602459097343
+"2189","Eagle, Maria","independence",3.46296751803207
+"2190","Eagle, Maria","bodies",3.27338264004571
+"2191","Eagle, Maria","organisations",3.26394477041396
+"2192","Eagle, Maria","payments",3.12902376494086
+"2193","Eagle, Maria","unsuccessful",3.06314042223207
+"2194","Eagle, Maria","65647",3.03028855770365
+"2195","Eagle, Maria","appeal",3.02816004552253
+"2196","Eagle, Maria","within",3.02687570473462
+"2197","Edwards, Jonathan","election",6.54674467443656
+"2198","Edwards, Jonathan","carmarthen",6.02542229001739
+"2199","Edwards, Jonathan","guildhall)",6.02542229001739
+"2200","Edwards, Jonathan","general",5.92641978901195
+"2201","Edwards, Jonathan","capacity",5.29744438634971
+"2202","Edwards, Jonathan","visited",5.19490192540945
+"2203","Edwards, Jonathan","financial",4.62379526251548
+"2204","Edwards, Jonathan","probate",4.30145034209128
+"2205","Edwards, Jonathan","wales",4.23566293662512
+"2206","Edwards, Jonathan","2008",3.79325145234411
+"2207","Edwards, Jonathan","official",3.78189249204024
+"2208","Edwards, Jonathan","write",3.46063735173971
+"2209","Elliott, Tom","covers",4.1062846694254
+"2210","Elliott, Tom","future",3.43957280256281
+"2211","Elliott, Tom","statutes",3.398473972902
+"2212","Elliott, Tom","bill",3.28551165488164
+"2213","Elliott, Tom","fully",3.16413841980111
+"2214","Elliott, Tom","consumers",2.72839744576541
+"2215","Elliott, Tom","passed",2.61907845362646
+"2216","Elliott, Tom","rights",2.59910702293687
+"2217","Elliott, Tom","considered",2.53002304633413
+"2218","Elliott, Tom","industry",2.44270562350646
+"2219","Elliott, Tom","defendant",2.29151603043696
+"2220","Elliott, Tom","mental",2.24457997622849
+"2221","Ellman, Louise","danish",3.87635814759977
+"2222","Ellman, Louise","diver",3.87635814759977
+"2223","Ellman, Louise","omalley",3.87635814759977
+"2224","Ellman, Louise","reopening",3.87635814759977
+"2225","Ellman, Louise","stephen",3.27333545844424
+"2226","Ellman, Louise","counterpart",3.02990879034318
+"2227","Ellman, Louise","commercial",2.59555981135252
+"2228","Ellman, Louise","inquest",2.47618282379502
+"2229","Ellman, Louise","commissioners",2.10267453211564
+"2230","Ellman, Louise","commissioners",1.98685091153302
+"2231","Ellman, Louise","grant",1.88640955245588
+"2232","Ellman, Louise","death",1.86030238312883
+"2233","Elmore, Chris","pregnant",7.72215166323271
+"2234","Elmore, Chris","barriers",4.26021258338486
+"2235","Elmore, Chris","women",4.02363613065053
+"2236","Elmore, Chris","justice",3.97589795036191
+"2237","Elmore, Chris","obstacles",3.95214184287518
+"2238","Elmore, Chris","accessing",3.93667588382649
+"2239","Elmore, Chris","experienced",3.46063735173971
+"2240","Elmore, Chris","faced",3.28547517620851
+"2241","Elmore, Chris","remove",2.57571417056019
+"2242","Elmore, Chris","potential",1.9229875624584
+"2243","Elmore, Chris","will",1.01920168406233
+"2244","Elmore, Chris","made",0.954024030588891
+"2245","Elphicke, Charlie","1998",2.72609496920126
+"2246","Elphicke, Charlie","human",2.23083295605124
+"2247","Elphicke, Charlie","reform",2.11268495438503
+"2248","Elphicke, Charlie","rights",1.96474023243783
+"2249","Elphicke, Charlie","received",1.6572798417963
+"2250","Elphicke, Charlie","act",1.55786218121204
+"2251","Elphicke, Charlie","will",1.01920168406233
+"2252","Elphicke, Charlie","convict",0
+"2253","Elphicke, Charlie","five",0
+"2254","Elphicke, Charlie","person",0
+"2255","Elphicke, Charlie","rape",0
+"2256","Elphicke, Charlie","year",0
+"2257","Esterson, Bill","james",10.6032178883612
+"2258","Esterson, Bill","thompson",10.2127864930934
+"2259","Esterson, Bill","unemployed",8.99843503390181
+"2260","Esterson, Bill","classed",8.339361272484
+"2261","Esterson, Bill","commission",8.2827894370734
+"2262","Esterson, Bill","criminal",8.16065163420763
+"2263","Esterson, Bill","week",8.09419470466866
+"2264","Esterson, Bill","hours",7.96674969574544
+"2265","Esterson, Bill","cells",7.93614319713163
+"2266","Esterson, Bill","per",7.80404083095993
+"2267","Esterson, Bill","spent",6.53339177699389
+"2268","Esterson, Bill","three",5.99227327679603
+"2269","Evans, Chris","internet",6.54911970654705
+"2270","Evans, Chris","dangerous",6.50419106995516
+"2271","Evans, Chris","bringing",6.215686463526
+"2272","Evans, Chris","legislative",6.12065933622543
+"2273","Evans, Chris","proposals",5.10099538342316
+"2274","Evans, Chris","drive",5.08649301312725
+"2275","Evans, Chris","death",4.81591601100754
+"2276","Evans, Chris","reoffending",4.22009860920581
+"2277","Evans, Chris","trolling",4.1918794459622
+"2278","Evans, Chris","porn",3.95214184287518
+"2279","Evans, Chris","rate",3.76843054704939
+"2280","Evans, Chris","revenge",3.75715434263479
+"2281","Evans, Graham","complex",2.51226765164198
+"2282","Evans, Graham","disputes",2.21410638215638
+"2283","Evans, Graham","skilled",2.1716251317958
+"2284","Evans, Graham","relevantly",2.06786575697609
+"2285","Evans, Graham","judiciary",1.99961113337449
+"2286","Evans, Graham","proceedings",1.54955351146843
+"2287","Evans, Graham","planning",1.44490248289367
+"2288","Evans, Graham","increase",1.4422406718438
+"2289","Evans, Graham","potential",1.4422406718438
+"2290","Evans, Graham","provision",1.40212450379549
+"2291","Evans, Graham","management",1.39975942148322
+"2292","Evans, Graham","members",1.30676722713648
+"2293","Evans, Jonathan","alternative",3.42469510436916
+"2294","Evans, Jonathan","dispute",3.13121927418238
+"2295","Evans, Jonathan","resolution",3.13121927418238
+"2296","Evans, Jonathan","awareness",2.76197019216753
+"2297","Evans, Jonathan","raise",2.59255877883951
+"2298","Evans, Jonathan","public",1.50097582298471
+"2299","Evans, Jonathan","services",1.23393786031977
+"2300","Evans, Jonathan","will",0.953375877446062
+"2301","Evans, Jonathan","convict",0
+"2302","Evans, Jonathan","five",0
+"2303","Evans, Jonathan","person",0
+"2304","Evans, Jonathan","rape",0
+"2305","Evans, Nigel","wrongfully",6.61877412151497
+"2306","Evans, Nigel","english",6.03010125026641
+"2307","Evans, Nigel","terrorism",5.31072525082514
+"2308","Evans, Nigel","recalled",4.98707717473703
+"2309","Evans, Nigel","limb",4.0655587238791
+"2310","Evans, Nigel","repetitive",4.0655587238791
+"2311","Evans, Nigel","strain",4.0655587238791
+"2312","Evans, Nigel","people",3.97615624368488
+"2313","Evans, Nigel","compensation",3.75524411795945
+"2314","Evans, Nigel","population",3.63573151395219
+"2315","Evans, Nigel","capacity",3.62085784225516
+"2316","Evans, Nigel","released",3.41527836237301
+"2317","Fabricant, Michael","meals",3.56434957305558
+"2318","Fabricant, Michael","served",3.18872327604643
+"2319","Fabricant, Michael","soldiers",3.04104746457308
+"2320","Fabricant, Michael","daily",2.97159039142941
+"2321","Fabricant, Michael","vexatious",2.96511597206594
+"2322","Fabricant, Michael","minimised",2.90091680990377
+"2323","Fabricant, Michael","overseas",2.55662983150491
+"2324","Fabricant, Michael","defence",2.40549051337143
+"2325","Fabricant, Michael","ways",2.33871258021393
+"2326","Fabricant, Michael","remand",2.25423123461042
+"2327","Fabricant, Michael","can",2.15470241208555
+"2328","Fabricant, Michael","discuss",2.02752005996842
+"2329","Farrelly, Paul","yet",3.38260625463544
+"2330","Farrelly, Paul","war",2.79458629730814
+"2331","Farrelly, Paul","implemented",2.33733237163766
+"2332","Farrelly, Paul","armed",2.24730259686733
+"2333","Farrelly, Paul","crime",2.03678250333142
+"2334","Farrelly, Paul","complainants",2.01160033647182
+"2335","Farrelly, Paul","favour",2.01160033647182
+"2336","Farrelly, Paul","sections",1.99527320595587
+"2337","Farrelly, Paul","pensions",1.90955082551733
+"2338","Farrelly, Paul","quarter",1.80240862399988
+"2339","Farrelly, Paul","took",1.61080285123965
+"2340","Farrelly, Paul","2013",1.56819969405029
+"2341","Farron, Tim","five",15.0379427713356
+"2342","Farron, Tim","people",12.6960283500794
+"2343","Farron, Tim","year",10.7679595017294
+"2344","Farron, Tim","guards",8.53546031630048
+"2345","Farron, Tim","disqualified",8.38661444340947
+"2346","Farron, Tim","prison",8.32742335671251
+"2347","Farron, Tim","transsexual",8.24527655384718
+"2348","Farron, Tim","possession",7.7269300226452
+"2349","Farron, Tim","gender",7.41848776203476
+"2350","Farron, Tim","explicit",7.32150391569037
+"2351","Farron, Tim","fire",7.07060808900175
+"2352","Farron, Tim","workers",6.93055699932485
+"2353","Fernandes, Suella","college",3.46284409553132
+"2354","Fernandes, Suella","progress",3.14328496014729
+"2355","Fernandes, Suella","secure",2.40057154656217
+"2356","Fernandes, Suella","made",1.43103604588334
+"2357","Fernandes, Suella","convict",0
+"2358","Fernandes, Suella","five",0
+"2359","Fernandes, Suella","person",0
+"2360","Fernandes, Suella","rape",0
+"2361","Fernandes, Suella","year",0
+"2362","Fernandes, Suella","offenc",0
+"2363","Fernandes, Suella","sexual",0
+"2364","Fernandes, Suella","agreement",0
+"2365","Ferrier, Margaret","129",7.76362524892973
+"2366","Ferrier, Margaret","oral",7.71798930990443
+"2367","Ferrier, Margaret","parliamentary",7.63206763072292
+"2368","Ferrier, Margaret","contribution",7.11411112277113
+"2369","Ferrier, Margaret","2016",6.91890329270209
+"2370","Ferrier, Margaret","official",5.07882697401704
+"2371","Ferrier, Margaret","report",4.21851631811548
+"2372","Ferrier, Margaret","1998",4.08249623844148
+"2373","Ferrier, Margaret","shoplifting",3.83832605536893
+"2374","Ferrier, Margaret","employ",3.72188056734512
+"2375","Ferrier, Margaret","50967",3.71133036988416
+"2376","Ferrier, Margaret","july",3.65996141593421
+"2377","Field, Frank","outsource",13.4609639747647
+"2378","Field, Frank","income",12.8130683629519
+"2379","Field, Frank","low",8.93726132507474
+"2380","Field, Frank","wage",8.55788876767085
+"2381","Field, Frank","direct",8.39732350687769
+"2382","Field, Frank","birkenhead",8.00912846449611
+"2383","Field, Frank","people",7.99275504380798
+"2384","Field, Frank","less",7.81365845473446
+"2385","Field, Frank","liverpool",7.55907463362241
+"2386","Field, Frank","foundation",7.43980304202609
+"2387","Field, Frank","call",7.36314094974792
+"2388","Field, Frank","employed",7.32787573715115
+"2389","Field, Mark","traffickers",4.0449829724651
+"2390","Field, Mark","human",2.90705815711288
+"2391","Field, Mark","orders",2.42027623722724
+"2392","Field, Mark","victim",2.18408064977124
+"2393","Field, Mark","august",2.06991966946267
+"2394","Field, Mark","convicted",1.98173457947083
+"2395","Field, Mark","confiscation",1.90212450379549
+"2396","Field, Mark","money",1.87471838100186
+"2397","Field, Mark","awarded",1.58321589314213
+"2398","Field, Mark","purse",1.5636355645199
+"2399","Field, Mark","value",1.53212626851558
+"2400","Field, Mark","compensation",1.44007038152496
+"2401","Fitzpatrick, Jim","fraud",15.1519154385989
+"2402","Fitzpatrick, Jim","insurance",9.87776738194865
+"2403","Fitzpatrick, Jim","injury",8.20970914375738
+"2404","Fitzpatrick, Jim","personal",6.5423850138194
+"2405","Fitzpatrick, Jim","20722",5.72814499660718
+"2406","Fitzpatrick, Jim","exaggerated",5.54217644198516
+"2407","Fitzpatrick, Jim","fabricated",5.25838349955417
+"2408","Fitzpatrick, Jim","project",4.61148427847358
+"2409","Fitzpatrick, Jim","reform",4.30338325436452
+"2410","Fitzpatrick, Jim","estimate",4.30137169881145
+"2411","Fitzpatrick, Jim","scale",4.1918794459622
+"2412","Fitzpatrick, Jim","made",4.16525979079402
+"2413","Flello, Robert","fenton",6.33752602284526
+"2414","Flello, Robert","urban",6.33752602284526
+"2415","Flello, Robert","trent",5.80300353902042
+"2416","Flello, Robert","town",5.80300353902042
+"2417","Flello, Robert","vision",5.63092573412822
+"2418","Flello, Robert","stoke",5.63092573412822
+"2419","Flello, Robert","city",4.17570643259917
+"2420","Flello, Robert","discuss",3.75423764842162
+"2421","Flello, Robert","make",3.52453530328396
+"2422","Flello, Robert","council",3.38505796653323
+"2423","Flello, Robert","regulation",3.37395053592368
+"2424","Flello, Robert","introduce",3.13573151395219
+"2425","Fletcher, Colleen","coventry",25.3215488654547
+"2426","Fletcher, Colleen","midlands",22.805572350868
+"2427","Fletcher, Colleen","jobseekers",21.0642038228684
+"2428","Fletcher, Colleen","credits",19.7836112242485
+"2429","Fletcher, Colleen","tax",19.3342300798459
+"2430","Fletcher, Colleen","west",18.7893798851157
+"2431","Fletcher, Colleen","allowance",18.1039626139395
+"2432","Fletcher, Colleen","appellants",17.7894211271128
+"2433","Fletcher, Colleen","income",17.6073635314921
+"2434","Fletcher, Colleen","appeal",17.4147327999478
+"2435","Fletcher, Colleen","support",16.9164143336454
+"2436","Fletcher, Colleen","independence",16.1358970741132
+"2437","Flint, Caroline","prison",8.29198618151041
+"2438","Flint, Caroline","officers",7.50435424203064
+"2439","Flint, Caroline","incidence",7.20069640988115
+"2440","Flint, Caroline","staff",6.56728661055602
+"2441","Flint, Caroline","private",6.28081762932064
+"2442","Flint, Caroline","safety",6.21480708338494
+"2443","Flint, Caroline","violent",5.91840883531259
+"2444","Flint, Caroline","2010",5.67795475657176
+"2445","Flint, Caroline","causes",5.45144202004806
+"2446","Flint, Caroline","run",5.4258672519847
+"2447","Flint, Caroline","increases",4.39480547319832
+"2448","Flint, Caroline","access",4.31993497454006
+"2449","Flynn, Paul","rainsbrook",28.493157339663
+"2450","Flynn, Paul","centre",21.3706211671069
+"2451","Flynn, Paul","secure",19.4909299281396
+"2452","Flynn, Paul","training",18.5784629208325
+"2453","Flynn, Paul","drug",17.8802210874177
+"2454","Flynn, Paul","prison",15.0862196220301
+"2455","Flynn, Paul","contract",13.7391014037113
+"2456","Flynn, Paul","run",12.4334837860886
+"2457","Flynn, Paul","population",10.8586178578396
+"2458","Flynn, Paul","made",10.8564467478631
+"2459","Flynn, Paul","medway",10.0676724744972
+"2460","Flynn, Paul","g4s",9.78810502494782
+"2461","Foster, Kevin","certificate",4.81110550945045
+"2462","Foster, Kevin","declaration",4.75492583232407
+"2463","Foster, Kevin","recognition",4.60774028822616
+"2464","Foster, Kevin","statutory",4.37858758994322
+"2465","Foster, Kevin","dated",4.15230640541991
+"2466","Foster, Kevin","gender",3.73157510637031
+"2467","Foster, Kevin","six",3.46259257018717
+"2468","Foster, Kevin","within",3.22028508309323
+"2469","Foster, Kevin","application",2.93713243852758
+"2470","Foster, Kevin","panel",2.26413643011456
+"2471","Foster, Kevin","states",2.18542331562958
+"2472","Foster, Kevin","months",2.12424842578755
+"2473","Fovargue, Yvonne","directly",5.2074599956297
+"2474","Fovargue, Yvonne","jobseekers",4.89954582923779
+"2475","Fovargue, Yvonne","1300",3.87635814759977
+"2476","Fovargue, Yvonne","allowance",3.55547118240797
+"2477","Fovargue, Yvonne","april",3.54755528870702
+"2478","Fovargue, Yvonne","hindley",3.27795718927577
+"2479","Fovargue, Yvonne","march",3.18819364804398
+"2480","Fovargue, Yvonne","chain",3.09696262832424
+"2481","Fovargue, Yvonne","went",3.02990879034318
+"2482","Fovargue, Yvonne","appeals",2.95308366193765
+"2483","Fovargue, Yvonne","employed",2.80798078962991
+"2484","Fovargue, Yvonne","2012",2.79185020092955
+"2485","Fox, Dr Liam","spread",5.24861374353734
+"2486","Fox, Dr Liam","population",4.78642810728924
+"2487","Fox, Dr Liam","islamic",4.10251589588201
+"2488","Fox, Dr Liam","extremism",3.65363233685082
+"2489","Fox, Dr Liam","prevent",2.78999237932388
+"2490","Fox, Dr Liam","extremists",2.63362435843454
+"2491","Fox, Dr Liam","radicalising",2.31786575697609
+"2492","Fox, Dr Liam","overseas",2.21410638215638
+"2493","Fox, Dr Liam","terrorist",2.21410638215638
+"2494","Fox, Dr Liam","muslim",2.11602702646169
+"2495","Fox, Dr Liam","recruiting",1.82545916923697
+"2496","Fox, Dr Liam","risks",1.81042892112758
+"2497","Foxcroft, Vicky","tagging",8.65206638599957
+"2498","Foxcroft, Vicky","electronic",8.13820619644844
+"2499","Foxcroft, Vicky","offender",7.14846862832907
+"2500","Foxcroft, Vicky","violence",6.72436475558889
+"2501","Foxcroft, Vicky","abuse",5.65733995320207
+"2502","Foxcroft, Vicky","immigration",5.57754244039026
+"2503","Foxcroft, Vicky","live",5.09003700921607
+"2504","Foxcroft, Vicky","make",5.00314578110031
+"2505","Foxcroft, Vicky","incidence",4.88184587445554
+"2506","Foxcroft, Vicky","contact",4.60924598630848
+"2507","Foxcroft, Vicky","rogue",4.54543283655548
+"2508","Foxcroft, Vicky","estimate",4.52770038508589
+"2509","Freer, Mike","division",2.51145226262694
+"2510","Freer, Mike","president",2.28094038323926
+"2511","Freer, Mike","committee",1.95149793852278
+"2512","Freer, Mike","policies",1.943380239358
+"2513","Freer, Mike","evidence",1.64525641290533
+"2514","Freer, Mike","given",1.51978119303064
+"2515","Freer, Mike","december",1.49139820847216
+"2516","Freer, Mike","access",1.47915665750199
+"2517","Freer, Mike","2011",1.44681393115052
+"2518","Freer, Mike","family",1.37247369523216
+"2519","Freer, Mike","aid",1.28753278062342
+"2520","Freer, Mike","legal",1.12297548005066
+"2521","Fuller, Richard","six",8.49083214164476
+"2522","Fuller, Richard","building",8.18463474093529
+"2523","Fuller, Richard","listed",7.09722122513738
+"2524","Fuller, Richard","shire",7.01345775073619
+"2525","Fuller, Richard","closed",6.58404212512324
+"2526","Fuller, Richard","months",6.55654583452613
+"2527","Fuller, Richard","preceding",5.72513706767297
+"2528","Fuller, Richard","three",5.68682672436371
+"2529","Fuller, Richard","bedford",5.63996246293441
+"2530","Fuller, Richard","counted",5.55536825524891
+"2531","Fuller, Richard","fewer",4.88085630848418
+"2532","Fuller, Richard","asylum)",4.75181151272038
+"2533","Garnier, Sir Edward","trafficking",4.59665910905788
+"2534","Garnier, Sir Edward","continuance",3.72656987909899
+"2535","Garnier, Sir Edward","human",3.30353809877978
+"2536","Garnier, Sir Edward","birds",3.03028855770365
+"2537","Garnier, Sir Edward","638",3.03028855770365
+"2538","Garnier, Sir Edward","england",2.79957905597792
+"2539","Garnier, Sir Edward","wales",2.78400276189295
+"2540","Garnier, Sir Edward","will",2.7403710111762
+"2541","Garnier, Sir Edward","consideration",2.68302353552264
+"2542","Garnier, Sir Edward","court",2.56368187545173
+"2543","Garnier, Sir Edward","search",2.51145226262694
+"2544","Garnier, Sir Edward","rspca",2.48300485726285
+"2545","Ghani, Nusrat","attacker",2.12678584630282
+"2546","Ghani, Nusrat","speech",2.08786744673619
+"2547","Ghani, Nusrat","crossexamined",2.06991966946267
+"2548","Ghani, Nusrat","social",1.63157171377893
+"2549","Ghani, Nusrat","2017",1.49984035049494
+"2550","Ghani, Nusrat","abuse",1.45183299982653
+"2551","Ghani, Nusrat","february",1.43150085255322
+"2552","Ghani, Nusrat","domestic",1.39917897119383
+"2553","Ghani, Nusrat","centre",1.37917895962982
+"2554","Ghani, Nusrat","justice",1.35568658566521
+"2555","Ghani, Nusrat","reform",1.35568658566521
+"2556","Ghani, Nusrat","data",1.34231279435367
+"2557","Gibb, Nick","ford",7.84165971879275
+"2558","Gibb, Nick","open",4.64801515390884
+"2559","Gibb, Nick","absconders",3.17590435439377
+"2560","Gibb, Nick","subsidiaries",3.06131590786101
+"2561","Gibb, Nick","failed",2.41818492389736
+"2562","Gibb, Nick","temporary",2.12730924814564
+"2563","Gibb, Nick","return",2.10195715788052
+"2564","Gibb, Nick","departmental",2.06518949825342
+"2565","Gibb, Nick","testing",1.90989561502547
+"2566","Gibb, Nick","executive",1.86227739551569
+"2567","Gibb, Nick","2013",1.85551890116679
+"2568","Gibb, Nick","licence",1.83792570857222
+"2569","Gillan, Cheryl","midlands)",3.03028855770365
+"2570","Gillan, Cheryl","petitioners",2.79458629730814
+"2571","Gillan, Cheryl","rail",2.55888403691262
+"2572","Gillan, Cheryl","select",2.15808655168045
+"2573","Gillan, Cheryl","speed",2.13288639644668
+"2574","Gillan, Cheryl","appearing",1.89718413605117
+"2575","Gillan, Cheryl","committee",1.7210594097955
+"2576","Gillan, Cheryl","high",1.70688875598074
+"2577","Gillan, Cheryl","london",1.6437362938691
+"2578","Gillan, Cheryl","bill",1.54880504722283
+"2579","Gillan, Cheryl","west",1.49267025883082
+"2580","Gillan, Cheryl","decision",1.35726635138996
+"2581","Gilmore, Sheila","pensions",5.39442136342349
+"2582","Gilmore, Sheila","sorting",5.30733472832811
+"2583","Gilmore, Sheila","147",5.30733472832811
+"2584","Gilmore, Sheila","sadler",5.30733472832811
+"2585","Gilmore, Sheila","purpose",5.20191178613496
+"2586","Gilmore, Sheila","january",5.06058956318425
+"2587","Gilmore, Sheila","kevin",5.04548584416387
+"2588","Gilmore, Sheila","visit",4.94922820458637
+"2589","Gilmore, Sheila","interpretation",4.72383378271118
+"2590","Gilmore, Sheila","2014",4.53708589129806
+"2591","Gilmore, Sheila","support",4.43654941919013
+"2592","Gilmore, Sheila","treasury",4.41206748011501
+"2593","Glass, Pat","unemployed",7.91814375214064
+"2594","Glass, Pat","classed",7.33819393125413
+"2595","Glass, Pat","week",7.12246040427227
+"2596","Glass, Pat","hours",7.01031558160645
+"2597","Glass, Pat","cells",6.98338349231972
+"2598","Glass, Pat","per",6.86714044323345
+"2599","Glass, Pat","spent",5.74903692524184
+"2600","Glass, Pat","working",5.30285818630134
+"2601","Glass, Pat","three",5.27288145427751
+"2602","Glass, Pat","2011",5.0698478085526
+"2603","Glass, Pat","overcrowding",4.76724871686908
+"2604","Glass, Pat","proportion",4.72218854137181
+"2605","Glen, John","outstanding",5.61034365919003
+"2606","Glen, John","imposed",5.31263921602989
+"2607","Glen, John","penalties",4.95085277556659
+"2608","Glen, John","financial",4.27256321617122
+"2609","Glen, John","current",4.18236993407183
+"2610","Glen, John","balance",3.83832605536893
+"2611","Glen, John","despatch",3.71133036988416
+"2612","Glen, John","total",3.62040725445897
+"2613","Glen, John","hire",2.84530496609973
+"2614","Glen, John","ministerial",2.58350820134967
+"2615","Glen, John","car",2.46369719538345
+"2616","Glen, John","2007",2.46369719538345
+"2617","Glindon, Mary","insolvency",8.27263850297023
+"2618","Glindon, Mary","punishment",7.35275688913234
+"2619","Glindon, Mary","service",7.03876832037541
+"2620","Glindon, Mary","officer",6.94219631694706
+"2621","Glindon, Mary","commence",6.41409528646848
+"2622","Glindon, Mary","noms",5.85206175594584
+"2623","Glindon, Mary","ordinated",5.68802752857598
+"2624","Glindon, Mary","staff",5.61571844003811
+"2625","Glindon, Mary","2012",5.04907606494421
+"2626","Glindon, Mary","aid",5.04332245812555
+"2627","Glindon, Mary","agreements",5.02504414635059
+"2628","Glindon, Mary","determined",4.92822646902415
+"2629","Godsiff, Roger","benefit",14.2152454498622
+"2630","Godsiff, Roger","tribunal",12.8227921321455
+"2631","Godsiff, Roger","reach",11.1727338547662
+"2632","Godsiff, Roger","disabled",10.3520301860628
+"2633","Godsiff, Roger","concentrix",9.12047402491915
+"2634","Godsiff, Roger","contract",8.73690093023861
+"2635","Godsiff, Roger","appeal",7.43659689612237
+"2636","Godsiff, Roger","collect",7.15099451397486
+"2637","Godsiff, Roger","birmingham",6.86616133990268
+"2638","Godsiff, Roger","fines",6.3590668988839
+"2639","Godsiff, Roger","synnex",6.34300530497638
+"2640","Godsiff, Roger","time",5.75289483051304
+"2641","Goldsmith, Zac","breached",15.5343114902785
+"2642","Goldsmith, Zac","issued",12.5754085251127
+"2643","Goldsmith, Zac","order",11.8712777417331
+"2644","Goldsmith, Zac","resulted",9.9194210320524
+"2645","Goldsmith, Zac","imposition",8.11198595110691
+"2646","Goldsmith, Zac","five",7.9282882669227
+"2647","Goldsmith, Zac","contempt",7.81926494488039
+"2648","Goldsmith, Zac","sequestration",7.14969360604401
+"2649","Goldsmith, Zac","courts",6.88033668601097
+"2650","Goldsmith, Zac","twice",6.50757107527853
+"2651","Goldsmith, Zac","molestation",5.59090256749294
+"2652","Goldsmith, Zac","restraining",5.54597896182733
+"2653","Goodman, Helen","libraries",11.4340555620648
+"2654","Goodman, Helen","probate",10.4398540429488
+"2655","Goodman, Helen","stalking",9.41781483398532
+"2656","Goodman, Helen","book",8.53675284941467
+"2657","Goodman, Helen","prison",6.19236219001313
+"2658","Goodman, Helen","foreign",6.02474216656789
+"2659","Goodman, Helen","help",6.00928356325243
+"2660","Goodman, Helen","serious",5.45476687593102
+"2661","Goodman, Helen","order",5.19616750042781
+"2662","Goodman, Helen","newspapers",5.13573151395219
+"2663","Goodman, Helen","building",5.12250153335803
+"2664","Goodman, Helen","charge",4.96009212740627
+"2665","Gove, Michael","lisbon",2.52779841611991
+"2666","Gove, Michael","triggering",2.52779841611991
+"2667","Gove, Michael","treaty",2.40308399192499
+"2668","Gove, Michael","white",1.86954912664401
+"2669","Gove, Michael","documents",1.85196813501885
+"2670","Gove, Michael","papers",1.71606761931717
+"2671","Gove, Michael","article",1.66553069264827
+"2672","Gove, Michael","assist",1.57013211821826
+"2673","Gove, Michael","make",1.50286690296156
+"2674","Gove, Michael","list",1.48164582605757
+"2675","Gove, Michael","leave",1.47156021377911
+"2676","Gove, Michael","governments",1.45232997629266
+"2677","Graham, Richard","stalking",11.3606040815888
+"2678","Graham, Richard","offences",7.69990352870374
+"2679","Graham, Richard","people",4.91676035799172
+"2680","Graham, Richard","restraining",4.65816733033775
+"2681","Graham, Richard","convicted",4.64001851804385
+"2682","Graham, Richard","orders",4.02884633347388
+"2683","Graham, Richard","hospitalisation",3.71133036988416
+"2684","Graham, Richard","therapeutic",3.71133036988416
+"2685","Graham, Richard","psychological",3.42382100930146
+"2686","Graham, Richard","breaches",3.41577058926626
+"2687","Graham, Richard","motoring",3.28601931495429
+"2688","Graham, Richard","surrender",3.1762704856974
+"2689","Grant, Peter","exemption",6.3622286936724
+"2690","Grant, Peter","individual)",5.30733472832811
+"2691","Grant, Peter","2000",5.17737759342571
+"2692","Grant, Peter","freedom",5.05356960093534
+"2693","Grant, Peter","wholly",5.04548584416387
+"2694","Grant, Peter","endanger",4.85970110422156
+"2695","Grant, Peter","request",4.79016876775989
+"2696","Grant, Peter","application",4.51361790645582
+"2697","Grant, Peter","disclosur",4.20641043963525
+"2698","Grant, Peter","likely",3.85345316464997
+"2699","Grant, Peter","section",3.57414132689762
+"2700","Grant, Peter","information",3.31905114486514
+"2701","Greatrex, Tom","handling",4.20246343337705
+"2702","Greatrex, Tom","share",3.55514009994706
+"2703","Greatrex, Tom","governments",3.04643305919697
+"2704","Greatrex, Tom","data",2.47510249662734
+"2705","Greatrex, Tom","personal",2.00219635834157
+"2706","Greatrex, Tom","convict",0
+"2707","Greatrex, Tom","five",0
+"2708","Greatrex, Tom","rape",0
+"2709","Greatrex, Tom","year",0
+"2710","Greatrex, Tom","offenc",0
+"2711","Greatrex, Tom","sexual",0
+"2712","Greatrex, Tom","agreement",0
+"2713","Green, Damian","submission",3.43310319184542
+"2714","Green, Damian","final",2.93189404102191
+"2715","Green, Damian","papers",2.54533961642677
+"2716","Green, Damian","immigration",2.06638952551378
+"2717","Green, Damian","hearing",2.02812109561414
+"2718","Green, Damian","appeal",1.61324797335805
+"2719","Green, Damian","average",1.5064042122892
+"2720","Green, Damian","time",1.41439864452425
+"2721","Green, Damian","months",1.27839638761931
+"2722","Green, Damian","will",0.852725308031161
+"2723","Green, Damian","convict",0
+"2724","Green, Damian","five",0
+"2725","Green, Kate","women",26.1929534529086
+"2726","Green, Kate","bench",16.5849065105322
+"2727","Green, Kate","recall",16.1238535381
+"2728","Green, Kate","half",13.6287241863966
+"2729","Green, Kate","number",12.8634880299416
+"2730","Green, Kate","community",12.631447279654
+"2731","Green, Kate","member",12.4766195671866
+"2732","Green, Kate","rehabilitation",12.0996141913085
+"2733","Green, Kate","service",11.8738447173206
+"2734","Green, Kate","year",11.8342896264061
+"2735","Green, Kate","sit",11.554321546158
+"2736","Green, Kate","training",11.494248908147
+"2737","Griffith, Nia","welsh",7.12844718726869
+"2738","Griffith, Nia","website",4.14632431625404
+"2739","Griffith, Nia","forms",3.47438573672608
+"2740","Griffith, Nia","cremation",3.30743904943112
+"2741","Griffith, Nia","allow",2.50753448919549
+"2742","Griffith, Nia","application",2.28196056113284
+"2743","Griffith, Nia","departments",2.28147716339386
+"2744","Griffith, Nia","members",2.13394194605068
+"2745","Griffith, Nia","proportion",1.76763127179559
+"2746","Griffith, Nia","public",1.73317759089468
+"2747","Griffith, Nia","convict",0
+"2748","Griffith, Nia","five",0
+"2749","Griffiths, Andrew","deradicalisation",10.9375796995461
+"2750","Griffiths, Andrew","drug",8.16016471404602
+"2751","Griffiths, Andrew","needles",8.0561544297221
+"2752","Griffiths, Andrew","programme",8.03664690644694
+"2753","Griffiths, Andrew","year",7.83919103513883
+"2754","Griffiths, Andrew","neglect",7.63199115780069
+"2755","Griffiths, Andrew","national",6.74187234750849
+"2756","Griffiths, Andrew","visitors",6.2209469478065
+"2757","Griffiths, Andrew","management",5.96214198155447
+"2758","Griffiths, Andrew","prosecuted",5.86294185887318
+"2759","Griffiths, Andrew","four",5.57444483097806
+"2760","Griffiths, Andrew","substance",5.42305157534106
+"2761","Gwynne, Andrew","reuse",10.1427201435076
+"2762","Gwynne, Andrew","graves",8.43179637157995
+"2763","Gwynne, Andrew","freedom",7.85311126692176
+"2764","Gwynne, Andrew","request",7.44379345514295
+"2765","Gwynne, Andrew","ward",6.796947945804
+"2766","Gwynne, Andrew","valuation",6.65327226137734
+"2767","Gwynne, Andrew","admitted",6.54667091688848
+"2768","Gwynne, Andrew","month",6.10211667530482
+"2769","Gwynne, Andrew","respond",5.78145500534438
+"2770","Gwynne, Andrew","2010",5.69846378876602
+"2771","Gwynne, Andrew","recruitment",5.46706722840512
+"2772","Gwynne, Andrew","owned",5.2052265070204
+"2773","Haigh, Louise","contractual",10.8194782939764
+"2774","Haigh, Louise","servants",10.153911669459
+"2775","Haigh, Louise","internships",9.09086567311096
+"2776","Haigh, Louise","limited",8.75839882265022
+"2777","Haigh, Louise","remedies",8.74280603532615
+"2778","Haigh, Louise","civil",8.67629483281357
+"2779","Haigh, Louise","heeley",8.56720973394385
+"2780","Haigh, Louise","sheffield",8.25174817451978
+"2781","Haigh, Louise","pip",8.24527655384718
+"2782","Haigh, Louise","g4s",7.96169713852001
+"2783","Haigh, Louise","payroll",7.75662983294301
+"2784","Haigh, Louise","agreement",7.73418910374076
+"2785","Halfon, Robert","bereaved",3.84983734922377
+"2786","Halfon, Robert","homicide",3.49364665469693
+"2787","Halfon, Robert","assistance",3.2935369167669
+"2788","Halfon, Robert","makes",3.15244021089631
+"2789","Halfon, Robert","families",2.29658775654052
+"2790","Halfon, Robert","convict",0
+"2791","Halfon, Robert","five",0
+"2792","Halfon, Robert","person",0
+"2793","Halfon, Robert","rape",0
+"2794","Halfon, Robert","year",0
+"2795","Halfon, Robert","offenc",0
+"2796","Halfon, Robert","sexual",0
+"2797","Hames, Duncan","type",3.17431544421342
+"2798","Hames, Duncan","aged",2.89516816908388
+"2799","Hames, Duncan","2010",1.70363844162505
+"2800","Hames, Duncan","prison",0.894159526383379
+"2801","Hames, Duncan","convict",0
+"2802","Hames, Duncan","five",0
+"2803","Hames, Duncan","person",0
+"2804","Hames, Duncan","rape",0
+"2805","Hames, Duncan","year",0
+"2806","Hames, Duncan","offenc",0
+"2807","Hames, Duncan","sexual",0
+"2808","Hames, Duncan","agreement",0
+"2809","Hamilton, Fabian","afforded",2.90091680990377
+"2810","Hamilton, Fabian","comparable",2.61224167530896
+"2811","Hamilton, Fabian","disordered",2.50757670884253
+"2812","Hamilton, Fabian","extend",2.35443030159498
+"2813","Hamilton, Fabian","mentally",1.8326918762094
+"2814","Hamilton, Fabian","system",1.6163029575881
+"2815","Hamilton, Fabian","justice",1.61358978717729
+"2816","Hamilton, Fabian","rights",1.50059513934525
+"2817","Hamilton, Fabian","criminal",1.29744512552689
+"2818","Hamilton, Fabian","victims",1.280089689943
+"2819","Hamilton, Fabian","offenders",1.00373705735419
+"2820","Hamilton, Fabian","will",0.77842814427368
+"2821","Hammond, Stephen","general",12.3644292424024
+"2822","Hammond, Stephen","regulation",10.2985315954906
+"2823","Hammond, Stephen","data",8.44665564590298
+"2824","Hammond, Stephen","protection",7.95533447486424
+"2825","Hammond, Stephen","knife",5.21370593674529
+"2826","Hammond, Stephen","implement",4.95775560789576
+"2827","Hammond, Stephen","enact",4.43211716260961
+"2828","Hammond, Stephen","sector",4.20845492814707
+"2829","Hammond, Stephen","london",3.96649629835076
+"2830","Hammond, Stephen","fca",3.43602425333506
+"2831","Hammond, Stephen","crime",3.42106368359872
+"2832","Hammond, Stephen","financial",3.27249694285175
+"2833","Hancock, Mike","portsmouth",4.84036545307348
+"2834","Hancock, Mike","overdoses",4.54543283655548
+"2835","Hancock, Mike","kingston",3.3296672641778
+"2836","Hancock, Mike","sale",3.26535130717057
+"2837","Hancock, Mike","site",3.09085732327292
+"2838","Hancock, Mike","raised",2.99362901770583
+"2839","Hancock, Mike","died",2.96878566766741
+"2840","Hancock, Mike","waiting",2.52933024643765
+"2841","Hancock, Mike","asylum",2.32888228793411
+"2842","Hancock, Mike","drug",2.14324406990666
+"2843","Hancock, Mike","two",2.09583330445966
+"2844","Hancock, Mike","one",2.04413046560326
+"2845","Hanson, David","2010",51.6482055556194
+"2846","Hanson, David","year",39.207847583305
+"2847","Hanson, David","prison",22.7810296705821
+"2848","Hanson, David","wales",22.0438452290348
+"2849","Hanson, David","offender",21.5979210540104
+"2850","Hanson, David","immediate",20.0490942583037
+"2851","Hanson, David","absconded",19.6173379372487
+"2852","Hanson, David","police",19.3544425881744
+"2853","Hanson, David","sentence",16.8706882281961
+"2854","Hanson, David","force",16.0750680130835
+"2855","Hanson, David","hostel",15.0009290116801
+"2856","Hanson, David","bail",14.3496151755286
+"2857","Harman, Harriet","history",15.052738101006
+"2858","Harman, Harriet","right",14.2379518577568
+"2859","Harman, Harriet","rape",12.6419719186216
+"2860","Harman, Harriet","complainants",12.4466589758056
+"2861","Harman, Harriet","previous",10.7914805818591
+"2862","Harman, Harriet","evidence",10.5673208408267
+"2863","Harman, Harriet","1999",10.2820105242804
+"2864","Harman, Harriet","sexual",9.76140578978141
+"2865","Harman, Harriet","subsection",9.6321853656226
+"2866","Harman, Harriet","proposal",8.05530578510417
+"2867","Harman, Harriet","bill",7.69977588060967
+"2868","Harman, Harriet","use",7.06122958879419
+"2869","Harrington, Richard","exercised",2.84530496609973
+"2870","Harrington, Richard","lasting",2.71267848175249
+"2871","Harrington, Richard","attorney",2.48505932319183
+"2872","Harrington, Richard","awareness",2.25513921852908
+"2873","Harrington, Richard","raise",2.11681537877662
+"2874","Harrington, Richard","power",2.02752005996842
+"2875","Harrington, Richard","bodies",1.91322529603858
+"2876","Harrington, Richard","may",1.45568603281517
+"2877","Harrington, Richard","communities",1.42880766297041
+"2878","Harrington, Richard","companies",1.38129988599616
+"2879","Harrington, Richard","public",1.22554162752219
+"2880","Harrington, Richard","will",0.77842814427368
+"2881","Harris, Carolyn","establishment",8.10267945096529
+"2882","Harris, Carolyn","autonomy",7.53644634553629
+"2883","Harris, Carolyn","999",7.23761701908369
+"2884","Harris, Carolyn","plus",6.84279973416052
+"2885","Harris, Carolyn","january",6.67133066480003
+"2886","Harris, Carolyn","regardless",5.63573151395219
+"2887","Harris, Carolyn","governors",5.45386962845809
+"2888","Harris, Carolyn","calls",4.95344051594896
+"2889","Harris, Carolyn","prison",4.74378190690581
+"2890","Harris, Carolyn","society",4.68185678520046
+"2891","Harris, Carolyn","grades",4.6482500099925
+"2892","Harris, Carolyn","justice",4.34510641568197
+"2893","Harris, Rebecca","leigh",4.10334315369087
+"2894","Harris, Rebecca","day",2.3011388781657
+"2895","Harris, Rebecca","paid",2.1569216975365
+"2896","Harris, Rebecca","claims",1.87531146429675
+"2897","Harris, Rebecca","aid",1.82084632035759
+"2898","Harris, Rebecca","legal",1.58812715410008
+"2899","Harris, Rebecca","2013",1.56819969405029
+"2900","Harris, Rebecca","convict",0
+"2901","Harris, Rebecca","five",0
+"2902","Harris, Rebecca","person",0
+"2903","Harris, Rebecca","rape",0
+"2904","Harris, Rebecca","year",0
+"2905","Hayes, Helen","beneficial",9.94460464692715
+"2906","Hayes, Helen","ownership",9.09796287544843
+"2907","Hayes, Helen","dependencies",8.41007880508194
+"2908","Hayes, Helen","central",8.19476335287659
+"2909","Hayes, Helen","leaders",6.57095035241702
+"2910","Hayes, Helen","registers",6.47372278259308
+"2911","Hayes, Helen","crown",5.51527850840869
+"2912","Hayes, Helen","accessible",5.35837871863402
+"2913","Hayes, Helen","nine",2.90091680990377
+"2914","Hayes, Helen","proposed",2.87705001830618
+"2915","Hayes, Helen","adopted",2.87475914111963
+"2916","Hayes, Helen","publicly",2.83026715421212
+"2917","Hayman, Sue","manorial",5.74956828593407
+"2918","Hayman, Sue","cumbria",4.49408099739619
+"2919","Hayman, Sue","feudal",4.0655587238791
+"2920","Hayman, Sue","tenure",3.74933095786226
+"2921","Hayman, Sue","rights",3.51726408378396
+"2922","Hayman, Sue","supreme",3.42469510436916
+"2923","Hayman, Sue","royal",3.27795718927577
+"2924","Hayman, Sue","abolish",3.17779514846045
+"2925","Hayman, Sue","legislation",3.13630485784933
+"2926","Hayman, Sue","7ws",2.94946629760185
+"2927","Hayman, Sue","land",2.86156738244361
+"2928","Hayman, Sue","purse",2.2793709394462
+"2929","Heald, Sir Oliver","paperless",5.74956828593407
+"2930","Heald, Sir Oliver","progress",2.81143953741682
+"2931","Heald, Sir Oliver","working",1.98499019636359
+"2932","Heald, Sir Oliver","made",1.27995755073906
+"2933","Heald, Sir Oliver","courts",1.2736629365532
+"2934","Heald, Sir Oliver","convict",0
+"2935","Heald, Sir Oliver","five",0
+"2936","Heald, Sir Oliver","person",0
+"2937","Heald, Sir Oliver","rape",0
+"2938","Heald, Sir Oliver","year",0
+"2939","Heald, Sir Oliver","offenc",0
+"2940","Heald, Sir Oliver","sexual",0
+"2941","Healey, John","must",7.11046993519059
+"2942","Healey, John","mark",6.87822955216921
+"2943","Healey, John","exceeded",6.77903388851131
+"2944","Healey, John","met",5.51656028874891
+"2945","Healey, John","performance",5.03091820755412
+"2946","Healey, John","civil",4.26632214775465
+"2947","Healey, John","management",4.03917109871134
+"2948","Healey, John","system",4.03917109871134
+"2949","Healey, John","officials",3.72960726819107
+"2950","Healey, John","service",3.52528235304966
+"2951","Healey, John","received",3.16317869922793
+"2952","Healey, John","employment",3.09235091918736
+"2953","Heaton-Harris, Chris","stillbirth",8.23063858456235
+"2954","Heaton-Harris, Chris","coroner",4.57880205259924
+"2955","Heaton-Harris, Chris","coronial",4.4813076267001
+"2956","Heaton-Harris, Chris","neonatal",4.28547517620851
+"2957","Heaton-Harris, Chris","perinatal",4.0655587238791
+"2958","Heaton-Harris, Chris","lorry",4.0655587238791
+"2959","Heaton-Harris, Chris","retrieve",4.0655587238791
+"2960","Heaton-Harris, Chris","deaths",4.00774326684498
+"2961","Heaton-Harris, Chris","balance",3.43310319184542
+"2962","Heaton-Harris, Chris","jurisdictions",3.42022720303473
+"2963","Heaton-Harris, Chris","consistency",3.22883350906107
+"2964","Heaton-Harris, Chris","conclusions",3.14952638886365
+"2965","Hemming, John","contempt",21.5928173268159
+"2966","Hemming, John","yardley",19.8328438674155
+"2967","Hemming, John","birmingham",19.2025880995769
+"2968","Hemming, John","committal",17.0353685672133
+"2969","Hemming, John","analysis",16.2241912200288
+"2970","Hemming, John","name",14.5000041393791
+"2971","Hemming, John","team",13.1820935386102
+"2972","Hemming, John","letter",12.6871511429431
+"2973","Hemming, John","performance",12.6424424640262
+"2974","Hemming, John","judge",12.6138432990582
+"2975","Hemming, John","sent",12.5984852271567
+"2976","Hemming, John","february",12.5663226841391
+"2977","Henderson, Gordon","kent",3.51149914457939
+"2978","Henderson, Gordon","deportation",3.09048767596813
+"2979","Henderson, Gordon","stalking",3.04226273002551
+"2980","Henderson, Gordon","awaiting",2.95214184287518
+"2981","Henderson, Gordon","guidelines",2.8757419427
+"2982","Henderson, Gordon","sentence",2.48405883751426
+"2983","Henderson, Gordon","foreign",2.25632089579173
+"2984","Henderson, Gordon","completed",2.17219184191364
+"2985","Henderson, Gordon","officers",2.01392746036401
+"2986","Henderson, Gordon","employed",1.91701234641691
+"2987","Henderson, Gordon","system",1.86634589531096
+"2988","Henderson, Gordon","england",1.81804072191759
+"2989","Hendrick, Mark","lancashire",40.5612256150699
+"2990","Hendrick, Mark","magistrates",37.1324812387165
+"2991","Hendrick, Mark","court",30.2910115075777
+"2992","Hendrick, Mark","preston",30.161305139401
+"2993","Hendrick, Mark","2014",25.2251317649051
+"2994","Hendrick, Mark","people",20.0069861310059
+"2995","Hendrick, Mark","crown",18.2804059824287
+"2996","Hendrick, Mark","2013",15.6370858122379
+"2997","Hendrick, Mark","convicted",15.5336490345536
+"2998","Hendrick, Mark","2011",14.3010072907857
+"2999","Hendrick, Mark","west",13.1722296598022
+"3000","Hendrick, Mark","cost",12.9415247006434
+"3001","Hepburn, Stephen","jarrow",6.71343734001864
+"3002","Hepburn, Stephen","tyneside",6.71343734001864
+"3003","Hepburn, Stephen","east",4.50124740599504
+"3004","Hepburn, Stephen","south",4.47446159679626
+"3005","Hepburn, Stephen","constituency",3.66015749206495
+"3006","Hepburn, Stephen","north",3.62215557087595
+"3007","Hepburn, Stephen","repossessed",3.43310319184542
+"3008","Hepburn, Stephen","1997",2.56193127140856
+"3009","Hepburn, Stephen","homes",2.01265452191727
+"3010","Hepburn, Stephen","allowance",1.53554500273985
+"3011","Hepburn, Stephen","successful",1.46693521046334
+"3012","Hepburn, Stephen","independence",1.45851442889927
+"3013","Herbert, Nick","unimplemented",4.0655587238791
+"3014","Herbert, Nick","judgements",3.17779514846045
+"3015","Herbert, Nick","europe",2.97159039142941
+"3016","Herbert, Nick","european",2.0229070933789
+"3017","Herbert, Nick","council",2.00262730004275
+"3018","Herbert, Nick","human",1.86644876020292
+"3019","Herbert, Nick","member",1.65294432376555
+"3020","Herbert, Nick","rights",1.643819615004
+"3021","Herbert, Nick","court",0.900615699382737
+"3022","Herbert, Nick","years",0.591980613658294
+"3023","Herbert, Nick","convict",0
+"3024","Herbert, Nick","five",0
+"3025","Hillier, Meg","hearing",11.1838475786084
+"3026","Hillier, Meg","tier",7.78334035730273
+"3027","Hillier, Meg","immigration",7.27223733919843
+"3028","Hillier, Meg","chamber",6.81753935559006
+"3029","Hillier, Meg","first",6.79455452680267
+"3030","Hillier, Meg","appeal",6.16395249151965
+"3031","Hillier, Meg","asylum",6.07005825026231
+"3032","Hillier, Meg","tribunal",6.06426026003975
+"3033","Hillier, Meg","time",5.40418224159909
+"3034","Hillier, Meg","upper",4.8462206044191
+"3035","Hillier, Meg","submission",3.83832605536893
+"3036","Hillier, Meg","london",3.73480214832391
+"3037","Hilling, Julie","girls",3.9816657709599
+"3038","Hilling, Julie","youth",2.18854142260176
+"3039","Hilling, Julie","potential",2.18046294194366
+"3040","Hilling, Julie","young",1.95404797866737
+"3041","Hilling, Julie","children",1.83555631563551
+"3042","Hilling, Julie","custody",1.7347204813758
+"3043","Hilling, Julie","made",1.08176156987901
+"3044","Hilling, Julie","convict",0
+"3045","Hilling, Julie","five",0
+"3046","Hilling, Julie","person",0
+"3047","Hilling, Julie","rape",0
+"3048","Hilling, Julie","year",0
+"3049","Hodge, Margaret","barking",6.48397114315036
+"3050","Hodge, Margaret","dagenham",6.48397114315036
+"3051","Hodge, Margaret","kpmg",5.7813664715923
+"3052","Hodge, Margaret","deloitte",5.49613020197267
+"3053","Hodge, Margaret","ernst",5.49613020197267
+"3054","Hodge, Margaret","pwc",5.49613020197267
+"3055","Hodge, Margaret","borough",5.39022309446641
+"3056","Hodge, Margaret","list",3.99199811068805
+"3057","Hodge, Margaret","london",3.81378048932048
+"3058","Hodge, Margaret","firms",3.72877545307478
+"3059","Hodge, Margaret","secondees",3.31951479760817
+"3060","Hodge, Margaret","civil",3.23416432090494
+"3061","Hodgson, Sharon","white",13.0630970024813
+"3062","Hodgson, Sharon","departments",10.5709840121525
+"3063","Hodgson, Sharon","members",10.3995787454141
+"3064","Hodgson, Sharon","british",10.3171766004938
+"3065","Hodgson, Sharon","marriages",9.77479211136698
+"3066","Hodgson, Sharon","executive",8.72010651389793
+"3067","Hodgson, Sharon","proportion",8.64919347357779
+"3068","Hodgson, Sharon","satisfaction",8.29460894229344
+"3069","Hodgson, Sharon","inciting",7.96333154191981
+"3070","Hodgson, Sharon","hatred",7.96333154191981
+"3071","Hodgson, Sharon","formal",7.84479518736608
+"3072","Hodgson, Sharon","board",7.52862143860573
+"3073","Hoey, Kate","paralegal",15.9170974526022
+"3074","Hoey, Kate","mercy",12.0230610341602
+"3075","Hoey, Kate","prerogative",12.0230610341602
+"3076","Hoey, Kate","royal",11.0927040145979
+"3077","Hoey, Kate","britain",10.6037604073107
+"3078","Hoey, Kate","great",10.6037604073107
+"3079","Hoey, Kate","survivors",9.52793830765455
+"3080","Hoey, Kate","patent",9.33851643334332
+"3081","Hoey, Kate","terrorism",9.03367161904374
+"3082","Hoey, Kate","brixton",8.85716531230866
+"3083","Hoey, Kate","profession",8.62434824672124
+"3084","Hoey, Kate","list",8.4477596787323
+"3085","Hollern, Kate","blackburn",12.0313704677059
+"3086","Hollern, Kate","overturned",10.3348756351079
+"3087","Hollern, Kate","dismissed",9.66679435262049
+"3088","Hollern, Kate","consideration",9.19278313915513
+"3089","Hollern, Kate","mandatory",8.8251114777479
+"3090","Hollern, Kate","lancashire",8.77869457223285
+"3091","Hollern, Kate","refused",7.85662057418034
+"3092","Hollern, Kate","constituency",7.38260936071498
+"3093","Hollern, Kate","local",6.93828707984582
+"3094","Hollern, Kate","authorities",6.70150278367623
+"3095","Hollern, Kate","applications",6.38388474320053
+"3096","Hollern, Kate","2011",6.18269720660946
+"3097","Hollingbery, George","support",2.21619323317072
+"3098","Hollingbery, George","victims",1.98310642032042
+"3099","Hollingbery, George","five",1.66682880358941
+"3100","Hollingbery, George","made",1.27995755073906
+"3101","Hollingbery, George","years",0.837187012497507
+"3102","Hollingbery, George","convict",0
+"3103","Hollingbery, George","person",0
+"3104","Hollingbery, George","rape",0
+"3105","Hollingbery, George","offenc",0
+"3106","Hollingbery, George","sexual",0
+"3107","Hollingbery, George","agreement",0
+"3108","Hollingbery, George","becom",0
+"3109","Hollinrake, Kevin","guardianship",5.24788201790788
+"3110","Hollinrake, Kevin","legislation",4.78964822062336
+"3111","Hollinrake, Kevin","missing",4.55597706316112
+"3112","Hollinrake, Kevin","proposals",3.99172247947518
+"3113","Hollinrake, Kevin","address",3.47438573672608
+"3114","Hollinrake, Kevin","needs",3.20025414365343
+"3115","Hollinrake, Kevin","families",2.90672428658086
+"3116","Hollinrake, Kevin","landlords",2.74516396509527
+"3117","Hollinrake, Kevin","eviction",2.68572709037698
+"3118","Hollinrake, Kevin","women",2.52977693017819
+"3119","Hollinrake, Kevin","affairs",2.50757670884253
+"3120","Hollinrake, Kevin","system",2.50396577486581
+"3121","Hollobone, Philip","foreign",27.1867050965525
+"3122","Hollobone, Philip","national",19.0903923467856
+"3123","Hollobone, Philip","countries",12.998143590499
+"3124","Hollobone, Philip","offenders",11.6865720876398
+"3125","Hollobone, Philip","return",11.4346783551283
+"3126","Hollobone, Philip","compulsory",11.0904442418211
+"3127","Hollobone, Philip","transfer",9.28455910298514
+"3128","Hollobone, Philip","agreements",8.027874400026
+"3129","Hollobone, Philip","largest",7.51966007803516
+"3130","Hollobone, Philip","prison",7.18256325992081
+"3131","Hollobone, Philip","detention",5.99823586488234
+"3132","Hollobone, Philip","507w",5.24861374353734
+"3133","Hopkins, Kelvin","electronic",12.8029066685629
+"3134","Hopkins, Kelvin","monitoring",9.87163530855181
+"3135","Hopkins, Kelvin","agenda",8.15223593344098
+"3136","Hopkins, Kelvin","transforming",7.94366092842604
+"3137","Hopkins, Kelvin","introduction",7.31497506383593
+"3138","Hopkins, Kelvin","homicide",7.09526417251683
+"3139","Hopkins, Kelvin","following",6.61781506142319
+"3140","Hopkins, Kelvin","reoffending",6.57102330976328
+"3141","Hopkins, Kelvin","technology",6.36612967598153
+"3142","Hopkins, Kelvin","introduce",5.44072356979878
+"3143","Hopkins, Kelvin","rehabilitation",5.40986134196452
+"3144","Hopkins, Kelvin","tagging",5.39948070959441
+"3145","Horwood, Martin","programme",5.30250181186118
+"3146","Horwood, Martin","transforming",4.54293950699337
+"3147","Horwood, Martin","rehabilitation",4.44551916968309
+"3148","Horwood, Martin","successor",3.56573088174181
+"3149","Horwood, Martin","shortage",3.48477266477566
+"3150","Horwood, Martin","mutuals",3.27333545844424
+"3151","Horwood, Martin","become",2.98317831100567
+"3152","Horwood, Martin","indicated",2.83330026878961
+"3153","Horwood, Martin","work",2.81780445529242
+"3154","Horwood, Martin","withdrawn",2.79545128374647
+"3155","Horwood, Martin","signed",2.64984497767234
+"3156","Horwood, Martin","interventions",2.59465887360667
+"3157","Howarth, George","insurance",7.15871550851781
+"3158","Howarth, George","billion",5.6868858266447
+"3159","Howarth, George","save",5.0741746043649
+"3160","Howarth, George","injury",4.70382010435823
+"3161","Howarth, George","whiplash",3.90932842747095
+"3162","Howarth, George","reform",3.81725309358936
+"3163","Howarth, George","claims",3.78789658766637
+"3164","Howarth, George","genuine",3.74933095786226
+"3165","Howarth, George","personal",3.74851308610077
+"3166","Howarth, George","fraudulent",2.93189404102191
+"3167","Howarth, George","vow",2.87478414296704
+"3168","Howarth, George","comes",2.83009143875762
+"3169","Howell, John","gambling",5.24861374353734
+"3170","Howell, John","education",3.57854054788012
+"3171","Howell, John","problems",3.28601931495429
+"3172","Howell, John","help",3.24538404638696
+"3173","Howell, John","programmes",2.42399965496672
+"3174","Howell, John","prison",1.76256468260781
+"3175","Howell, John","will",1.55685628854736
+"3176","Howell, John","service",1.42482871163778
+"3177","Howell, John","convict",0
+"3178","Howell, John","five",0
+"3179","Howell, John","person",0
+"3180","Howell, John","rape",0
+"3181","Howlett, Ben","intersex",4.28547517620851
+"3182","Howlett, Ben","bias",3.95214184287518
+"3183","Howlett, Ben","charge",3.47041521612069
+"3184","Howlett, Ben","court",3.32897372211154
+"3185","Howlett, Ben","unsold",3.31951479760817
+"3186","Howlett, Ben","will",2.75107867201082
+"3187","Howlett, Ben","sold",2.65208034988392
+"3188","Howlett, Ben","criminal",2.59489025105377
+"3189","Howlett, Ben","people",2.39281143781709
+"3190","Howlett, Ben","gender",2.36717934215402
+"3191","Howlett, Ben","receipt",2.36406537080784
+"3192","Howlett, Ben","make",2.34969020218931
+"3193","Huddleston, Nigel","just",4.23205405292339
+"3194","Huddleston, Nigel","solutions",4.07799290524222
+"3195","Huddleston, Nigel","international",3.97476746650851
+"3196","Huddleston, Nigel","future",3.43957280256281
+"3197","Huddleston, Nigel","convict",0
+"3198","Huddleston, Nigel","five",0
+"3199","Huddleston, Nigel","person",0
+"3200","Huddleston, Nigel","rape",0
+"3201","Huddleston, Nigel","year",0
+"3202","Huddleston, Nigel","offenc",0
+"3203","Huddleston, Nigel","sexual",0
+"3204","Huddleston, Nigel","agreement",0
+"3205","Hunt, Tristram","abolished",6.86689055136285
+"3206","Hunt, Tristram","relocated",6.42130314514237
+"3207","Hunt, Tristram","jobs",5.46562416993857
+"3208","Hunt, Tristram","trent",5.04951886677335
+"3209","Hunt, Tristram","stoke",4.89978431698144
+"3210","Hunt, Tristram","2020",4.26796164029886
+"3211","Hunt, Tristram","ministerial",4.00611275613461
+"3212","Hunt, Tristram","advisory",3.73006992017433
+"3213","Hunt, Tristram","statutory",3.73006992017433
+"3214","Hunt, Tristram","departmental",3.58037271374495
+"3215","Hunt, Tristram","accountable",3.42304186276409
+"3216","Hunt, Tristram","executive",3.2285885522696
+"3217","Huppert, Dr Julian","guardianship",4.14632431625404
+"3218","Huppert, Dr Julian","launch",3.81674328312721
+"3219","Huppert, Dr Julian","private",3.74028574263235
+"3220","Huppert, Dr Julian","missing",3.59965380639627
+"3221","Huppert, Dr Julian","fund",3.36785357919879
+"3222","Huppert, Dr Julian","contractors",2.86156738244361
+"3223","Huppert, Dr Julian","longer",2.80064765981174
+"3224","Huppert, Dr Julian","people",2.65949414700761
+"3225","Huppert, Dr Julian","consultation",2.47510249662734
+"3226","Huppert, Dr Julian","enable",2.38261729153062
+"3227","Huppert, Dr Julian","sector",2.28081468926633
+"3228","Huppert, Dr Julian","2014",2.26438125180991
+"3229","Huq, Dr Rupa","fraud",5.11242902624509
+"3230","Huq, Dr Rupa","benefit",4.87568384466262
+"3231","Huq, Dr Rupa","model",3.79819167604396
+"3232","Huq, Dr Rupa","overturned",3.42022720303473
+"3233","Huq, Dr Rupa","house",2.82116768671028
+"3234","Huq, Dr Rupa","convictions",2.79310712758443
+"3235","Huq, Dr Rupa","2014",2.48541725320677
+"3236","Huq, Dr Rupa","2010",2.36530516856514
+"3237","Huq, Dr Rupa","health",2.3320124516766
+"3238","Huq, Dr Rupa","abuse",2.2625183190908
+"3239","Huq, Dr Rupa","potential",2.18046294194366
+"3240","Huq, Dr Rupa","conducted",2.14053394887999
+"3241","Hussain, Imran","bradford",9.09024840045826
+"3242","Hussain, Imran","humber",9.09024840045826
+"3243","Hussain, Imran","discount",7.37919238516902
+"3244","Hussain, Imran","yorkshire",7.03534121798697
+"3245","Hussain, Imran","2008",6.60573830482494
+"3246","Hussain, Imran","brought",6.19362587914656
+"3247","Hussain, Imran","motor",6.13179551903103
+"3248","Hussain, Imran","insurance",5.14056238014058
+"3249","Hussain, Imran","invasive",4.6015555121686
+"3250","Hussain, Imran","rate",4.47005483733151
+"3251","Hussain, Imran","olds",4.46126780918538
+"3252","Hussain, Imran","potential",4.39480547319832
+"3253","Irranca-Davies, Huw","ogmore",4.54543283655548
+"3254","Irranca-Davies, Huw","recently",3.79819167604396
+"3255","Irranca-Davies, Huw","books",2.77156191585442
+"3256","Irranca-Davies, Huw","rules",2.63584201965588
+"3257","Irranca-Davies, Huw","governing",2.57470586172593
+"3258","Irranca-Davies, Huw","provision",2.11981299668154
+"3259","Irranca-Davies, Huw","successful",2.07455966975989
+"3260","Irranca-Davies, Huw","independence",2.0626508862662
+"3261","Irranca-Davies, Huw","reason",2.0461038836634
+"3262","Irranca-Davies, Huw","payment",1.86374362690268
+"3263","Irranca-Davies, Huw","appeals",1.80366606649618
+"3264","Irranca-Davies, Huw","personal",1.5828752038135
+"3265","Jackson, Stewart","education",4.38279918308302
+"3266","Jackson, Stewart","meaningful",3.2883807836292
+"3267","Jackson, Stewart","medical",2.98317831100567
+"3268","Jackson, Stewart","general",2.70051267548735
+"3269","Jackson, Stewart","research",2.64984497767234
+"3270","Jackson, Stewart","encourage",2.48215439173454
+"3271","Jackson, Stewart","regulation",2.24930035728245
+"3272","Jackson, Stewart","enable",2.08969360247652
+"3273","Jackson, Stewart","potential",1.9229875624584
+"3274","Jackson, Stewart","data",1.84483247791272
+"3275","Jackson, Stewart","part",1.78808567676192
+"3276","Jackson, Stewart","prisons",1.760522993878
+"3277","James, Margot","nine",3.17779514846045
+"3278","James, Margot","comply",2.65536262541257
+"3279","James, Margot","wage",2.56193127140856
+"3280","James, Margot","minimum",2.54533961642677
+"3281","James, Margot","employees",2.29943850898823
+"3282","James, Margot","successfully",1.85554257798505
+"3283","James, Margot","legislation",1.81764591523608
+"3284","James, Margot","companies",1.51313821247883
+"3285","James, Margot","tribunal",1.30770501022297
+"3286","James, Margot","years",0.591980613658294
+"3287","James, Margot","convict",0
+"3288","James, Margot","five",0
+"3289","James, Siân C.","english",14.3677342585261
+"3290","James, Siân C.","postcode",10.0567208340992
+"3291","James, Siân C.","welsh",8.75347999097391
+"3292","James, Siân C.","home",5.67865307472008
+"3293","James, Siân C.","women",5.04711655052522
+"3294","James, Siân C.","speakers",4.84036545307348
+"3295","James, Siân C.","wales",3.60696259502595
+"3296","James, Siân C.","held",3.50787126329775
+"3297","James, Siân C.","prisoners",2.95793373168006
+"3298","James, Siân C.","remanded",2.52030713879609
+"3299","James, Siân C.","whose",2.46369719538345
+"3300","James, Siân C.","language",2.46369719538345
+"3301","Jamieson, Cathy","scotland",14.5084940668389
+"3302","Jamieson, Cathy","ordinarily",7.49866191572452
+"3303","Jamieson, Cathy","accommodated",6.95044651430334
+"3304","Jamieson, Cathy","units",6.39070452290697
+"3305","Jamieson, Cathy","england",6.0421093591811
+"3306","Jamieson, Cathy","resident",4.9407624812118
+"3307","Jamieson, Cathy","transferred",4.90790826570383
+"3308","Jamieson, Cathy","secure",4.73396992862935
+"3309","Jamieson, Cathy","three",3.60359298974821
+"3310","Jamieson, Cathy","young",3.46271834705357
+"3311","Jamieson, Cathy","people",3.43482170446428
+"3312","Jamieson, Cathy","scottish",3.07114171377589
+"3313","Jarvis, Dan","secure",68.8272020916216
+"3314","Jarvis, Dan","youth",63.0501934248257
+"3315","Jarvis, Dan","college",62.4497003289723
+"3316","Jarvis, Dan","offender",56.2273418035604
+"3317","Jarvis, Dan","2014",52.6424448255151
+"3318","Jarvis, Dan","2010",50.2958464992416
+"3319","Jarvis, Dan","estimate",45.7643268400189
+"3320","Jarvis, Dan","victim",45.0389201498574
+"3321","Jarvis, Dan","official",44.2166105918459
+"3322","Jarvis, Dan","may",43.0614225083544
+"3323","Jarvis, Dan","homicide",40.863624061054
+"3324","Jarvis, Dan","made",40.5966489697253
+"3325","Jenkin, Bernard","renegotiation",2.24065381335005
+"3326","Jenkin, Bernard","referendum",1.89909583802198
+"3327","Jenkin, Bernard","europe",1.77586492552981
+"3328","Jenkin, Bernard","specific",1.69130312731772
+"3329","Jenkin, Bernard","strategy",1.67370710383621
+"3330","Jenkin, Bernard","matters",1.64159429702559
+"3331","Jenkin, Bernard","relationship",1.62685320785461
+"3332","Jenkin, Bernard","communications",1.56315958217859
+"3333","Jenkin, Bernard","consequences",1.50232089081311
+"3334","Jenkin, Bernard","equivalent",1.49338095103485
+"3335","Jenkin, Bernard","deal",1.45261206052098
+"3336","Jenkin, Bernard","guidelines",1.43787097135
+"3337","Jenkyns, Andrea","incestuous",3.71133036988416
+"3338","Jenkyns, Andrea","juvenile",2.79625184343734
+"3339","Jenkyns, Andrea","eligibility",2.2679546969101
+"3340","Jenkyns, Andrea","limitations",2.19638418859702
+"3341","Jenkyns, Andrea","apply",1.9244819322312
+"3342","Jenkyns, Andrea","abuse",1.72802690974297
+"3343","Jenkyns, Andrea","compensation",1.71402659362082
+"3344","Jenkyns, Andrea","sexual",1.64155130505809
+"3345","Jenkyns, Andrea","injury",1.62178290750776
+"3346","Jenkyns, Andrea","claim",1.43229278945972
+"3347","Jenkyns, Andrea","criminal",1.29744512552689
+"3348","Jenkyns, Andrea","victims",1.280089689943
+"3349","Johnson, Alan","ashes",16.7038873477225
+"3350","Johnson, Alan","loss",15.9010104663471
+"3351","Johnson, Alan","1996",12.7801476698044
+"3352","Johnson, Alan","son",12.1568428700236
+"3353","Johnson, Alan","hull",11.2491354794711
+"3354","Johnson, Alan","jenni",8.77015194683978
+"3355","Johnson, Alan","murray",8.77015194683978
+"3356","Johnson, Alan","chloe",8.77015194683978
+"3357","Johnson, Alan","louise",8.77015194683978
+"3358","Johnson, Alan","medlam",8.77015194683978
+"3359","Johnson, Alan","angela",8.77015194683978
+"3360","Johnson, Alan","reece",8.77015194683978
+"3361","Johnson, Diana","contrary",74.6015816604468
+"3362","Johnson, Diana","four",66.2131579600152
+"3363","Johnson, Diana","section",65.8346104006774
+"3364","Johnson, Diana","convicted",57.5160695257432
+"3365","Johnson, Diana","ashes",57.1449448737775
+"3366","Johnson, Diana","act",57.1344540738954
+"3367","Johnson, Diana","2003",53.2422926477424
+"3368","Johnson, Diana","hull",51.0082443718416
+"3369","Johnson, Diana","offence",50.9234654883687
+"3370","Johnson, Diana","loss",45.6288491225477
+"3371","Johnson, Diana","people",42.8487908714743
+"3372","Johnson, Diana","sexual",40.848724668082
+"3373","Johnson, Gareth","video",5.31072525082514
+"3374","Johnson, Gareth","link",4.86136978039679
+"3375","Johnson, Gareth","spaces",3.34741420767242
+"3376","Johnson, Gareth","availability",3.25370641570922
+"3377","Johnson, Gareth","scope",3.17779514846045
+"3378","Johnson, Gareth","efficiency",3.06314042223207
+"3379","Johnson, Gareth","infanticide",3.04104746457308
+"3380","Johnson, Gareth","east",3.00464178162622
+"3381","Johnson, Gareth","south",2.98676190206969
+"3382","Johnson, Gareth","via",2.97159039142941
+"3383","Johnson, Gareth","sufficient",2.8835764369274
+"3384","Johnson, Gareth","manslaughter",2.75237232997826
+"3385","Jones, David","fitting",2.64439379870175
+"3386","Jones, David","contractors",2.50976062055959
+"3387","Jones, David","possible",2.36704370058914
+"3388","Jones, David","construction",2.26206346474295
+"3389","Jones, David","based",2.16666767781905
+"3390","Jones, David","carried",1.88931757970644
+"3391","Jones, David","north",1.77420688856103
+"3392","Jones, David","locally",1.68492009985882
+"3393","Jones, David","new",1.45789430931389
+"3394","Jones, David","work",1.23103866084069
+"3395","Jones, David","wales",1.12122780361465
+"3396","Jones, David","will",0.747889569674787
+"3397","Jones, Gerald","justice",2.28196056113284
+"3398","Jones, Gerald","access",2.25944911590024
+"3399","Jones, Gerald","fees",2.14596231804009
+"3400","Jones, Gerald","employment",1.74998484191408
+"3401","Jones, Gerald","tribunal",1.68823990878185
+"3402","Jones, Gerald","made",1.16843603864808
+"3403","Jones, Gerald","convict",0
+"3404","Jones, Gerald","five",0
+"3405","Jones, Gerald","person",0
+"3406","Jones, Gerald","rape",0
+"3407","Jones, Gerald","year",0
+"3408","Jones, Gerald","offenc",0
+"3409","Jones, Graham","191341",4.54543283655548
+"3410","Jones, Graham","hyndburn",4.54543283655548
+"3411","Jones, Graham","xiy",4.48283398317258
+"3412","Jones, Graham","xiiy",4.48283398317258
+"3413","Jones, Graham","viiy",4.1011843711962
+"3414","Jones, Graham","100",3.90589726335257
+"3415","Jones, Graham","viy",3.86526098777769
+"3416","Jones, Graham","2004",3.53580107160243
+"3417","Jones, Graham","two",2.89252476306058
+"3418","Jones, Graham","submitted",2.84577620407675
+"3419","Jones, Graham","one",2.82116806623052
+"3420","Jones, Graham","previously",2.74368404965547
+"3421","Jones, Graham P","coroners",6.03021123538673
+"3422","Jones, Graham P","mergers",4.6015555121686
+"3423","Jones, Graham P","offices",3.85238329239812
+"3424","Jones, Graham P","2010",2.91479550854606
+"3425","Jones, Graham P","closed",2.88320152041909
+"3426","Jones, Graham P","subject",2.85710301670671
+"3427","Jones, Graham P","year",1.60143069848958
+"3428","Jones, Graham P","convict",0
+"3429","Jones, Graham P","five",0
+"3430","Jones, Graham P","person",0
+"3431","Jones, Graham P","rape",0
+"3432","Jones, Graham P","offenc",0
+"3433","Jones, Helen","warrington",8.35092127556373
+"3434","Jones, Helen","pharmacies",7.4802602295914
+"3435","Jones, Helen","risley",7.32150391569037
+"3436","Jones, Helen","helplines",6.37234805415421
+"3437","Jones, Helen","claims",5.68715567248604
+"3438","Jones, Helen","fraudulent",5.66192885640488
+"3439","Jones, Helen","library",5.55948872402818
+"3440","Jones, Helen","will",5.55406715177639
+"3441","Jones, Helen","region",5.25096775761661
+"3442","Jones, Helen","north",5.07103379905765
+"3443","Jones, Helen","west",5.02019630989066
+"3444","Jones, Helen","officer",4.96459695791654
+"3445","Jones, Kevan","budget",5.06977234109145
+"3446","Jones, Kevan","financial",4.23962599336308
+"3447","Jones, Kevan","departments",3.85640026341653
+"3448","Jones, Kevan","seabrook",3.71133036988416
+"3449","Jones, Kevan","steering",3.71133036988416
+"3450","Jones, Kevan","advertising",3.46063735173971
+"3451","Jones, Kevan","communications",3.12631916435718
+"3452","Jones, Kevan","2014",2.70645325460363
+"3453","Jones, Kevan","2010",2.57565922314829
+"3454","Jones, Kevan","dealing",2.21890157424772
+"3455","Jones, Kevan","contact",2.17502206078864
+"3456","Jones, Kevan","solicitors",2.16473832385233
+"3457","Jones, Susan Elan","motoring",11.6009443502442
+"3458","Jones, Susan Elan","penalties",9.366680176686
+"3459","Jones, Susan Elan","review",6.37905526129941
+"3460","Jones, Susan Elan","volunteering",5.42821276431277
+"3461","Jones, Susan Elan","offences",5.23185654071961
+"3462","Jones, Susan Elan","sentencing",5.03336025486512
+"3463","Jones, Susan Elan","gcse",3.95214184287518
+"3464","Jones, Susan Elan","transport",3.54624899033599
+"3465","Jones, Susan Elan","introduce",3.13573151395219
+"3466","Jones, Susan Elan","programme",2.96878114567547
+"3467","Jones, Susan Elan","english",2.89550017572774
+"3468","Jones, Susan Elan","purpose",2.82116768671028
+"3469","Kane, Mike","bilateral",4.54543283655548
+"3470","Kane, Mike","indonesia",4.54543283655548
+"3471","Kane, Mike","bribery",4.19330722170474
+"3472","Kane, Mike","corporate",3.83630669925203
+"3473","Kane, Mike","sanctioned",3.54624899033599
+"3474","Kane, Mike","benefits",2.86734636679085
+"3475","Kane, Mike","bodies",2.70570916153304
+"3476","Kane, Mike","length",2.49094246850339
+"3477","Kane, Mike","agreement",2.3432128691399
+"3478","Kane, Mike","progress",2.22263811052184
+"3479","Kane, Mike","prosecuted",2.2202881354221
+"3480","Kane, Mike","establishing",2.17646965574086
+"3481","Kaufman, Sir Gerald","gorton",9.39235769033044
+"3482","Kaufman, Sir Gerald","reply",7.54046814433311
+"3483","Kaufman, Sir Gerald","manchester",6.94366250987381
+"3484","Kaufman, Sir Gerald","dated",6.58482072690408
+"3485","Kaufman, Sir Gerald","intends",6.08452174278384
+"3486","Kaufman, Sir Gerald","regard",6.08452174278384
+"3487","Kaufman, Sir Gerald","letter",5.83170917314109
+"3488","Kaufman, Sir Gerald","member",4.35564582339727
+"3489","Kaufman, Sir Gerald","right",4.33160145660552
+"3490","Kaufman, Sir Gerald","sherratt",3.71133036988416
+"3491","Kaufman, Sir Gerald","lawson",3.56573088174181
+"3492","Kaufman, Sir Gerald","hussain",3.43602425333506
+"3493","Kawczynski, Daniel","crematorium",18.9245892315239
+"3494","Kawczynski, Daniel","cremation",15.1180779588791
+"3495","Kawczynski, Daniel","infant",10.6978758174996
+"3496","Kawczynski, Daniel","emstrey",8.28402110458559
+"3497","Kawczynski, Daniel","shrewsbury",8.03837311251176
+"3498","Kawczynski, Daniel","amending",5.91659609790616
+"3499","Kawczynski, Daniel","practice",5.90321526007258
+"3500","Kawczynski, Daniel","sexual",5.22731819795107
+"3501","Kawczynski, Daniel","baby",5.18254874628667
+"3502","Kawczynski, Daniel","regulations",5.05232182566931
+"3503","Kawczynski, Daniel","appoint",4.8349049269335
+"3504","Kawczynski, Daniel","national",4.80671023858619
+"3505","Kendall, Liz","gender",4.10007489123824
+"3506","Kendall, Liz","diagnosis",2.84879127854937
+"3507","Kendall, Liz","work",2.56261132430039
+"3508","Kendall, Liz","contesting",2.48215439173454
+"3509","Kendall, Liz","terminal",2.36704370058914
+"3510","Kendall, Liz","dismissal",2.34752121359238
+"3511","Kendall, Liz","appellant",2.26206346474295
+"3512","Kendall, Liz","occurred",2.15472256357675
+"3513","Kendall, Liz","people",2.01123457423429
+"3514","Kendall, Liz","took",1.89542657792812
+"3515","Kendall, Liz","condition",1.77877987103414
+"3516","Kendall, Liz","place",1.36943338594333
+"3517","Kennedy, Seema","enforcement",2.40418977961694
+"3518","Kennedy, Seema","powers",2.34117850482026
+"3519","Kennedy, Seema","effectiveness",2.06133339555135
+"3520","Kennedy, Seema","child",1.93011211272259
+"3521","Kennedy, Seema","orders",1.63797034109543
+"3522","Kennedy, Seema","custody",1.52987966264354
+"3523","Kennedy, Seema","relating",1.49962450800248
+"3524","Kennedy, Seema","made",0.954024030588891
+"3525","Kennedy, Seema","court",0.949332302184983
+"3526","Kennedy, Seema","convict",0
+"3527","Kennedy, Seema","five",0
+"3528","Kennedy, Seema","person",0
+"3529","Khan, Sadiq","prison",145.35198929405
+"3530","Khan, Sadiq","2010",138.31319916815
+"3531","Khan, Sadiq","2014",117.416850001657
+"3532","Khan, Sadiq","2013",105.129796539413
+"3533","Khan, Sadiq","month",98.9691116276669
+"3534","Khan, Sadiq","staff",95.8993411207792
+"3535","Khan, Sadiq","four",84.264665122525
+"3536","Khan, Sadiq","year",75.641753466885
+"3537","Khan, Sadiq","january",70.4585006340798
+"3538","Khan, Sadiq","2011",67.9529730949574
+"3539","Khan, Sadiq","2012",60.4932784465388
+"3540","Khan, Sadiq","may",59.2639736525723
+"3541","Kinahan, Danny","maghaberry",5.24861374353734
+"3542","Kinahan, Danny","accurate",3.74933095786226
+"3543","Kinahan, Danny","reflection",3.33130058958113
+"3544","Kinahan, Danny","made",3.1552642722856
+"3545","Kinahan, Danny","motion",3.03028855770365
+"3546","Kinahan, Danny","policies",2.96856235031315
+"3547","Kinahan, Danny","staff",2.85891499306614
+"3548","Kinahan, Danny","inspections",2.80064765981174
+"3549","Kinahan, Danny","inspectorate",2.73798999521449
+"3550","Kinahan, Danny","bisexual",2.55888403691262
+"3551","Kinahan, Danny","gay",2.48300485726285
+"3552","Kinahan, Danny","assembly",2.42100705324603
+"3553","Kinnock, Stephen","existing",5.68313498747624
+"3554","Kinnock, Stephen","steel",4.26021258338486
+"3555","Kinnock, Stephen","changing",3.98506397046232
+"3556","Kinnock, Stephen","category",3.93590077532276
+"3557","Kinnock, Stephen","consistency",3.66115306706041
+"3558","Kinnock, Stephen","incarcerated",3.370953895301
+"3559","Kinnock, Stephen","public",3.20922130025133
+"3560","Kinnock, Stephen","procurement",3.10405944221048
+"3561","Kinnock, Stephen","land",3.01635686885598
+"3562","Kinnock, Stephen","port",2.95214184287518
+"3563","Kinnock, Stephen","talbot",2.95214184287518
+"3564","Kinnock, Stephen","disturbances",2.79625184343734
+"3565","Kirby, Simon","will",17.2393185385445
+"3566","Kirby, Simon","energy",14.2498005264186
+"3567","Kirby, Simon","departmental",8.75937666929366
+"3568","Kirby, Simon","replies",8.65838526935974
+"3569","Kirby, Simon","letter",6.79928515841002
+"3570","Kirby, Simon","finance",6.64467811652137
+"3571","Kirby, Simon","member",6.451123069471
+"3572","Kirby, Simon","email",5.96490586713265
+"3573","Kirby, Simon","water",5.92821276431277
+"3574","Kirby, Simon","cost",5.62802931831525
+"3575","Kirby, Simon","initiative",5.55533176717822
+"3576","Kirby, Simon","usage",5.42821276431277
+"3577","Knight, Julian","landowner",6.33752602284526
+"3578","Knight, Julian","evict",5.37145418075397
+"3579","Knight, Julian","potential",4.48281923594249
+"3580","Knight, Julian","travellers",3.84000962356849
+"3581","Knight, Julian","faster",3.43602425333506
+"3582","Knight, Julian","substantially",3.16876301142263
+"3583","Knight, Julian","whereabouts",3.11814120131826
+"3584","Knight, Julian","easier",3.0124252070077
+"3585","Knight, Julian","get",2.74516396509527
+"3586","Knight, Julian","order",2.62659592546129
+"3587","Knight, Julian","deny",2.55499091953533
+"3588","Knight, Julian","disclose",2.49119570551037
+"3589","Knight, Sir Greg","whiplash",4.7456018079812
+"3590","Knight, Sir Greg","pedal",4.4813076267001
+"3591","Knight, Sir Greg","progress",4.11968087114532
+"3592","Knight, Sir Greg","cyclists",3.66115306706041
+"3593","Knight, Sir Greg","traffic",3.31435636097134
+"3594","Knight, Sir Greg","bailiffs",3.11687542582858
+"3595","Knight, Sir Greg","methods",3.06314042223207
+"3596","Knight, Sir Greg","tackling",3.01103068551658
+"3597","Knight, Sir Greg","road",3.00464178162622
+"3598","Knight, Sir Greg","made",2.78062420909438
+"3599","Knight, Sir Greg","recommendations",2.59148526165396
+"3600","Knight, Sir Greg","scheduled",2.57144118043676
+"3601","Kwarteng, Kwasi","intimidating",3.34969020218931
+"3602","Kwarteng, Kwasi","bailiffs",3.28547517620851
+"3603","Kwarteng, Kwasi","threatening",3.22883350906107
+"3604","Kwarteng, Kwasi","sutton",3.12614137666199
+"3605","Kwarteng, Kwasi","behaviour",2.82136936861559
+"3606","Kwarteng, Kwasi","exercise",2.73368058740397
+"3607","Kwarteng, Kwasi","put",2.68302353552264
+"3608","Kwarteng, Kwasi","restrictions",2.66614817783265
+"3609","Kwarteng, Kwasi","half",2.60625718289888
+"3610","Kwarteng, Kwasi","highdown",2.57144118043676
+"3611","Kwarteng, Kwasi","permitted",2.45633048929136
+"3612","Kwarteng, Kwasi","prevent",2.27801923853236
+"3613","Lady Hermon","comfort",4.28547517620851
+"3614","Lady Hermon","became",3.51149914457939
+"3615","Lady Hermon","irish",3.43310319184542
+"3616","Lady Hermon","republic",3.24812180703875
+"3617","Lady Hermon","citizens",2.69884505754746
+"3618","Lady Hermon","aware",2.60401046975569
+"3619","Lady Hermon","called",2.47672025797448
+"3620","Lady Hermon","ireland",2.39416778770785
+"3621","Lady Hermon","letters",2.33281484449932
+"3622","Lady Hermon","requested",2.23733225713145
+"3623","Lady Hermon","runs",2.17219184191364
+"3624","Lady Hermon","within",1.93800346859359
+"3625","Lamb, Norman","discount",4.33193472857385
+"3626","Lamb, Norman","nhs",3.96071390393424
+"3627","Lamb, Norman","impact",3.14102057054366
+"3628","Lamb, Norman","carried",3.04643305919697
+"3629","Lamb, Norman","lost",2.96878566766741
+"3630","Lamb, Norman","illness",2.94611216943278
+"3631","Lamb, Norman","rate",2.62413347934719
+"3632","Lamb, Norman","due",2.49222281348348
+"3633","Lamb, Norman","mental",2.24457997622849
+"3634","Lamb, Norman","days",2.15251832037035
+"3635","Lamb, Norman","working",1.56927253840345
+"3636","Lamb, Norman","three",1.56040153701073
+"3637","Lammy, David","unsuccessful",5.71684164164157
+"3638","Lammy, David","claim",3.83413531623385
+"3639","Lammy, David","independence",3.44318198245784
+"3640","Lammy, David","appeal",3.01085876620266
+"3641","Lammy, David","overturned",2.72839744576541
+"3642","Lammy, David","personal",2.64229270136729
+"3643","Lammy, David","payment",2.55183897591465
+"3644","Lammy, David","whose",2.46369719538345
+"3645","Lammy, David","2013",2.44872288842994
+"3646","Lammy, David","died",2.42400334715768
+"3647","Lammy, David","heard",2.38776570287631
+"3648","Lammy, David","nicolson",2.34725142363783
+"3649","Latham, Pauline","vulnerable",3.72029485792731
+"3650","Latham, Pauline","traumatisation",3.2883807836292
+"3651","Latham, Pauline","exploitation",2.84879127854937
+"3652","Latham, Pauline","criminal",2.33661689732089
+"3653","Latham, Pauline","old",2.14312373374476
+"3654","Latham, Pauline","1999",2.12678584630282
+"3655","Latham, Pauline","roll",2.12678584630282
+"3656","Latham, Pauline","limit",2.11021767100035
+"3657","Latham, Pauline","crossexamination",2.06991966946267
+"3658","Latham, Pauline","start",2.0210162749154
+"3659","Latham, Pauline","pre",1.9649115890036
+"3660","Latham, Pauline","pilot",1.95218637052553
+"3661","Lavery, Ian","oakwood",17.7913544721109
+"3662","Lavery, Ian","prison",17.6653223356805
+"3663","Lavery, Ian","noms",14.7464382843788
+"3664","Lavery, Ian","office",11.8866636148907
+"3665","Lavery, Ian","hour",11.1429286858672
+"3666","Lavery, Ian","staff",10.6492903366464
+"3667","Lavery, Ian","service",10.5751004648266
+"3668","Lavery, Ian","per",10.5028169264579
+"3669","Lavery, Ian","three",10.1202587224876
+"3670","Lavery, Ian","retired",9.63591366656073
+"3671","Lavery, Ian","cells",9.60641749523468
+"3672","Lavery, Ian","increase",9.17296884914669
+"3673","Law, Chris","2952",3.71133036988416
+"3674","Law, Chris","foundation",2.84530496609973
+"3675","Law, Chris","election",2.83009143875762
+"3676","Law, Chris","accredited",2.79625184343734
+"3677","Law, Chris","general",2.56193127140856
+"3678","Law, Chris","scotland",2.54533961642677
+"3679","Law, Chris","status",2.38776570287631
+"3680","Law, Chris","wage",2.33871258021393
+"3681","Law, Chris","capacity",2.2900315730418
+"3682","Law, Chris","2015",2.2639600220934
+"3683","Law, Chris","visit",2.24570350539172
+"3684","Law, Chris","live",2.06575516700017
+"3685","Leech, John","evasion",2.68572709037698
+"3686","Leech, John","unpaid",2.54820162515169
+"3687","Leech, John","television",2.11195959474311
+"3688","Leech, John","outstanding",1.96826477440939
+"3689","Leech, John","imprisoned",1.71853275413533
+"3690","Leech, John","licence",1.55333073247474
+"3691","Leech, John","fines",1.53340722113761
+"3692","Leech, John","non",1.45805602395016
+"3693","Leech, John","payment",1.40885775553315
+"3694","Leech, John","2012",1.28900164513632
+"3695","Leech, John","average",1.27314392935718
+"3696","Leech, John","relating",1.20237452523316
+"3697","Lefroy, Jeremy","staffordshire",3.0150728235643
+"3698","Lefroy, Jeremy","monetary",2.97159039142941
+"3699","Lefroy, Jeremy","value",1.93800346859359
+"3700","Lefroy, Jeremy","written",1.89687471440397
+"3701","Lefroy, Jeremy","fines",1.81435189204623
+"3702","Lefroy, Jeremy","total",1.78265719015427
+"3703","Lefroy, Jeremy","2011",1.7118933295973
+"3704","Lefroy, Jeremy","service",1.10366757427426
+"3705","Lefroy, Jeremy","courts",0.900615699382737
+"3706","Lefroy, Jeremy","year",0.591980613658294
+"3707","Lefroy, Jeremy","convict",0
+"3708","Lefroy, Jeremy","five",0
+"3709","Leslie, Charlotte","grandparents",11.0675681174319
+"3710","Leslie, Charlotte","premises",8.92560142599415
+"3711","Leslie, Charlotte","grandchildren",8.58512287696761
+"3712","Leslie, Charlotte","appeal",8.37506565118118
+"3713","Leslie, Charlotte","approved",8.27062588197492
+"3714","Leslie, Charlotte","cafcass",6.72847320819328
+"3715","Leslie, Charlotte","parental",6.36193458114751
+"3716","Leslie, Charlotte","shorten",5.74956828593407
+"3717","Leslie, Charlotte","immigration",5.5900134984914
+"3718","Leslie, Charlotte","involving",5.22264829289251
+"3719","Leslie, Charlotte","process",5.19698725954053
+"3720","Leslie, Charlotte","breakdown",5.13897187627229
+"3721","Leslie, Chris","confiscation",17.0482777341375
+"3722","Leslie, Chris","2012",12.5120375581665
+"3723","Leslie, Chris","2013",11.8775218267537
+"3724","Leslie, Chris","order",11.0105463284163
+"3725","Leslie, Chris","issued",9.67982453084941
+"3726","Leslie, Chris","drug",9.51655860286406
+"3727","Leslie, Chris","financial",7.35699039215245
+"3728","Leslie, Chris","crimes",7.31083897888322
+"3729","Leslie, Chris","related",7.06264026672962
+"3730","Leslie, Chris","collected",6.34005313337635
+"3731","Leslie, Chris","value",5.85481707649483
+"3732","Leslie, Chris","100001",5.17897576133697
+"3733","Lewell-Buck, Emma","remote",7.8333354055907
+"3734","Lewell-Buck, Emma","video",7.42697711204584
+"3735","Lewell-Buck, Emma","conferencing",6.72847320819328
+"3736","Lewell-Buck, Emma","reoffending",6.58302301416319
+"3737","Lewell-Buck, Emma","courtrooms",6.58279177560648
+"3738","Lewell-Buck, Emma","disabled",6.33242600347651
+"3739","Lewell-Buck, Emma","availability",5.63912347253556
+"3740","Lewell-Buck, Emma","survey",5.6271314710979
+"3741","Lewell-Buck, Emma","rate",5.25215150703354
+"3742","Lewell-Buck, Emma","illiterate",5.24861374353734
+"3743","Lewell-Buck, Emma","probability",5.24861374353734
+"3744","Lewell-Buck, Emma","sites",4.95951037938384
+"3745","Lilley, Peter","dickinson",3.11814120131826
+"3746","Lilley, Peter","harpenden",3.11814120131826
+"3747","Lilley, Peter","hitchin",3.11814120131826
+"3748","Lilley, Peter","farm",2.73373133054671
+"3749","Lilley, Peter","hertfordshire",2.73373133054671
+"3750","Lilley, Peter","cross",2.63306995124559
+"3751","Lilley, Peter","william",2.63306995124559
+"3752","Lilley, Peter","rural",2.49119570551037
+"3753","Lilley, Peter","behalf",2.34932145977515
+"3754","Lilley, Peter","reply",2.19472199556186
+"3755","Lilley, Peter","letter",1.69737211921404
+"3756","Lilley, Peter","constituent",1.56777649975397
+"3757","Llwyd, Elfyn","harass",23.0633879893625
+"3758","Llwyd, Elfyn","1997",21.1656705553107
+"3759","Llwyd, Elfyn","victim",18.2899857464706
+"3760","Llwyd, Elfyn","court",17.8837945258232
+"3761","Llwyd, Elfyn","england",14.6168336707781
+"3762","Llwyd, Elfyn","wales",14.5355085517889
+"3763","Llwyd, Elfyn","proceeded",13.8838306214549
+"3764","Llwyd, Elfyn","agenda",13.7300835077693
+"3765","Llwyd, Elfyn","protection",13.6180963432458
+"3766","Llwyd, Elfyn","stalk",13.2166466893802
+"3767","Llwyd, Elfyn","tagging",12.2677043194992
+"3768","Llwyd, Elfyn","act",12.1420928685217
+"3769","Long Bailey, Rebecca","1287",3.74933095786226
+"3770","Long Bailey, Rebecca","budget",3.55070657190092
+"3771","Long Bailey, Rebecca","expertise",3.43310319184542
+"3772","Long Bailey, Rebecca","small",3.06209355073595
+"3773","Long Bailey, Rebecca","minor",2.93639188796211
+"3774","Long Bailey, Rebecca","limit",2.8757419427
+"3775","Long Bailey, Rebecca","funded",2.81922999954547
+"3776","Long Bailey, Rebecca","1293",2.74099913247552
+"3777","Long Bailey, Rebecca","whiplash",2.7371112523786
+"3778","Long Bailey, Rebecca","nuisance",2.73373133054671
+"3779","Long Bailey, Rebecca","reference",2.63976260714791
+"3780","Long Bailey, Rebecca","located",2.61566627500507
 "3781","Lord Ahmed","asylum",7.51348450857186
 "3782","Lord Ahmed","immigration",6.66662534601329
 "3783","Lord Ahmed","hear",4.40533566245622
@@ -6239,162 +6239,162 @@
 "6238","Ritchie, Margaret","devolved",4.71044539401927
 "6239","Ritchie, Margaret","legislation",4.60700791659635
 "6240","Ritchie, Margaret","embargo",4.54543283655548
-"6241","Roberts, Liz Saville","wales",69.3107147667996
-"6242","Roberts, Liz Saville","community",68.5121498780261
-"6243","Roberts, Liz Saville","rehabilitation",60.8984845681481
-"6244","Roberts, Liz Saville","companies",59.7929771632381
-"6245","Roberts, Liz Saville","victim",44.7397362408343
-"6246","Roberts, Liz Saville","port",42.905567783521
-"6247","Roberts, Liz Saville","talbot",42.905567783521
-"6248","Roberts, Liz Saville","supervised",39.6348302966623
-"6249","Roberts, Liz Saville","england",31.778344724199
-"6250","Roberts, Liz Saville","probation",30.6470356388375
-"6251","Roberts, Liz Saville","order",25.4181674244417
-"6252","Roberts, Liz Saville","new",24.9435912635753
-"6253","Robertson, John","disincentive",3.398473972902
-"6254","Robertson, John","bringing",2.72839744576541
-"6255","Robertson, John","discrimination",2.3298211284408
-"6256","Robertson, John","sex",2.08817355861364
-"6257","Robertson, John","level",1.76919043086107
-"6258","Robertson, John","women",1.70557525838882
-"6259","Robertson, John","fees",1.58489820787812
-"6260","Robertson, John","claim",1.49598102858838
-"6261","Robertson, John","tribunal",1.24684780501662
-"6262","Robertson, John","acts",1.24274410550915
-"6263","Robertson, John","will",0.813041680110636
-"6264","Robertson, John","convict",0
-"6265","Robertson, Laurence","will",10.1694289430822
-"6266","Robertson, Laurence","fathers",9.54250776064785
-"6267","Robertson, Laurence","children",7.4914132751141
-"6268","Robertson, Laurence","mercy",6.69938040437862
-"6269","Robertson, Laurence","prerogative",6.69938040437862
-"6270","Robertson, Laurence","royal",6.18097535193625
-"6271","Robertson, Laurence","child",5.62411026461801
-"6272","Robertson, Laurence","restricted",5.33207992525376
-"6273","Robertson, Laurence","adequacy",5.30703186178246
-"6274","Robertson, Laurence","intervened",5.30235469043411
-"6275","Robertson, Laurence","contact",5.23038964346284
-"6276","Robertson, Laurence","made",5.20499012544919
-"6277","Robinson, Gavin","maximum",5.8416872351157
-"6278","Robinson, Gavin","hyde",5.47457507061764
-"6279","Robinson, Gavin","park",4.78728815867349
-"6280","Robinson, Gavin","increased",4.53563209681439
-"6281","Robinson, Gavin","northern",3.82348608149829
-"6282","Robinson, Gavin","ireland",3.78551165488164
-"6283","Robinson, Gavin","attributable",3.66115306706041
-"6284","Robinson, Gavin","behaviour",3.45545766451327
-"6285","Robinson, Gavin","sentences",3.17186721576563
-"6286","Robinson, Gavin","30414",3.03028855770365
-"6287","Robinson, Gavin","outwith",3.03028855770365
-"6288","Robinson, Gavin","bombing",2.96410638215638
-"6289","Rosindell, Andrew","people",8.95102633089338
-"6290","Rosindell, Andrew","principles",8.42678246767716
-"6291","Rosindell, Andrew","leave",8.08570279679457
-"6292","Rosindell, Andrew","prison",7.23762954315501
-"6293","Rosindell, Andrew","convicted",7.19793666730277
-"6294","Rosindell, Andrew","membership",7.10604058142984
-"6295","Rosindell, Andrew","dependencies",7.10476803744014
-"6296","Rosindell, Andrew","january",6.80297809328882
-"6297","Rosindell, Andrew","television",6.44841843672063
-"6298","Rosindell, Andrew","consoles",6.37993248332274
-"6299","Rosindell, Andrew","30551",6.12263181572202
-"6300","Rosindell, Andrew","30552",6.12263181572202
-"6301","Rotheram, Steve","altcourse",32.6529470136637
-"6302","Rotheram, Steve","prison",10.8282863764838
-"6303","Rotheram, Steve","liverpool",9.57769211038865
-"6304","Rotheram, Steve","g4s",9.08706396277029
-"6305","Rotheram, Steve","secretariat",9.03224489903568
-"6306","Rotheram, Steve","zone",8.89780167683854
-"6307","Rotheram, Steve","staff",8.75465022076781
-"6308","Rotheram, Steve","exclusion",7.78075742067567
-"6309","Rotheram, Steve","part",7.12808266380133
-"6310","Rotheram, Steve","enterprise",6.76521250927089
-"6311","Rotheram, Steve","joint",6.56637718810236
-"6312","Rotheram, Steve","attempted",6.52957272870362
-"6313","Roy, Frank","motherwell",3.03028855770365
-"6314","Roy, Frank","wishaw",3.03028855770365
-"6315","Roy, Frank","submitted",1.89718413605117
-"6316","Roy, Frank","live",1.68668203088942
-"6317","Roy, Frank","disabl",1.67384856512182
-"6318","Roy, Frank","constituency",1.52360489198906
-"6319","Roy, Frank","allowance",1.44772571233929
-"6320","Roy, Frank","june",1.40803403347358
-"6321","Roy, Frank","independence",1.37510059084413
-"6322","Roy, Frank","decision",1.35726635138996
-"6323","Roy, Frank","applicants",1.31749054425015
-"6324","Roy, Frank","payment",1.24249575126845
-"6325","Ruane, Chris","per",9.88711504910511
-"6326","Ruane, Chris","hours",9.78788533465132
-"6327","Ruane, Chris","unemployed",9.05710708935289
-"6328","Ruane, Chris","killed",8.86973395004114
-"6329","Ruane, Chris","closure",8.5689972326939
-"6330","Ruane, Chris","classed",8.39373600155216
-"6331","Ruane, Chris","proportion",8.36080663366141
-"6332","Ruane, Chris","week",8.14697088616634
-"6333","Ruane, Chris","cells",7.98788884312181
-"6334","Ruane, Chris","spent",7.96510494631289
-"6335","Ruane, Chris","year",7.63663061112243
-"6336","Ruane, Chris","rhyl",6.91809396928489
-"6337","Ruffley, David","suffolk",23.0829098376606
-"6338","Ruffley, David","edmunds",17.6372381478218
-"6339","Ruffley, David","bury",15.2892967796429
-"6340","Ruffley, David","england",12.4932101130575
-"6341","Ruffley, David","wales",9.68307367789566
-"6342","Ruffley, David","east",8.16463431463035
-"6343","Ruffley, David","speeding",7.53448735016262
-"6344","Ruffley, David","constituency",6.91705767395196
-"6345","Ruffley, David","a14",6.12263181572202
-"6346","Ruffley, David","a143",6.12263181572202
-"6347","Ruffley, David","notices",5.9044768857149
-"6348","Ruffley, David","fixed",5.77131362537207
-"6349","Russell, Sir Bob","led",4.77513553822592
-"6350","Russell, Sir Bob","replacement",4.46482104489395
-"6351","Russell, Sir Bob","lighting",3.76660089921696
-"6352","Russell, Sir Bob","buildings",3.54841377712207
-"6353","Russell, Sir Bob","introduce",3.47878177219783
-"6354","Russell, Sir Bob","implement",3.43026611699385
-"6355","Russell, Sir Bob","programme",3.29356696811189
-"6356","Russell, Sir Bob","throughout",2.84879127854937
-"6357","Russell, Sir Bob","sites",2.09982405777574
-"6358","Russell, Sir Bob","guidance",1.84898243303657
-"6359","Russell, Sir Bob","operators",1.67062816592052
-"6360","Russell, Sir Bob","will",1.49577913934957
-"6361","Ryan, Joan","51526",3.2883807836292
-"6362","Ryan, Joan","retirement",3.19932959467002
-"6363","Ryan, Joan","ratification",3.12614137666199
-"6364","Ryan, Joan","istanbul",3.01103068551658
-"6365","Ryan, Joan","extending",2.8835764369274
-"6366","Ryan, Joan","territorial",2.84879127854937
-"6367","Ryan, Joan","mandatory",2.73195743460209
-"6368","Ryan, Joan","jurisdiction",2.50976062055959
-"6369","Ryan, Joan","extra",2.43207266168937
-"6370","Ryan, Joan","age",2.04719304503465
-"6371","Ryan, Joan","potential",2.03963631832758
-"6372","Ryan, Joan","convention",1.99248315660954
-"6373","Sandbach, Antoinette","qualifications",3.83630669925203
-"6374","Sandbach, Antoinette","civilian",3.61880850954184
-"6375","Sandbach, Antoinette","entry",3.61562058168189
-"6376","Sandbach, Antoinette","officers",3.33954873307659
-"6377","Sandbach, Antoinette","jewish",3.25379110666075
-"6378","Sandbach, Antoinette","christian",3.13398010069454
-"6379","Sandbach, Antoinette","education",3.09910702293687
-"6380","Sandbach, Antoinette","checks",3.01635686885598
-"6381","Sandbach, Antoinette","provision",2.80424900759097
-"6382","Sandbach, Antoinette","prison",2.73658731665753
-"6383","Sandbach, Antoinette","initial",2.61880850954184
-"6384","Sandbach, Antoinette","staff",2.56163816707134
-"6385","Sanders, Adrian","torbay",3.56573088174181
-"6386","Sanders, Adrian","invitation",2.53941356285557
-"6387","Sanders, Adrian","visit",1.96961226838972
-"6388","Sanders, Adrian","ministers",1.93417925483982
-"6389","Sanders, Adrian","constituency",1.79282101736715
-"6390","Sanders, Adrian","purse",1.78808567676192
-"6391","Sanders, Adrian","october",1.67062816592052
-"6392","Sanders, Adrian","issued",1.44371094452865
-"6393","Sanders, Adrian","cost",1.21274374354822
-"6394","Sanders, Adrian","public",1.17746230935846
-"6395","Sanders, Adrian","months",1.12122780361465
-"6396","Sanders, Adrian","2014",0.992996867834185
+"6241","Robertson, John","disincentive",3.398473972902
+"6242","Robertson, John","bringing",2.72839744576541
+"6243","Robertson, John","discrimination",2.3298211284408
+"6244","Robertson, John","sex",2.08817355861364
+"6245","Robertson, John","level",1.76919043086107
+"6246","Robertson, John","women",1.70557525838882
+"6247","Robertson, John","fees",1.58489820787812
+"6248","Robertson, John","claim",1.49598102858838
+"6249","Robertson, John","tribunal",1.24684780501662
+"6250","Robertson, John","acts",1.24274410550915
+"6251","Robertson, John","will",0.813041680110636
+"6252","Robertson, John","convict",0
+"6253","Robertson, Laurence","will",10.1694289430822
+"6254","Robertson, Laurence","fathers",9.54250776064785
+"6255","Robertson, Laurence","children",7.4914132751141
+"6256","Robertson, Laurence","mercy",6.69938040437862
+"6257","Robertson, Laurence","prerogative",6.69938040437862
+"6258","Robertson, Laurence","royal",6.18097535193625
+"6259","Robertson, Laurence","child",5.62411026461801
+"6260","Robertson, Laurence","restricted",5.33207992525376
+"6261","Robertson, Laurence","adequacy",5.30703186178246
+"6262","Robertson, Laurence","intervened",5.30235469043411
+"6263","Robertson, Laurence","contact",5.23038964346284
+"6264","Robertson, Laurence","made",5.20499012544919
+"6265","Robinson, Gavin","maximum",5.8416872351157
+"6266","Robinson, Gavin","hyde",5.47457507061764
+"6267","Robinson, Gavin","park",4.78728815867349
+"6268","Robinson, Gavin","increased",4.53563209681439
+"6269","Robinson, Gavin","northern",3.82348608149829
+"6270","Robinson, Gavin","ireland",3.78551165488164
+"6271","Robinson, Gavin","attributable",3.66115306706041
+"6272","Robinson, Gavin","behaviour",3.45545766451327
+"6273","Robinson, Gavin","sentences",3.17186721576563
+"6274","Robinson, Gavin","30414",3.03028855770365
+"6275","Robinson, Gavin","outwith",3.03028855770365
+"6276","Robinson, Gavin","bombing",2.96410638215638
+"6277","Rosindell, Andrew","people",8.95102633089338
+"6278","Rosindell, Andrew","principles",8.42678246767716
+"6279","Rosindell, Andrew","leave",8.08570279679457
+"6280","Rosindell, Andrew","prison",7.23762954315501
+"6281","Rosindell, Andrew","convicted",7.19793666730277
+"6282","Rosindell, Andrew","membership",7.10604058142984
+"6283","Rosindell, Andrew","dependencies",7.10476803744014
+"6284","Rosindell, Andrew","january",6.80297809328882
+"6285","Rosindell, Andrew","television",6.44841843672063
+"6286","Rosindell, Andrew","consoles",6.37993248332274
+"6287","Rosindell, Andrew","30551",6.12263181572202
+"6288","Rosindell, Andrew","30552",6.12263181572202
+"6289","Rotheram, Steve","altcourse",32.6529470136637
+"6290","Rotheram, Steve","prison",10.8282863764838
+"6291","Rotheram, Steve","liverpool",9.57769211038865
+"6292","Rotheram, Steve","g4s",9.08706396277029
+"6293","Rotheram, Steve","secretariat",9.03224489903568
+"6294","Rotheram, Steve","zone",8.89780167683854
+"6295","Rotheram, Steve","staff",8.75465022076781
+"6296","Rotheram, Steve","exclusion",7.78075742067567
+"6297","Rotheram, Steve","part",7.12808266380133
+"6298","Rotheram, Steve","enterprise",6.76521250927089
+"6299","Rotheram, Steve","joint",6.56637718810236
+"6300","Rotheram, Steve","attempted",6.52957272870362
+"6301","Roy, Frank","motherwell",3.03028855770365
+"6302","Roy, Frank","wishaw",3.03028855770365
+"6303","Roy, Frank","submitted",1.89718413605117
+"6304","Roy, Frank","live",1.68668203088942
+"6305","Roy, Frank","disabl",1.67384856512182
+"6306","Roy, Frank","constituency",1.52360489198906
+"6307","Roy, Frank","allowance",1.44772571233929
+"6308","Roy, Frank","june",1.40803403347358
+"6309","Roy, Frank","independence",1.37510059084413
+"6310","Roy, Frank","decision",1.35726635138996
+"6311","Roy, Frank","applicants",1.31749054425015
+"6312","Roy, Frank","payment",1.24249575126845
+"6313","Ruane, Chris","per",9.88711504910511
+"6314","Ruane, Chris","hours",9.78788533465132
+"6315","Ruane, Chris","unemployed",9.05710708935289
+"6316","Ruane, Chris","killed",8.86973395004114
+"6317","Ruane, Chris","closure",8.5689972326939
+"6318","Ruane, Chris","classed",8.39373600155216
+"6319","Ruane, Chris","proportion",8.36080663366141
+"6320","Ruane, Chris","week",8.14697088616634
+"6321","Ruane, Chris","cells",7.98788884312181
+"6322","Ruane, Chris","spent",7.96510494631289
+"6323","Ruane, Chris","year",7.63663061112243
+"6324","Ruane, Chris","rhyl",6.91809396928489
+"6325","Ruffley, David","suffolk",23.0829098376606
+"6326","Ruffley, David","edmunds",17.6372381478218
+"6327","Ruffley, David","bury",15.2892967796429
+"6328","Ruffley, David","england",12.4932101130575
+"6329","Ruffley, David","wales",9.68307367789566
+"6330","Ruffley, David","east",8.16463431463035
+"6331","Ruffley, David","speeding",7.53448735016262
+"6332","Ruffley, David","constituency",6.91705767395196
+"6333","Ruffley, David","a14",6.12263181572202
+"6334","Ruffley, David","a143",6.12263181572202
+"6335","Ruffley, David","notices",5.9044768857149
+"6336","Ruffley, David","fixed",5.77131362537207
+"6337","Russell, Sir Bob","led",4.77513553822592
+"6338","Russell, Sir Bob","replacement",4.46482104489395
+"6339","Russell, Sir Bob","lighting",3.76660089921696
+"6340","Russell, Sir Bob","buildings",3.54841377712207
+"6341","Russell, Sir Bob","introduce",3.47878177219783
+"6342","Russell, Sir Bob","implement",3.43026611699385
+"6343","Russell, Sir Bob","programme",3.29356696811189
+"6344","Russell, Sir Bob","throughout",2.84879127854937
+"6345","Russell, Sir Bob","sites",2.09982405777574
+"6346","Russell, Sir Bob","guidance",1.84898243303657
+"6347","Russell, Sir Bob","operators",1.67062816592052
+"6348","Russell, Sir Bob","will",1.49577913934957
+"6349","Ryan, Joan","51526",3.2883807836292
+"6350","Ryan, Joan","retirement",3.19932959467002
+"6351","Ryan, Joan","ratification",3.12614137666199
+"6352","Ryan, Joan","istanbul",3.01103068551658
+"6353","Ryan, Joan","extending",2.8835764369274
+"6354","Ryan, Joan","territorial",2.84879127854937
+"6355","Ryan, Joan","mandatory",2.73195743460209
+"6356","Ryan, Joan","jurisdiction",2.50976062055959
+"6357","Ryan, Joan","extra",2.43207266168937
+"6358","Ryan, Joan","age",2.04719304503465
+"6359","Ryan, Joan","potential",2.03963631832758
+"6360","Ryan, Joan","convention",1.99248315660954
+"6361","Sandbach, Antoinette","qualifications",3.83630669925203
+"6362","Sandbach, Antoinette","civilian",3.61880850954184
+"6363","Sandbach, Antoinette","entry",3.61562058168189
+"6364","Sandbach, Antoinette","officers",3.33954873307659
+"6365","Sandbach, Antoinette","jewish",3.25379110666075
+"6366","Sandbach, Antoinette","christian",3.13398010069454
+"6367","Sandbach, Antoinette","education",3.09910702293687
+"6368","Sandbach, Antoinette","checks",3.01635686885598
+"6369","Sandbach, Antoinette","provision",2.80424900759097
+"6370","Sandbach, Antoinette","prison",2.73658731665753
+"6371","Sandbach, Antoinette","initial",2.61880850954184
+"6372","Sandbach, Antoinette","staff",2.56163816707134
+"6373","Sanders, Adrian","torbay",3.56573088174181
+"6374","Sanders, Adrian","invitation",2.53941356285557
+"6375","Sanders, Adrian","visit",1.96961226838972
+"6376","Sanders, Adrian","ministers",1.93417925483982
+"6377","Sanders, Adrian","constituency",1.79282101736715
+"6378","Sanders, Adrian","purse",1.78808567676192
+"6379","Sanders, Adrian","october",1.67062816592052
+"6380","Sanders, Adrian","issued",1.44371094452865
+"6381","Sanders, Adrian","cost",1.21274374354822
+"6382","Sanders, Adrian","public",1.17746230935846
+"6383","Sanders, Adrian","months",1.12122780361465
+"6384","Sanders, Adrian","2014",0.992996867834185
+"6385","Saville Roberts, Liz","wales",69.3107147667996
+"6386","Saville Roberts, Liz","community",68.5121498780261
+"6387","Saville Roberts, Liz","rehabilitation",60.8984845681481
+"6388","Saville Roberts, Liz","companies",59.7929771632381
+"6389","Saville Roberts, Liz","victim",44.7397362408343
+"6390","Saville Roberts, Liz","port",42.905567783521
+"6391","Saville Roberts, Liz","talbot",42.905567783521
+"6392","Saville Roberts, Liz","supervised",39.6348302966623
+"6393","Saville Roberts, Liz","england",31.778344724199
+"6394","Saville Roberts, Liz","probation",30.6470356388375
+"6395","Saville Roberts, Liz","order",25.4181674244417
+"6396","Saville Roberts, Liz","new",24.9435912635753
 "6397","Sawford, Andy","students",3.398473972902
 "6398","Sawford, Andy","revenge",3.398473972902
 "6399","Sawford, Andy","pornography",3.27333545844424

--- a/data_generators/.Rhistory
+++ b/data_generators/.Rhistory
@@ -1,10 +1,3 @@
-clusterNum <- cutree(hier,h=similarityThreshold)
-#number of clusters with more than one occupant
-clustSizes <- sapply(seq(max(clusterNum)),function(x)length(which(clusterNum==x)))
-names(clustSizes) <- seq(max(clusterNum))
-numberOfGroups <- length(clustSizes[which(clustSizes>1)])
-#nonSingleClusters
-GroupDF <- data_frame(answer=nonEmptyAnswers,
 YN=nonEmptyYN,
 profession=nonEmptyProfs,
 profession2=nonEmptyProf2s,
@@ -510,3 +503,10 @@ runApp('~/Documents/PQTool')
 names(termsAndSumsN) <- gsub("probabl", "probability", names(termsAndSumsN))
 shiny::runApp('~/Documents/PQTool')
 shiny::runApp('~/Documents/PQTool')
+shiny::runApp('~/Documents/PQTool')
+runApp('~/Documents/PQTool')
+runApp('~/Documents/PQTool')
+runApp('~/Documents/PQTool')
+runApp('~/Documents/PQTool')
+runApp('~/Documents/PQTool')
+runApp('~/Documents/PQTool')

--- a/data_generators/DataCreator.R
+++ b/data_generators/DataCreator.R
@@ -288,6 +288,12 @@ nameCleaner <- function(name){
   else if (name == "Soames, Nicholas"){
     name <- "Soames, Sir Nicholas"
   }
+  else if (name == "Roberts, Liz Saville"){
+    name <- "Saville Roberts, Liz"
+  }
+  else if (name == "Bailey, Rebecca Long"){
+    name <- "Long Bailey, Rebecca"
+  }
   name
 }
 

--- a/global.R
+++ b/global.R
@@ -96,3 +96,34 @@ queryVec <- function(query){
   return(which(vocab %in% query))
 }
 
+#some stuff to transform MP/peer names into URLs
+
+familyName <- function(name){
+  commaPosn <- regexpr(",", name) %>% as.vector()
+  substr(name, 1, commaPosn-1)
+}
+
+firstName <- function(name){
+  commaPosn <- regexpr(",", name) %>% as.vector()
+  substr(name, commaPosn+2, nchar(name))
+}
+
+urlName <- function(name){
+  fn <- firstName(name)
+  if(
+    grepl(
+      "Lord|Lady|The|Baroness|Baron|Viscount",
+      name
+    )){
+    name %>%
+      gsub("The ", "", .) %>%
+      gsub("Lord Bishop", "Bishop", .) %>%
+      gsub(" ", "_", .)
+  } else {
+    paste0(firstName(name), "_", familyName(name), sep="") %>%
+      gsub("Dr |Sir ", "", .) %>%
+      gsub("de ", "de_", .) %>%
+      gsub(" ", "-", .)
+  }
+}
+

--- a/server.R
+++ b/server.R
@@ -418,6 +418,28 @@ function(input, output, session) {
               min.freq = 0.1)
   )
   
+  
+  
+  linkText <- reactive({
+    paste0("TheyWorkForYouPage for ",
+           input$person_choice)
+  })
+  
+  linkURL <- reactive({
+    paste0("https://www.theyworkforyou.com/",
+           if(input$member_analysis=="Commons"){
+             "mp/"
+           } else {
+             "peer/"
+           },
+           urlName(input$person_choice)
+           )
+  })
+  
+  output$memberlink <- renderUI({
+    tags$a(href = linkURL(), target="_blank", linkText())
+  })
+  
   addPopover(session, "member_wordcloud", "Wordcloud",
              content = paste0("This wordcloud shows the words that are most important in the questions asked by this
                               member.<br><br> The bigger the word, the more important it is."),

--- a/ui.R
+++ b/ui.R
@@ -218,6 +218,9 @@ navbarPage("PQ Text Analysis",
                                "right",
                                options = list(container = "body")
                              )
+                      ),
+                      column(2,
+                             htmlOutput("memberlink")
                       )
                     ),
                     


### PR DESCRIPTION
Generates a link to the TheyWorkForYou page for each MP/peer. This is quite fiddly because of the nature of names in both houses.