### PR TITLE
Encourage user to change selection

### DIFF
--- a/pq.js
+++ b/pq.js
@@ -343,6 +343,10 @@ function tidy_table(){
         table_entries[i].innerHTML = a_text.format_html();
     }
 }
+
+function noChange(set_one, set_two) {
+  return set_one.length == set_one.filter(set_two).length;
+}
  
  //function codeAddress() {
 //    alert("Welcome! Just a quick reminder that I cannot be run in Internet Explorer, try Mozille Firefox or Google Chrome instead.")

--- a/server.R
+++ b/server.R
@@ -219,6 +219,14 @@ function(input, output, session) {
                                     $('.introjs-tooltiptext').text('Please select a row before continuing.');
                                     introJs().previousStep();
                                    }
+                                 } else if (this._currentStep == 5 ) {
+                                   new_selection = $('.selected')
+                                   prev_selection = selected_rows
+                                   if(noChange(new_selection, prev_selection)) {
+                                    this._currentStep = 4;
+                                    $('.introjs-tooltiptext').text('Please select another point on the graph before continuing.');
+                                    introJs().previousStep();
+                                   }
                                  }")
               ),
               options = list("nextLabel" = "Next",


### PR DESCRIPTION
- This is a minor thing and I am not entirely convinced it needed fixing.
- This fix is also imperfect but does at least encourage the user to interact with the graph.
- If you play around with this a little, you'll see that if you change the selection and then change it back to the original selection (by clicking the points on the graph during the intro) you'll still get asked to change the selection before proceeding.
- Without this change, if the user does not change the selection by clicking on the points, the text in the following step does not entirely make sense.