### PR TITLE
Update Readme for external repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,15 @@ git remote add staging git@github.com:moj-analytical-services/pq-tool-staging.gi
 ```
 git push staging branch-to-test
 ```
+## Deploying for External access
 
+A seperate repo (pq-tool-external) has been created to allow access outside of the MoJ to selected people - usually from other government departments.
+
+### To add this as a remote repo
+```
+git remote add staging git@github.com:moj-analytical-services/pq-tool-external.git
+```
+
+### Then you can push to that repo (and deploy from the Jenkins console using the pq-tool-external job)
+```
+git push external branch-to-deploy

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ git remote add staging git@github.com:moj-analytical-services/pq-tool-staging.gi
 ```
 git push staging branch-to-test
 ```
-## Deploying for External access
+## Deploying for external access
 
 A seperate repo (pq-tool-external) has been created to allow access outside of the MoJ to selected people - usually from other government departments.
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,6 @@ A seperate repo (pq-tool-external) has been created to allow access outside of t
 git remote add staging git@github.com:moj-analytical-services/pq-tool-external.git
 ```
 
-### Then you can push to that repo (and deploy from the Jenkins console using the pq-tool-external job)
+### Then you can push to that repo (and deploy from the Jenkins console using the pq-tool-external job - here you can also give a list of email addresses for the people you wish to give access)
 ```
 git push external branch-to-deploy


### PR DESCRIPTION
Have set up a separate repo (which works in the same way as staging) for the deployment to authorised people outside of the moj.

PR is to update the Readme for this functionality - although it is pretty much copy and pasting the staging bit 