### PR TITLE
Fixing Internet Explorer issues by writing javascript

### DIFF
--- a/IE.js
+++ b/IE.js
@@ -1,0 +1,17 @@
+function CheckIE()
+{
+	var Browser;
+    Browser = navigator.userAgent;
+    if (Browser.indexOf("Trident") == -1)
+    {
+        
+    }
+    else
+    {
+    	window.alert("Welcome! Just a quick reminder that I cannot be run in Internet Explorer, try Mozilla Firefox or Google Chrome instead.")
+    }
+}
+
+window.onload = CheckIE()
+
+

--- a/ui.R
+++ b/ui.R
@@ -18,6 +18,9 @@ navbarPage("MoJ Parliamentary Analysis Tool",
            tabPanel("Search",
                     introjsUI(),
                     tags$head(
+                      #sort out IE issues by doing a pop-up
+                      tags$meta("http-equiv" = "X-UA-compatible", content = "IE = edge"),
+                      includeScript("IE.js"),
                       includeScript("google-analytics.js"),
                       tags$link(rel = "stylesheet", type = "text/css", href = "pq.css")
                     ),


### PR DESCRIPTION
* detects whether IE11 is being used
* if it is, give a pop-up that warns users not to use it