### PR TITLE
Point selection was not possible in FireFox

### DIFF
--- a/pq.js
+++ b/pq.js
@@ -85,6 +85,25 @@ function rowActivate() {
     }
 }
 
+function set_path() {
+    if (!("path" in MouseEvent.prototype))
+    Object.defineProperty(MouseEvent.prototype, "path", {
+      get: function() {
+        var path = [];
+        var currentElem = this.target;
+        while (currentElem) {
+          path.push(currentElem);
+          currentElem = currentElem.parentElement;
+        }
+        if (path.indexOf(window) === -1 && path.indexOf(document) === -1)
+          path.push(document);
+        if (path.indexOf(window) === -1)
+          path.push(window);
+        return path;
+      }
+    });
+}
+
 //Plotly point-clicking functions
 function get_point_locations(e) {
     last_mouse_location = [e.clientX, e.clientY];

--- a/ui.R
+++ b/ui.R
@@ -21,7 +21,7 @@ navbarPage("MoJ Parliamentary Analysis Tool",
                       includeScript("google-analytics.js"),
                       tags$link(rel = "stylesheet", type = "text/css", href = "pq.css")
                     ),
-                    tags$body(onmousemove = "get_point_locations(event)"),
+                    tags$body(onload = 'set_path()', onmousemove = "get_point_locations(event)"),
                     tags$head(includeScript("pq.js")),
                     fluidRow(
                       column(8,


### PR DESCRIPTION
- MouseEvent does not have `path` in FireFox, for some reason.
- This is crucial for the function which gets all points from the graph.
- I suspect that what I have done here is not best practice, because it extends the functionality of an existing object.  It does. however, work and for the time being my JS is insufficient to (quickly) get this to a better place in terms of code quality.
- Please test it thoroughly on your machines.