### PR TITLE
Fix hol only update

### DIFF
--- a/R/apiClient.R
+++ b/R/apiClient.R
@@ -32,12 +32,23 @@ number_to_fetch <- function() {
   }
 }
 
+get_constituencies <- function(raw_response) 
+  map_chr(1:nrow(raw_response), function(n) {
+    constituency <- raw_response$tablingMemberConstituency$'_value'[n]
+
+    if(length(constituency) == 0 | is.na(constituency)) {
+      'NA'
+    } else {
+      constituency
+    }
+})
+
 parse_response <- function(raw_response) {
   tibble(
     Question_MP     = do.call("rbind", raw_response$tablingMemberPrinted)$'_value',
     Question_Text   = raw_response$questionText,
     Question_ID     = raw_response$uin,
-    MP_Constituency = raw_response$tablingMemberConstituency$'_value',
+    MP_Constituency = get_constituencies(raw_response),
     Question_Date   = raw_response$date$'_value',
     Answer_Text     = raw_response$answer$answerText$'_value',
     Answer_MP       = raw_response$answer$answeringMemberPrinted$'_value',

--- a/tests/testthat/test-api-client.R
+++ b/tests/testthat/test-api-client.R
@@ -210,6 +210,21 @@ test_that('get_all_members() calls the members API to retrieve all member record
   )
 })
 
+context('get_constituencies')
+
+test_that('returns NA for members of the HoL', {
+  questions     <- readRDS('./examples/api-responses/response-full.rds')$result$items
+  hol_questions <- questions[questions$houseId$'_value' == 2,][1:2,]
+  expect_equal(get_constituencies(hol_questions), c('NA', 'NA'))
+})
+
+test_that('returns the constituency for member of the HoC', {
+  questions     <- readRDS('./examples/api-responses/response-full.rds')$result$items
+  hoc_questions <- questions[questions$houseId$'_value' == 1,][1:2,]
+  expect_equal(get_constituencies(hoc_questions), c('Blaydon', 'Blaydon'))
+})
+
+
 context('get_parties')
 
 test_that('get_parties calls total_members, get_all_members and get_party', {


### PR DESCRIPTION
- Previously updates comprised purely of questions asked in the HoL would cause an error because there's no constituency associated with these records (the entire column is absent).